### PR TITLE
ci: add CodeQL code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan so new query-pack findings surface even with no code changes.
+    # Offset from the OSV weekly cron (Mon 12:00) to spread CI load.
+    - cron: "0 9 * * 4"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload code-scanning results to the Security tab.
+      security-events: write
+      # The CodeQL action reads workflow run metadata.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # JavaScript and TypeScript share one CodeQL extractor. build-mode
+          # "none" is correct for an interpreted project: CodeQL analyzes the
+          # source directly, so no npm install or build step is needed.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds higher-signal security queries beyond the
+          # default set. Appropriate for a plugin that makes authenticated
+          # network calls to a reverse-engineered API. Dial back to the default
+          # suite (drop this line) if it proves noisy on this small codebase.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds `.github/workflows/codeql.yml` (CodeQL advanced setup) for GitHub-native semantic security analysis of the TypeScript source.

- Language: `javascript-typescript`, `build-mode: none` (CodeQL analyzes source directly; no npm install/build needed).
- Triggers: push and PR to `main`, plus a weekly cron (offset from the OSV cron to spread load).
- Query suite: `security-extended` (higher-signal security queries; tunable down to default if noisy).

## Why

OSV-Scanner and Dependency Review cover *dependency* vulnerabilities. CodeQL is a different layer: it analyzes *first-party* code for security and quality issues. This matters as the plugin moves toward write-back features that make authenticated network calls to a reverse-engineered API. CodeQL is free for public repositories.

## Notes

- This is *advanced setup* (a workflow file). Do not also enable CodeQL "default setup" in the repo Settings UI; GitHub treats the two as mutually exclusive and will error.
- Code-scanning alerts surface in the Security tab and as PR annotations; they do not fail this check unless wired to.
- No plugin code changes; CI/infra only.