### PR TITLE
Refactor: extract runImport into import-runner.ts with parity tests

### DIFF
--- a/__tests__/import-runner.test.ts
+++ b/__tests__/import-runner.test.ts
@@ -1,0 +1,640 @@
+import { runImport, type ImportRunDeps, type ImportRunObserver, type AttachmentPipeline } from '../import-runner';
+import {
+	NoteWriter,
+	type FileLike,
+	type FolderLike,
+	type VaultLike,
+	type DuplicatePromptDecision,
+} from '../note-writer';
+import { PlaudApiError } from '../plaud-client-re';
+import type { ArtifactSelection, ImportModalOptions } from '../import-core';
+import type {
+	PlaudRecordingId,
+	Recording,
+	Summary,
+	Transcript,
+	TranscriptAndSummary,
+} from '../plaud-client';
+
+// -----------------------------------------------------------------------------
+// Test doubles
+//
+// The runner is headless: a REAL NoteWriter writes into an in-memory fake vault
+// (the same shape note-writer.test.ts uses), the attachment pipeline is a stub
+// that records its calls, and the observer/fetchArtifacts are spies so we can
+// assert ordering and call counts. No `obsidian` import is needed because the
+// runner has none.
+// -----------------------------------------------------------------------------
+
+type FakeVault = VaultLike & {
+	files: Map<string, string>;
+	folders: Set<string>;
+};
+
+function makeFakeVault(): FakeVault {
+	const files = new Map<string, string>();
+	const folders = new Set<string>();
+	const vault: FakeVault = {
+		files,
+		folders,
+		getFileByPath(path: string): FileLike | null {
+			return files.has(path) ? { path } : null;
+		},
+		getFolderByPath(path: string): FolderLike | null {
+			return folders.has(path) ? { path } : null;
+		},
+		async createFolder(path: string): Promise<FolderLike> {
+			folders.add(path);
+			return { path };
+		},
+		async create(path: string, data: string): Promise<FileLike> {
+			files.set(path, data);
+			return { path };
+		},
+		async read(file: FileLike): Promise<string> {
+			return files.get(file.path) ?? '';
+		},
+		async process(file: FileLike, fn: (data: string) => string): Promise<string> {
+			const next = fn(files.get(file.path) ?? '');
+			files.set(file.path, next);
+			return next;
+		},
+	};
+	return vault;
+}
+
+function makeWriter(
+	vault: VaultLike,
+	options: Partial<ConstructorParameters<typeof NoteWriter>[1]> = {},
+): NoteWriter {
+	return new NoteWriter(vault, {
+		outputFolder: 'Plaud',
+		onDuplicate: 'skip',
+		...options,
+	});
+}
+
+let nextId = 0;
+function makeRecording(overrides: Partial<Recording> = {}): Recording {
+	nextId += 1;
+	return {
+		id: `rec-${nextId}` as PlaudRecordingId,
+		title: `Recording ${nextId}`,
+		createdAt: new Date(2026, 5, 28, 9, 0),
+		durationSeconds: 600,
+		transcriptAvailable: true,
+		summaryAvailable: true,
+		isTrashed: false,
+		...overrides,
+	};
+}
+
+function makeTranscript(id: PlaudRecordingId): Transcript {
+	return {
+		id,
+		segments: [
+			{ startSeconds: 0, endSeconds: 10, speaker: 'Charles', text: 'Hello.' },
+		],
+		rawText: 'Hello.',
+	};
+}
+
+function makeSummary(id: PlaudRecordingId): Summary {
+	return { id, text: '- A point' };
+}
+
+function makeArtifacts(
+	recording: Recording,
+	overrides: Partial<TranscriptAndSummary> = {},
+): TranscriptAndSummary {
+	return {
+		transcript: makeTranscript(recording.id),
+		summary: makeSummary(recording.id),
+		...overrides,
+	};
+}
+
+const SELECTION: ArtifactSelection = {
+	includeSummary: true,
+	includeTranscript: true,
+	includeAttachments: true,
+	includeMindmap: true,
+	includeCard: true,
+};
+
+const OPTIONS: ImportModalOptions = {
+	outputFolder: 'Plaud',
+	onDuplicate: 'skip',
+};
+
+function makeAttachmentStub(): {
+	pipeline: AttachmentPipeline;
+	importCalls: Array<{ notePath: string; replaceExisting: boolean; recordingId: string }>;
+} {
+	const importCalls: Array<{
+		notePath: string;
+		replaceExisting: boolean;
+		recordingId: string;
+	}> = [];
+	const pipeline: AttachmentPipeline = {
+		extractAttachmentAssetsFromSummaryMarkdown: () => [],
+		mergeAttachmentAssets: (base, extra) => [...base, ...extra],
+		importAttachmentsForNote: async (notePath, _attachments, _selection, replaceExisting, recordingId) => {
+			importCalls.push({ notePath, replaceExisting, recordingId });
+		},
+	};
+	return { pipeline, importCalls };
+}
+
+function makeFetch(
+	artifactsById: Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>,
+): { fetchArtifacts: ImportRunDeps['fetchArtifacts']; calls: PlaudRecordingId[] } {
+	const calls: PlaudRecordingId[] = [];
+	const fetchArtifacts = async (id: PlaudRecordingId): Promise<TranscriptAndSummary> => {
+		calls.push(id);
+		const entry = artifactsById.get(id);
+		if (typeof entry === 'function') {
+			// A thrower: model a fetch that rejects for this recording.
+			return entry();
+		}
+		if (entry === undefined) {
+			throw new Error(`no artifacts registered for ${id}`);
+		}
+		return entry;
+	};
+	return { fetchArtifacts, calls };
+}
+
+function makeObserver(shouldAbort?: () => boolean): {
+	observer: ImportRunObserver;
+	starts: Array<[number, number]>;
+	written: string[];
+	events: string[];
+} {
+	const starts: Array<[number, number]> = [];
+	const written: string[] = [];
+	const events: string[] = [];
+	const observer: ImportRunObserver = {
+		onRecordingStart: (index, total, recording) => {
+			starts.push([index, total]);
+			events.push(`start:${recording.id}:${index}/${total}`);
+		},
+		onRecordingWritten: (recording) => {
+			written.push(recording.id);
+			events.push(`written:${recording.id}`);
+		},
+		shouldAbort,
+	};
+	return { observer, starts, written, events };
+}
+
+function unprocessedError(): PlaudApiError {
+	// Mirrors the -12 "start trans task error" envelope: a PlaudApiError (not an
+	// auth/parse subclass) whose message includes the in-band marker that
+	// isPlaudUnprocessedError keys on.
+	return new PlaudApiError(
+		'in-band error from /ai/transsumm: status=-12 msg=start trans task error',
+		200,
+		'/ai/transsumm',
+		-12,
+	);
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('runImport', () => {
+	it('creates a note for a recording with content', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { observer, starts, written } = makeObserver();
+		const { pipeline } = makeAttachmentStub();
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.processed).toBe(1);
+		expect(outcome.results).toHaveLength(1);
+		expect(outcome.results[0]).toMatchObject({
+			kind: 'written',
+			writeOutcome: { status: 'created' },
+		});
+		expect(calls).toEqual([recording.id]);
+		expect(starts).toEqual([[1, 1]]);
+		expect(written).toEqual([recording.id]);
+	});
+
+	it('overwrites an existing note on a second run with onDuplicate overwrite', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const writer = makeWriter(vault, { onDuplicate: 'overwrite' });
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const deps: ImportRunDeps = {
+			recordings: [recording],
+			selection: SELECTION,
+			writer,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+		};
+
+		const first = await runImport(deps);
+		expect(first.results[0]).toMatchObject({ writeOutcome: { status: 'created' } });
+
+		const second = await runImport(deps);
+		expect(second.stop).toBe('completed');
+		expect(second.results[0]).toMatchObject({
+			kind: 'written',
+			writeOutcome: { status: 'overwritten' },
+		});
+	});
+
+	it('skips a duplicate on a second run with onDuplicate skip', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const writer = makeWriter(vault, { onDuplicate: 'skip' });
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { observer, written } = makeObserver();
+		const deps: ImportRunDeps = {
+			recordings: [recording],
+			selection: SELECTION,
+			writer,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		};
+
+		await runImport(deps);
+		const second = await runImport(deps);
+
+		expect(second.results[0]).toMatchObject({
+			kind: 'written',
+			writeOutcome: { status: 'skipped' },
+		});
+		// A skip does not refresh a row badge — onRecordingWritten fires only on
+		// the create in the first run.
+		expect(written).toEqual([recording.id]);
+	});
+
+	it('skips a no-content recording without fetching artifacts', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording({
+			transcriptAvailable: false,
+			summaryAvailable: false,
+		});
+		const { fetchArtifacts, calls } = makeFetch(new Map());
+		const { observer, starts, written } = makeObserver();
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.results[0]).toEqual({ kind: 'skipped-no-content', recording });
+		// onRecordingStart still fires (the button text advances), but no fetch
+		// and no badge refresh.
+		expect(starts).toEqual([[1, 1]]);
+		expect(calls).toEqual([]);
+		expect(written).toEqual([]);
+	});
+
+	it('writes a placeholder when Plaud reports the recording unprocessed', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, () => { throw unprocessedError(); }]]),
+		);
+		const { observer, written } = makeObserver();
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.results[0]).toMatchObject({
+			kind: 'placeholder-written',
+			outcome: { status: 'created' },
+		});
+		expect(written).toEqual([recording.id]);
+	});
+
+	it('keeps an existing real note instead of downgrading to a placeholder', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const writer = makeWriter(vault);
+
+		// First, a successful import writes the real note.
+		const good = makeFetch(new Map([[recording.id, makeArtifacts(recording)]]));
+		await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts: good.fetchArtifacts,
+		});
+
+		// Then a later run fails to fetch with an unprocessed error; the existing
+		// real note must win over a downgrade to a stub.
+		const bad = makeFetch(
+			new Map([[recording.id, () => { throw unprocessedError(); }]]),
+		);
+		const { observer, written } = makeObserver();
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts: bad.fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.results[0]).toMatchObject({
+			kind: 'written',
+			writeOutcome: { status: 'skipped' },
+		});
+		// kept-existing is reported as a skip and does NOT refresh the badge.
+		expect(written).toEqual([]);
+	});
+
+	it('records a failure for a generic fetch error', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const boom = new Error('network down');
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, () => { throw boom; }]]),
+		);
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.results[0]).toMatchObject({ kind: 'failed', cause: boom });
+	});
+
+	it('records a failure for an unprocessed error when placeholders are disabled', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, () => { throw unprocessedError(); }]]),
+		);
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: { ...OPTIONS, writePlaceholderForUnprocessed: false },
+			fetchArtifacts,
+		});
+
+		expect(outcome.results[0]).toMatchObject({ kind: 'failed' });
+		// No placeholder note was written.
+		expect(vault.files.size).toBe(0);
+	});
+
+	it('stops with cancelled when a per-file duplicate prompt is dismissed', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const artifacts = new Map<PlaudRecordingId, TranscriptAndSummary>([
+			[recA.id, makeArtifacts(recA)],
+			[recB.id, makeArtifacts(recB)],
+		]);
+
+		// Seed both notes so the second run hits the duplicate prompt for each.
+		await runImport({
+			recordings: [recA, recB],
+			selection: SELECTION,
+			writer: makeWriter(vault, { onDuplicate: 'skip' }),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts: makeFetch(artifacts).fetchArtifacts,
+		});
+
+		// Prompt overwrites the first duplicate, cancels the second.
+		const promptWriter = makeWriter(vault, {
+			onDuplicate: 'prompt',
+			promptOnDuplicate: async ({ recordingId }): Promise<DuplicatePromptDecision> =>
+				recordingId === recB.id ? 'cancel' : 'overwrite',
+		});
+		const outcome = await runImport({
+			recordings: [recA, recB],
+			selection: SELECTION,
+			writer: promptWriter,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts: makeFetch(artifacts).fetchArtifacts,
+		});
+
+		expect(outcome.stop).toBe('cancelled');
+		// recA completed (overwritten) before recB cancelled — processed counts
+		// the finished recordings, the x in "x/y".
+		expect(outcome.processed).toBe(1);
+		expect(outcome.results).toHaveLength(1);
+		expect(outcome.results[0]).toMatchObject({ writeOutcome: { status: 'overwritten' } });
+	});
+
+	it('stops with aborted before processing the next recording', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map([
+				[recA.id, makeArtifacts(recA)],
+				[recB.id, makeArtifacts(recB)],
+			]),
+		);
+		// shouldAbort is false for the first iteration's top check, true for the
+		// second, so recB is never started.
+		let topChecks = 0;
+		const { observer, starts } = makeObserver(() => {
+			topChecks += 1;
+			return topChecks >= 2;
+		});
+
+		const outcome = await runImport({
+			recordings: [recA, recB],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('aborted');
+		expect(outcome.processed).toBe(1);
+		expect(outcome.results).toHaveLength(1);
+		// recB never started: one onRecordingStart, one fetch.
+		expect(starts).toEqual([[1, 2]]);
+		expect(calls).toEqual([recA.id]);
+	});
+
+	it('stops with aborted on the final check after the last write', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		// Abort only on the second shouldAbort call: the iteration top check
+		// passes, the recording is written, then the post-loop check aborts.
+		let checks = 0;
+		const { observer } = makeObserver(() => {
+			checks += 1;
+			return checks >= 2;
+		});
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('aborted');
+		expect(outcome.processed).toBe(1);
+		// The recording WAS written before the final abort fired.
+		expect(outcome.results).toHaveLength(1);
+		expect(outcome.results[0]).toMatchObject({ writeOutcome: { status: 'created' } });
+	});
+
+	it('fetches once per processed recording and reports 1-based progress in order', async () => {
+		const vault = makeFakeVault();
+		const withContent1 = makeRecording();
+		const noContent = makeRecording({
+			transcriptAvailable: false,
+			summaryAvailable: false,
+		});
+		const withContent2 = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map([
+				[withContent1.id, makeArtifacts(withContent1)],
+				[withContent2.id, makeArtifacts(withContent2)],
+			]),
+		);
+		const { observer, starts, written, events } = makeObserver();
+
+		const outcome = await runImport({
+			recordings: [withContent1, noContent, withContent2],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.processed).toBe(3);
+		expect(outcome.results.map((r) => r.kind)).toEqual([
+			'written',
+			'skipped-no-content',
+			'written',
+		]);
+		// Fetch skips the no-content recording entirely.
+		expect(calls).toEqual([withContent1.id, withContent2.id]);
+		// Progress is 1-based and fires for every recording, including the skip.
+		expect(starts).toEqual([[1, 3], [2, 3], [3, 3]]);
+		expect(written).toEqual([withContent1.id, withContent2.id]);
+		// Ordering: start precedes the corresponding written, and the skip's
+		// start fires between the two writes.
+		expect(events).toEqual([
+			`start:${withContent1.id}:1/3`,
+			`written:${withContent1.id}`,
+			`start:${noContent.id}:2/3`,
+			`start:${withContent2.id}:3/3`,
+			`written:${withContent2.id}`,
+		]);
+	});
+
+	it('imports attachments only when the bundle has assets and the note was written', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const asset = { dataType: 'image', url: 'https://example.com/a.png', name: 'a.png' };
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording, { attachments: [asset] })]]),
+		);
+		const { pipeline, importCalls } = makeAttachmentStub();
+
+		await runImport({
+			recordings: [recording],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+		});
+
+		expect(importCalls).toHaveLength(1);
+		expect(importCalls[0]).toMatchObject({
+			recordingId: recording.id,
+			replaceExisting: false,
+		});
+	});
+
+	it('runs the fold hook for a written note and skips it for a duplicate skip', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const writer = makeWriter(vault, { onDuplicate: 'skip' });
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const foldPaths: string[] = [];
+		const deps: ImportRunDeps = {
+			recordings: [recording],
+			selection: SELECTION,
+			writer,
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			applyFold: async (path) => { foldPaths.push(path); },
+		};
+
+		await runImport(deps);
+		expect(foldPaths).toHaveLength(1);
+
+		// Second run skips the duplicate; fold must NOT run on a skip.
+		await runImport(deps);
+		expect(foldPaths).toHaveLength(1);
+	});
+});

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -14,13 +14,11 @@ import type {
 import {
 	NoteWriter,
 	NoteWriterError,
-	NoteWriterCancelledError,
 	type DuplicatePolicy,
 	type DuplicatePromptCallback,
-	buildNoteTags,
 	findTranscriptHeadingLine,
-	type FormatMarkdownOptions,
 } from './note-writer';
+import { runImport } from './import-runner';
 import { buildPlaudIdIndex, type ImportedRecord } from './vault-index';
 import { AttachmentImporter } from './attachment-importer';
 import {
@@ -1451,249 +1449,44 @@ export class ImportModal extends Modal {
 			this.importButton.textContent = `Importing 0 of ${selected.length}…`;
 		}
 
-		// Sequential rather than parallel: Plaud does not document a rate
-		// limit, and sequential ordering is cheap insurance against
-		// throttling. A per-recording failure is caught and recorded but
-		// does not stop the batch — this is the "partial success" semantic
-		// users expect for a multi-select import.
-		const results: ImportResult[] = [];
-		for (let i = 0; i < selected.length; i++) {
-			// Bail on mid-import modal close. Fire a partial Notice so
-			// the user sees what was completed before they hit Esc.
-			if (this.aborted) {
-				new Notice(
-					`${formatImportNotice(tallyImportResults(results))} (cancelled at ${i}/${selected.length})`,
-				);
-				return;
-			}
-
-			const recording = selected[i];
-			if (this.importButton) {
-				this.importButton.textContent = `Importing ${i + 1} of ${selected.length}…`;
-			}
-			// Plaud never produced a transcript OR a summary for this
-			// recording — the list metadata already told us so, before the
-			// doomed /ai/transsumm + /file/detail round-trip that would
-			// otherwise return a -12 "start trans task error". There is
-			// nothing to write, so record a benign "no content" skip rather
-			// than letting the error path classify it as a failure.
-			if (!recording.transcriptAvailable && !recording.summaryAvailable) {
-				this.logImportDebug('skipped recording with no content in Plaud', {
-					recordingId: recording.id,
-					recordingTitle: recording.title,
-				});
-				results.push({ kind: 'skipped-no-content', recording });
-				continue;
-			}
-			try {
-				const {
-					transcript,
-					summary,
-					aiKeywords,
-					chapters,
-					attachments,
-					nestedAssetLinks,
-				} = await this.ensureArtifactsForRecording(recording.id);
-				const summaryLinkedAttachments = this.attachments.extractAttachmentAssetsFromSummaryMarkdown(
-					summary?.text ?? null,
-				);
-				const mergedAttachments = this.attachments.mergeAttachmentAssets(
-					attachments ?? [],
-					summaryLinkedAttachments,
-				);
-				// DD-004: combine Plaud's AI-generated keyword list (from
-				// /file/detail/), the recording's own tags, and the user's
-				// custom tags before the note is rendered. buildNoteTags
-				// owns the mode filtering, namespacing, slug, and dedup
-				// rules; this site just feeds it the sources and settings.
-				// The recording's tags are ALWAYS overwritten with the
-				// built list (even when empty) so a restrictive tag mode
-				// cannot leak the raw Plaud tags into the frontmatter.
-				// formatFrontmatter omits empty tags:/keywords: keys.
-				const tagResult = buildNoteTags(recording.tags, aiKeywords, {
-					tagMode: this.noteWriterOptions.tagMode ?? 'plaud',
-					customTags: this.noteWriterOptions.customTags ?? '',
-					aiKeywordsAsProperty:
-						this.noteWriterOptions.aiKeywordsAsProperty ?? true,
-				});
-				const enrichedRecording = { ...recording, tags: tagResult.tags };
-				const formatOptions: FormatMarkdownOptions = {
-					includeTranscript: selection.includeTranscript,
-					includeSummary: selection.includeSummary,
-					keywords: tagResult.keywords,
-				};
-				const selectedChapters = selection.includeTranscript
-					? chapters
-					: undefined;
-				const writeOutcome = await writer.writeNote(
-					enrichedRecording,
-					transcript,
-					summary,
-					selectedChapters,
-					formatOptions,
-				);
-				this.logImportDebug('note write outcome', {
-					recordingId: recording.id,
-					recordingTitle: recording.title,
-					status: writeOutcome.status,
-					path: writeOutcome.path,
-					attachmentCount: mergedAttachments.length,
-					summaryLinkedAttachmentCount: summaryLinkedAttachments.length,
-				});
-				// Refresh the badge for this row when the write produced a
-				// note (created or overwritten). 'skipped' means the file
-				// already existed and we honored the duplicate policy —
-				// the badge is already there, no work to do.
-				if (writeOutcome.status === 'created' || writeOutcome.status === 'overwritten') {
-					this.updateRowBadge(recording.id);
-				}
-				if (
-					(
-						selection.includeAttachments ||
-						selection.includeMindmap ||
-						selection.includeCard
-					) &&
-					writeOutcome.status !== 'skipped' &&
-					mergedAttachments.length > 0
-				) {
-					await this.attachments.importAttachmentsForNote(
-						writeOutcome.path,
-						mergedAttachments,
-						selection,
-						writeOutcome.status === 'overwritten',
-						recording.id,
-						nestedAssetLinks,
-					);
-				} else {
-					this.logImportDebug('attachment import not started', {
-						recordingId: recording.id,
-						noteStatus: writeOutcome.status,
-						attachmentCount: mergedAttachments.length,
-						summaryLinkedAttachmentCount: summaryLinkedAttachments.length,
-						reason:
-							!(
-								selection.includeAttachments ||
-								selection.includeMindmap ||
-								selection.includeCard
-							)
-								? 'attachments disabled by artifact selection'
-								: writeOutcome.status === 'skipped'
-								? 'note skipped by duplicate policy'
-								: 'no attachments in transcript bundle',
-					});
-				}
-				// Apply transcript folding AFTER all post-write mutations
-				// (including attachment section insertion) so the saved
-				// heading line always matches the final file layout.
-				if (
-					writeOutcome.status !== 'skipped' &&
-					this.noteWriterOptions.foldTranscript !== false
-				) {
-					await this.applyTranscriptFold(writeOutcome.path);
-				}
-				// Report the original recording in the result so any
-				// downstream UI that renders the import summary sees the
-				// same object the modal already knows about. The merged
-				// tags only need to exist long enough to land in the
-				// written note's frontmatter.
-				results.push({ kind: 'written', recording, writeOutcome });
-			} catch (err) {
-				// User cancelled the per-file duplicate prompt. Break the
-				// loop without recording a failure — the current recording
-				// was not written, but the cancellation is user-intent,
-				// not an error condition worth classifying.
-				if (err instanceof NoteWriterCancelledError) {
-					new Notice(
-						`${formatImportNotice(tallyImportResults(results))} (cancelled at ${i}/${selected.length})`,
-					);
-					return;
-				}
-				// Log the full error object (including stack and any wrapped
-				// `cause`) so it's visible in DevTools. TODO: also plumb a
-				// logError(errorIds.IMPORT_RECORDING_FAILED, ...) telemetry
-				// call once the plugin has telemetry infrastructure.
-				console.error(
-					`Plaud importer: import failed for recording ${recording.id} "${recording.title}"`,
-					err,
-				);
-				const classification = classifyError(err);
-
-				// Plaud confirmed (in-band) it has no transcript/summary for this
-				// recording yet. Rather than a bare failure, write a placeholder
-				// note carrying the recording ID and a Plaud link so the user
-				// keeps a breadcrumb; a later successful import replaces it
-				// automatically. Gated by the writePlaceholderForUnprocessed
-				// setting (default on). A failure of the placeholder write itself
-				// falls through to the normal failure path below.
-				if (
-					this.noteWriterOptions.writePlaceholderForUnprocessed !== false &&
-					isPlaudUnprocessedError(err)
-				) {
-					try {
-						// Pass Plaud's own concise error line as the stub's reason
-						// (e.g. "...: status=-12 msg=start trans task error"), not
-						// the full classified paragraph, since the placeholder body
-						// already carries the plain-English explanation.
-						const outcome = await writer.writePlaceholderNote(
-							recording,
-							err instanceof Error ? err.message : classification.message,
-						);
-						this.logImportDebug('placeholder note outcome', {
-							recordingId: recording.id,
-							recordingTitle: recording.title,
-							status: outcome.status,
-							path: outcome.path,
-						});
-						if (outcome.status === 'kept-existing') {
-							// A real note already exists; nothing to write. Report
-							// as a benign skip rather than a placeholder.
-							results.push({
-								kind: 'written',
-								recording,
-								writeOutcome: { status: 'skipped', path: outcome.path },
-							});
-						} else {
-							this.updateRowBadge(recording.id);
-							results.push({
-								kind: 'placeholder-written',
-								recording,
-								outcome,
-								reason: classification.message,
-								classification,
-							});
-						}
-						continue;
-					} catch (placeholderErr) {
-						// The stub write failed (vault error, collision with a
-						// different recording, etc.). Fall through and report the
-						// original Plaud failure so the user still sees something.
-						console.error(
-							`Plaud importer: placeholder write failed for recording ${recording.id}`,
-							placeholderErr,
-						);
+		// Delegate the per-recording loop to the headless runner. The modal
+		// keeps every UI concern: the observer updates the button text and
+		// refreshes row badges, and the outcome drives the summary or the
+		// partial-cancel Notice. fetchArtifacts reuses the warm artifact
+		// cache so a prior "review artifacts" preflight is not re-fetched;
+		// applyFold persists the post-write transcript fold.
+		const outcome = await runImport({
+			recordings: selected,
+			selection,
+			writer,
+			attachments: this.attachments,
+			options: this.noteWriterOptions,
+			fetchArtifacts: (id) => this.ensureArtifactsForRecording(id),
+			applyFold: (filePath) => this.applyTranscriptFold(filePath),
+			observer: {
+				onRecordingStart: (index, total) => {
+					if (this.importButton) {
+						this.importButton.textContent = `Importing ${index} of ${total}…`;
 					}
-				}
+				},
+				onRecordingWritten: (recording) => {
+					this.updateRowBadge(recording.id);
+				},
+				shouldAbort: () => this.aborted,
+			},
+		});
 
-				results.push({
-					kind: 'failed',
-					recording,
-					reason: classification.message,
-					classification,
-					cause: err,
-				});
-			}
-		}
-
-		// Final abort check — if the user closed the modal right after
-		// the last write, we still want the partial Notice to fire.
-		if (this.aborted) {
+		if (outcome.stop !== 'completed') {
+			// 'aborted' (modal closed mid-run) and 'cancelled' (per-file
+			// duplicate prompt dismissed) both surface the same partial
+			// Notice the inline loop used to fire at each stop site.
 			new Notice(
-				`${formatImportNotice(tallyImportResults(results))} (cancelled at ${selected.length}/${selected.length})`,
+				`${formatImportNotice(tallyImportResults(outcome.results))} (cancelled at ${outcome.processed}/${selected.length})`,
 			);
 			return;
 		}
 
-		this.renderSummary(tallyImportResults(results));
+		this.renderSummary(tallyImportResults(outcome.results));
 	}
 
 	private async resolveDuplicatePolicyForImport(

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -1,0 +1,382 @@
+// -----------------------------------------------------------------------------
+// import-runner.ts
+//
+// Headless orchestration of a multi-select import. `runImport` owns the
+// sequential per-recording loop that was previously buried inside
+// `ImportModal.onImportClick`: fetch artifacts, merge attachments, build tags,
+// write the note, import attachments, fold the transcript, and classify
+// failures into placeholders or partial-success skips.
+//
+// It imports NO `obsidian` API. Every UI concern (button text, row badges,
+// abort detection, the final Notice/summary) is delegated to the caller via an
+// optional observer and the returned `ImportRunOutcome`, so the same loop runs
+// under the modal UI today and under the planned background auto-sync with a
+// no-op observer. Types come from `import-core.ts`, keeping the runner on the
+// acyclic side of the former import-modal <-> attachment-importer cycle.
+// -----------------------------------------------------------------------------
+
+import type {
+	PlaudRecordingId,
+	Recording,
+	TranscriptAndSummary,
+	AttachmentAsset,
+} from './plaud-client';
+import {
+	NoteWriterCancelledError,
+	buildNoteTags,
+	type NoteWriter,
+	type FormatMarkdownOptions,
+} from './note-writer';
+import {
+	classifyError,
+	isPlaudUnprocessedError,
+	type ImportResult,
+	type ArtifactSelection,
+	type ImportModalOptions,
+} from './import-core';
+
+/**
+ * The slice of `AttachmentImporter` the runner uses. Declared structurally so
+ * the runner depends only on these three methods (the real `AttachmentImporter`
+ * satisfies it) and tests can pass a lightweight stub.
+ */
+export interface AttachmentPipeline {
+	extractAttachmentAssetsFromSummaryMarkdown(
+		summaryMarkdown: string | null,
+	): readonly AttachmentAsset[];
+	mergeAttachmentAssets(
+		base: readonly AttachmentAsset[],
+		extra: readonly AttachmentAsset[],
+	): readonly AttachmentAsset[];
+	importAttachmentsForNote(
+		notePath: string,
+		attachments: readonly AttachmentAsset[],
+		selection: ArtifactSelection,
+		replaceExisting: boolean,
+		recordingId: string,
+		nestedAssetLinks?: Readonly<Record<string, string>>,
+	): Promise<void>;
+}
+
+/**
+ * Hooks the caller supplies to observe and steer the run. Every callback is
+ * optional; a fully headless caller (auto-sync) passes none. The runner never
+ * shows UI itself — these are how the modal updates the button text, refreshes
+ * row badges, and signals a mid-run abort.
+ */
+export interface ImportRunObserver {
+	/**
+	 * Fired before each recording is processed (including no-content skips).
+	 * `index` is 1-based to match the modal's "Importing i of n" button text.
+	 */
+	onRecordingStart?(index: number, total: number, recording: Recording): void;
+	/**
+	 * Fired exactly when a note was created/overwritten or a placeholder was
+	 * written. The modal calls `updateRowBadge` here, which also rebuilds the
+	 * imported index backing cross-folder dedup, so the call sites are
+	 * load-bearing, not cosmetic.
+	 */
+	onRecordingWritten?(recording: Recording): void;
+	/** Polled at the top of every iteration; truthy ends the run as 'aborted'. */
+	shouldAbort?(): boolean;
+}
+
+export interface ImportRunDeps {
+	/** Already filtered to the user's selection, in display order. */
+	readonly recordings: readonly Recording[];
+	readonly selection: ArtifactSelection;
+	/** Pre-built by the caller (duplicate policy + prompt callback already bound). */
+	readonly writer: NoteWriter;
+	readonly attachments: AttachmentPipeline;
+	readonly options: ImportModalOptions;
+	/**
+	 * Resolves the transcript/summary bundle for one recording. The modal
+	 * injects its warm `ensureArtifactsForRecording` so a prior "review
+	 * artifacts" preflight is not re-fetched.
+	 */
+	fetchArtifacts(recordingId: PlaudRecordingId): Promise<TranscriptAndSummary>;
+	/** Optional post-write transcript fold. Omitted by headless callers. */
+	applyFold?(path: string): Promise<void>;
+	readonly observer?: ImportRunObserver;
+}
+
+/**
+ * Why the run ended:
+ *   - 'completed': every selected recording was processed.
+ *   - 'aborted': `observer.shouldAbort()` was truthy (modal closed mid-run).
+ *   - 'cancelled': the user cancelled a per-file duplicate prompt.
+ * 'aborted' and 'cancelled' both produce the modal's "(cancelled at x/y)"
+ * partial Notice; they are distinguished so headless callers can tell a
+ * user-driven stop from an interrupted one.
+ */
+export type ImportRunStop = 'completed' | 'aborted' | 'cancelled';
+
+export interface ImportRunOutcome {
+	readonly results: ImportResult[];
+	readonly stop: ImportRunStop;
+	/** Count of recordings finished before the stop; the x in "x/y". */
+	readonly processed: number;
+}
+
+/**
+ * Emit a granular debug event when a logger is wired and enabled. Mirrors the
+ * modal's private `logImportDebug` so the lifted loop logs identically.
+ */
+function emitImportDebug(
+	options: ImportModalOptions,
+	message: string,
+	payload?: unknown,
+): void {
+	const logger = options.debugLogger;
+	if (!logger || !logger.enabled) {
+		return;
+	}
+	logger.log({
+		kind: 'note',
+		endpoint: '/import',
+		message,
+		payload,
+	});
+}
+
+/**
+ * Run the import loop over `deps.recordings`. Sequential rather than parallel:
+ * Plaud documents no rate limit, and sequential ordering is cheap insurance
+ * against throttling. A per-recording failure is caught and recorded but does
+ * not stop the batch — the "partial success" semantic a multi-select import
+ * users expect.
+ */
+export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> {
+	const { recordings, selection, writer, options } = deps;
+	const observer = deps.observer;
+	const total = recordings.length;
+	const shouldAbort = (): boolean => observer?.shouldAbort?.() ?? false;
+
+	const results: ImportResult[] = [];
+	for (let i = 0; i < total; i++) {
+		// Bail on mid-import modal close. The caller renders the partial
+		// Notice so the user sees what was completed before they hit Esc.
+		if (shouldAbort()) {
+			return { results, stop: 'aborted', processed: i };
+		}
+
+		const recording = recordings[i];
+		observer?.onRecordingStart?.(i + 1, total, recording);
+		// Plaud never produced a transcript OR a summary for this
+		// recording — the list metadata already told us so, before the
+		// doomed /ai/transsumm + /file/detail round-trip that would
+		// otherwise return a -12 "start trans task error". There is
+		// nothing to write, so record a benign "no content" skip rather
+		// than letting the error path classify it as a failure.
+		if (!recording.transcriptAvailable && !recording.summaryAvailable) {
+			emitImportDebug(options, 'skipped recording with no content in Plaud', {
+				recordingId: recording.id,
+				recordingTitle: recording.title,
+			});
+			results.push({ kind: 'skipped-no-content', recording });
+			continue;
+		}
+		try {
+			const {
+				transcript,
+				summary,
+				aiKeywords,
+				chapters,
+				attachments,
+				nestedAssetLinks,
+			} = await deps.fetchArtifacts(recording.id);
+			const summaryLinkedAttachments = deps.attachments.extractAttachmentAssetsFromSummaryMarkdown(
+				summary?.text ?? null,
+			);
+			const mergedAttachments = deps.attachments.mergeAttachmentAssets(
+				attachments ?? [],
+				summaryLinkedAttachments,
+			);
+			// DD-004: combine Plaud's AI-generated keyword list (from
+			// /file/detail/), the recording's own tags, and the user's
+			// custom tags before the note is rendered. buildNoteTags
+			// owns the mode filtering, namespacing, slug, and dedup
+			// rules; this site just feeds it the sources and settings.
+			// The recording's tags are ALWAYS overwritten with the
+			// built list (even when empty) so a restrictive tag mode
+			// cannot leak the raw Plaud tags into the frontmatter.
+			// formatFrontmatter omits empty tags:/keywords: keys.
+			const tagResult = buildNoteTags(recording.tags, aiKeywords, {
+				tagMode: options.tagMode ?? 'plaud',
+				customTags: options.customTags ?? '',
+				aiKeywordsAsProperty: options.aiKeywordsAsProperty ?? true,
+			});
+			const enrichedRecording = { ...recording, tags: tagResult.tags };
+			const formatOptions: FormatMarkdownOptions = {
+				includeTranscript: selection.includeTranscript,
+				includeSummary: selection.includeSummary,
+				keywords: tagResult.keywords,
+			};
+			const selectedChapters = selection.includeTranscript
+				? chapters
+				: undefined;
+			const writeOutcome = await writer.writeNote(
+				enrichedRecording,
+				transcript,
+				summary,
+				selectedChapters,
+				formatOptions,
+			);
+			emitImportDebug(options, 'note write outcome', {
+				recordingId: recording.id,
+				recordingTitle: recording.title,
+				status: writeOutcome.status,
+				path: writeOutcome.path,
+				attachmentCount: mergedAttachments.length,
+				summaryLinkedAttachmentCount: summaryLinkedAttachments.length,
+			});
+			// Refresh the badge for this row when the write produced a
+			// note (created or overwritten). 'skipped' means the file
+			// already existed and we honored the duplicate policy —
+			// the badge is already there, no work to do.
+			if (writeOutcome.status === 'created' || writeOutcome.status === 'overwritten') {
+				observer?.onRecordingWritten?.(recording);
+			}
+			if (
+				(
+					selection.includeAttachments ||
+					selection.includeMindmap ||
+					selection.includeCard
+				) &&
+				writeOutcome.status !== 'skipped' &&
+				mergedAttachments.length > 0
+			) {
+				await deps.attachments.importAttachmentsForNote(
+					writeOutcome.path,
+					mergedAttachments,
+					selection,
+					writeOutcome.status === 'overwritten',
+					recording.id,
+					nestedAssetLinks,
+				);
+			} else {
+				emitImportDebug(options, 'attachment import not started', {
+					recordingId: recording.id,
+					noteStatus: writeOutcome.status,
+					attachmentCount: mergedAttachments.length,
+					summaryLinkedAttachmentCount: summaryLinkedAttachments.length,
+					reason:
+						!(
+							selection.includeAttachments ||
+							selection.includeMindmap ||
+							selection.includeCard
+						)
+							? 'attachments disabled by artifact selection'
+							: writeOutcome.status === 'skipped'
+							? 'note skipped by duplicate policy'
+							: 'no attachments in transcript bundle',
+				});
+			}
+			// Apply transcript folding AFTER all post-write mutations
+			// (including attachment section insertion) so the saved
+			// heading line always matches the final file layout.
+			if (
+				writeOutcome.status !== 'skipped' &&
+				options.foldTranscript !== false
+			) {
+				await deps.applyFold?.(writeOutcome.path);
+			}
+			// Report the original recording in the result so any
+			// downstream UI that renders the import summary sees the
+			// same object the modal already knows about. The merged
+			// tags only need to exist long enough to land in the
+			// written note's frontmatter.
+			results.push({ kind: 'written', recording, writeOutcome });
+		} catch (err) {
+			// User cancelled the per-file duplicate prompt. Stop the
+			// loop without recording a failure — the current recording
+			// was not written, but the cancellation is user-intent,
+			// not an error condition worth classifying.
+			if (err instanceof NoteWriterCancelledError) {
+				return { results, stop: 'cancelled', processed: i };
+			}
+			// Log the full error object (including stack and any wrapped
+			// `cause`) so it's visible in DevTools. TODO: also plumb a
+			// logError(errorIds.IMPORT_RECORDING_FAILED, ...) telemetry
+			// call once the plugin has telemetry infrastructure.
+			console.error(
+				`Plaud importer: import failed for recording ${recording.id} "${recording.title}"`,
+				err,
+			);
+			const classification = classifyError(err);
+
+			// Plaud confirmed (in-band) it has no transcript/summary for this
+			// recording yet. Rather than a bare failure, write a placeholder
+			// note carrying the recording ID and a Plaud link so the user
+			// keeps a breadcrumb; a later successful import replaces it
+			// automatically. Gated by the writePlaceholderForUnprocessed
+			// setting (default on). A failure of the placeholder write itself
+			// falls through to the normal failure path below.
+			if (
+				options.writePlaceholderForUnprocessed !== false &&
+				isPlaudUnprocessedError(err)
+			) {
+				try {
+					// Pass Plaud's own concise error line as the stub's reason
+					// (e.g. "...: status=-12 msg=start trans task error"), not
+					// the full classified paragraph, since the placeholder body
+					// already carries the plain-English explanation.
+					const outcome = await writer.writePlaceholderNote(
+						recording,
+						err instanceof Error ? err.message : classification.message,
+					);
+					emitImportDebug(options, 'placeholder note outcome', {
+						recordingId: recording.id,
+						recordingTitle: recording.title,
+						status: outcome.status,
+						path: outcome.path,
+					});
+					if (outcome.status === 'kept-existing') {
+						// A real note already exists; nothing to write. Report
+						// as a benign skip rather than a placeholder.
+						results.push({
+							kind: 'written',
+							recording,
+							writeOutcome: { status: 'skipped', path: outcome.path },
+						});
+					} else {
+						observer?.onRecordingWritten?.(recording);
+						results.push({
+							kind: 'placeholder-written',
+							recording,
+							outcome,
+							reason: classification.message,
+							classification,
+						});
+					}
+					continue;
+				} catch (placeholderErr) {
+					// The stub write failed (vault error, collision with a
+					// different recording, etc.). Fall through and report the
+					// original Plaud failure so the user still sees something.
+					console.error(
+						`Plaud importer: placeholder write failed for recording ${recording.id}`,
+						placeholderErr,
+					);
+				}
+			}
+
+			results.push({
+				kind: 'failed',
+				recording,
+				reason: classification.message,
+				classification,
+				cause: err,
+			});
+		}
+	}
+
+	// Reached only when every recording was processed. A late abort (modal
+	// closed right after the last write) is reported as 'aborted' so the
+	// caller still fires the partial Notice instead of the success summary.
+	if (shouldAbort()) {
+		return { results, stop: 'aborted', processed: total };
+	}
+
+	return { results, stop: 'completed', processed: total };
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts import-core.ts import-modal.ts attachment-importer.ts note-writer.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/import-modal.test.ts __tests__/note-writer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs",
+		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},


### PR DESCRIPTION
## Phase 0.2 of the import-core/import-runner refactor

Lifts the per-recording import loop out of `ImportModal.onImportClick` into a headless `runImport(deps)` in `import-runner.ts`. No behavior change; this is the prerequisite seam for auto-sync (Phase 2, needs a headless import path) and audio download (Phase 1, adds one gated step to the runner).

### What moved
- `import-runner.ts` (new): `runImport(deps): Promise<ImportRunOutcome>`. Imports no `obsidian` API. The loop body, iteration order, and catch order are lifted verbatim from `onImportClick`.
- UI concerns move behind an optional `ImportRunObserver` (`onRecordingStart` for the button text, `onRecordingWritten` for the row badge, `shouldAbort` for mid-run close). The stop reason and processed count come back in `ImportRunOutcome` so the modal renders either the success summary or the partial-cancel Notice.
- `onImportClick` keeps its head (selection filter, duplicate-policy resolve, `NoteWriter` construction, button disable) and becomes a thin shell that builds the UI observer and delegates.

### The three gotchas (handled)
- **Hidden badge side effect:** `onRecordingWritten` fires at exactly the two original `updateRowBadge` sites, so the `importedIndex` refresh backing cross-folder dedup is preserved.
- **Warm cache:** `fetchArtifacts: (id) => this.ensureArtifactsForRecording(id)` reuses the modal's artifact cache; the runner has no cache of its own.
- **Order:** skip-no-content, fetch, merge, build tags, write, badge, attachments, fold, push; catch order cancelled, classify, placeholder, fail. Lifted exactly.

### Notice parity
The three original stop-site Notices (`(cancelled at x/y)`) are reproduced byte-for-byte from `outcome.stop` + `outcome.processed`:
- top-of-loop abort -> `processed = i`
- per-file duplicate cancel -> `processed = i`
- final post-loop abort -> `processed = total`

### Tests
`import-runner.test.ts`: 14 parity tests driving a **real** `NoteWriter` over an in-memory vault. Branches covered: created, overwritten, skipped-duplicate, skipped-no-content, placeholder-written, kept-existing, failed, cancelled, aborted (both top-of-loop and final-check). Plus: `fetchArtifacts` called once per processed recording and zero for no-content, 1-based progress, and observer ordering.

### Local gate
`npm run lint && npm run build && npm test` green. 623 tests (was 609; +14). `import-runner.ts` and its test added to the explicit lint file list.

### Merge policy
Medium-risk per the roadmap (verbatim lift of the previously untested import loop). **Not a self-merge** - requesting Charles's review before merge.

### Still pending (Charles)
Manual Obsidian smoke test: multi-select import behaves identically (Notices, badges, button states). Unit tests cannot see the DOM or Notice UX, so this is the hands-on validation step. The build auto-copied to the test vault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk imports now run with clearer progress updates and better handling of partial completion.
  * Imported notes can now include attachments and related content more consistently.

* **Bug Fixes**
  * Improved behavior for empty items, interrupted imports, and duplicate notes.
  * Added safer handling for problematic source files, including placeholder notes when content isn’t ready yet.
  * Existing notes are preserved instead of being downgraded during re-imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->