### PR TITLE
Fix #15: fold Plaud template outputs into the note instead of saving .bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, and other per-recording templates) were imported as unreadable `.bin` files in the note's attachments folder. They now fold into the note as a collapsible **Template outputs** section, one subsection per template titled by its Plaud tab name, with the Markdown body rendered inline. The section sits below the summary and opens collapsed so it does not bury the transcript. Whatever templates you selected in Plaud are mirrored, including a verbatim-transcript template if you generated one.
+
 ## [0.13.1] - 2026-06-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Fixed
 
-- Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, and other per-recording templates) were imported as unreadable `.bin` files in the note's attachments folder. They now fold into the note as a collapsible **Template outputs** section, one subsection per template titled by its Plaud template name, with the Markdown body rendered inline. The section sits below the summary and opens collapsed so it does not bury the transcript. Whatever templates you selected in Plaud are mirrored, including a verbatim-transcript template if you generated one.
+- Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, and other per-recording templates) were imported as unreadable `.bin` files in the note's attachments folder. They now render in the note as a **Template outputs** section below the summary, one subsection per template titled by its Plaud template name, with the Markdown body inline. Each template heading is foldable, and the transcript below stays collapsed by default. Whatever templates you selected in Plaud are mirrored, including a verbatim-transcript template if you generated one.
 
 ## [0.13.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Fixed
 
-- Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, and other per-recording templates) were imported as unreadable `.bin` files in the note's attachments folder. They now fold into the note as a collapsible **Template outputs** section, one subsection per template titled by its Plaud tab name, with the Markdown body rendered inline. The section sits below the summary and opens collapsed so it does not bury the transcript. Whatever templates you selected in Plaud are mirrored, including a verbatim-transcript template if you generated one.
+- Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, and other per-recording templates) were imported as unreadable `.bin` files in the note's attachments folder. They now fold into the note as a collapsible **Template outputs** section, one subsection per template titled by its Plaud template name, with the Markdown body rendered inline. The section sits below the summary and opens collapsed so it does not bury the transcript. Whatever templates you selected in Plaud are mirrored, including a verbatim-transcript template if you generated one.
 
 ## [0.13.1] - 2026-06-29
 

--- a/__tests__/attachment-importer.test.ts
+++ b/__tests__/attachment-importer.test.ts
@@ -1,0 +1,47 @@
+import { inferAssetExtension } from '../attachment-importer';
+import type { AttachmentAsset } from '../plaud-client';
+
+function asset(overrides: Partial<AttachmentAsset> = {}): AttachmentAsset {
+	return {
+		dataType: 'consumer_note',
+		url: 'https://s3.amazonaws.com/blob?X-Amz-Signature=fake',
+		...overrides,
+	};
+}
+
+describe('inferAssetExtension', () => {
+	it('maps a text/plain response to .md instead of falling through to .bin', () => {
+		expect(
+			inferAssetExtension(asset(), '# Heading\n\nbody', 'text/plain; charset=utf-8'),
+		).toBe('md');
+	});
+
+	it('maps a Markdown mime hint to .md', () => {
+		expect(inferAssetExtension(asset({ mimeType: 'text/markdown' }), 'body', '')).toBe(
+			'md',
+		);
+	});
+
+	it('still classifies known binary mimes ahead of the text branch', () => {
+		expect(inferAssetExtension(asset(), '', 'image/png')).toBe('png');
+		expect(inferAssetExtension(asset(), '', 'application/pdf')).toBe('pdf');
+	});
+
+	it('uses a real file extension on the URL when no mime is decisive', () => {
+		expect(
+			inferAssetExtension(asset({ url: 'https://s3.test/file.webp?sig=x' }), '', ''),
+		).toBe('webp');
+	});
+
+	it('sniffs a JSON body when nothing else matches', () => {
+		expect(
+			inferAssetExtension(asset({ url: 'https://s3.test/blob?sig=x' }), '[1,2,3]', ''),
+		).toBe('json');
+	});
+
+	it('falls back to bin for an opaque binary body', () => {
+		expect(
+			inferAssetExtension(asset({ url: 'https://s3.test/blob?sig=x' }), '\x00\x01', ''),
+		).toBe('bin');
+	});
+});

--- a/__tests__/attachment-importer.test.ts
+++ b/__tests__/attachment-importer.test.ts
@@ -10,10 +10,22 @@ function asset(overrides: Partial<AttachmentAsset> = {}): AttachmentAsset {
 }
 
 describe('inferAssetExtension', () => {
-	it('maps a text/plain response to .md instead of falling through to .bin', () => {
+	it('maps a non-JSON text/plain response to .md instead of falling through to .bin', () => {
 		expect(
 			inferAssetExtension(asset(), '# Heading\n\nbody', 'text/plain; charset=utf-8'),
 		).toBe('md');
+	});
+
+	it('treats a JSON body served as text/plain as json, not md (nested images still import)', () => {
+		// The text/plain fallback runs AFTER the JSON-body sniff, so a JSON
+		// envelope with a generic text MIME still resolves to json.
+		expect(
+			inferAssetExtension(
+				asset({ url: 'https://s3.test/blob?sig=x' }),
+				'{"picture_link":"https://x/y.png"}',
+				'text/plain; charset=utf-8',
+			),
+		).toBe('json');
 	});
 
 	it('maps a Markdown mime hint to .md', () => {

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -7,7 +7,6 @@ import {
 	extractPlaudPlaceholderFlag,
 	extractSpeakers,
 	findTranscriptHeadingLine,
-	findTemplateOutputsHeadingLine,
 	formatChapterIndexSection,
 	formatDurationHoursMinutes,
 	formatFrontmatter,
@@ -2911,24 +2910,20 @@ describe('formatMarkdown consumer_note template outputs', () => {
 		expect(md).toContain('name: x');
 		expect(md).not.toContain('***');
 	});
-});
 
-describe('findTemplateOutputsHeadingLine', () => {
-	it('returns the 0-based line index of the Template outputs heading', () => {
+	it('keeps a fenced block open across a shorter or mismatched fence line', () => {
+		// A ``` line inside a ~~~ block must NOT close it, so the `## Inside`
+		// heading stays code (untouched) while the real `## Real` heading demotes.
+		const body = '~~~text\n```\n## Inside\n~~~\n\n## Real';
 		const md = formatMarkdown(
 			makeRecording(),
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ heading: 'Key Points', markdown: 'body' }] },
+			{ consumerNotes: [{ heading: 'Fences', markdown: body }] },
 		);
-		const line = findTemplateOutputsHeadingLine(md);
-		expect(line).not.toBeNull();
-		expect(md.split('\n')[line as number]).toBe('## Template outputs');
-	});
-
-	it('returns null when the note has no Template outputs block', () => {
-		const md = formatMarkdown(makeRecording(), makeTranscript(), makeSummary());
-		expect(findTemplateOutputsHeadingLine(md)).toBeNull();
+		const lines = md.split('\n');
+		expect(lines).toContain('## Inside');
+		expect(lines).toContain('#### Real');
 	});
 });

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -2761,8 +2761,8 @@ describe('NoteWriter.writeNote superseding a placeholder', () => {
 
 describe('formatMarkdown consumer_note template outputs', () => {
 	const consumerNotes: readonly ConsumerNote[] = [
-		{ tabName: 'Key Points', markdown: '- First point\n- Second point' },
-		{ tabName: 'Daily Journal', markdown: '## Reflections\n\nA good day.' },
+		{ heading: 'Key Points', markdown: '- First point\n- Second point' },
+		{ heading: 'Daily Journal', markdown: '## Reflections\n\nA good day.' },
 	];
 
 	it('renders a Template outputs block with one subsection per output', () => {
@@ -2821,7 +2821,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Verbatim Transcript', markdown: 'Speaker 1: hello' }] },
+			{ consumerNotes: [{ heading: 'Verbatim Transcript', markdown: 'Speaker 1: hello' }] },
 		);
 		// The user's "Verbatim Transcript" template renders as its own section...
 		expect(md).toContain('### Verbatim Transcript');
@@ -2836,7 +2836,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: '   ', markdown: 'body' }] },
+			{ consumerNotes: [{ heading: '   ', markdown: 'body' }] },
 		);
 		expect(md).toContain('### Template output');
 	});
@@ -2847,7 +2847,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Outline', markdown: '# Top\n\n## Sub' }] },
+			{ consumerNotes: [{ heading: 'Outline', markdown: '# Top\n\n## Sub' }] },
 		);
 		const lines = md.split('\n');
 		// Shallowest body heading (H1) shifts to H4; the H2 shifts in step to H5.
@@ -2863,7 +2863,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Mixed', markdown: body }] },
+			{ consumerNotes: [{ heading: 'Mixed', markdown: body }] },
 		);
 		const lines = md.split('\n');
 		expect(lines).toContain('#### Real heading');
@@ -2876,7 +2876,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Deep', markdown: '#### Already deep\n\ntext' }] },
+			{ consumerNotes: [{ heading: 'Deep', markdown: '#### Already deep\n\ntext' }] },
 		);
 		expect(md.split('\n')).toContain('#### Already deep');
 	});
@@ -2887,7 +2887,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Notes', markdown: 'Action items\n---\nFollow up' }] },
+			{ consumerNotes: [{ heading: 'Notes', markdown: 'Action items\n---\nFollow up' }] },
 		);
 		const lines = md.split('\n');
 		const idx = lines.indexOf('Action items');
@@ -2904,7 +2904,7 @@ describe('formatMarkdown consumer_note template outputs', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Config', markdown: body }] },
+			{ consumerNotes: [{ heading: 'Config', markdown: body }] },
 		);
 		// The literal YAML `---` lines inside the fence stay verbatim; the setext
 		// rewrite is fence-aware, so no `***` is produced from this body.
@@ -2920,7 +2920,7 @@ describe('findTemplateOutputsHeadingLine', () => {
 			makeTranscript(),
 			makeSummary(),
 			undefined,
-			{ consumerNotes: [{ tabName: 'Key Points', markdown: 'body' }] },
+			{ consumerNotes: [{ heading: 'Key Points', markdown: 'body' }] },
 		);
 		const line = findTemplateOutputsHeadingLine(md);
 		expect(line).not.toBeNull();

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -7,6 +7,7 @@ import {
 	extractPlaudPlaceholderFlag,
 	extractSpeakers,
 	findTranscriptHeadingLine,
+	findTemplateOutputsHeadingLine,
 	formatChapterIndexSection,
 	formatDurationHoursMinutes,
 	formatFrontmatter,
@@ -29,6 +30,7 @@ import {
 } from '../note-writer';
 import type {
 	Chapter,
+	ConsumerNote,
 	PlaudRecordingId,
 	Recording,
 	Summary,
@@ -2441,6 +2443,25 @@ describe('findTranscriptHeadingLine', () => {
 		expect(findTranscriptHeadingLine(md, 4)).toBe(6);
 	});
 
+	it('returns the LAST match so an earlier duplicate heading cannot shadow the real transcript', () => {
+		// A consumer_note body heading can demote to exactly `#### Transcript`
+		// and render before the real wrapping transcript heading. The real one
+		// is always the final section, so the last match is the correct fold target.
+		const md = [
+			'## Template outputs',
+			'### Verbatim',
+			'#### Transcript',
+			'decoy body',
+			'',
+			'---',
+			'',
+			'#### Transcript',
+			'',
+			'##### 00:00 Intro',
+		].join('\n');
+		expect(findTranscriptHeadingLine(md, 4)).toBe(7);
+	});
+
 	it('returns null when no wrapping heading matches at the given level', () => {
 		const md = '## Summary\n\nbody\n\n> [!note]- Transcript\n> **[00:00]** A: hi';
 		expect(findTranscriptHeadingLine(md, 4)).toBeNull();
@@ -2731,5 +2752,183 @@ describe('NoteWriter.writeNote superseding a placeholder', () => {
 		expect(outcome.status).toBe('overwritten');
 		// Replacing our own stub needs no user decision.
 		expect(promptOnDuplicate).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// consumer_note template outputs — folded into the note as a section (#15)
+// ---------------------------------------------------------------------------
+
+describe('formatMarkdown consumer_note template outputs', () => {
+	const consumerNotes: readonly ConsumerNote[] = [
+		{ tabName: 'Key Points', markdown: '- First point\n- Second point' },
+		{ tabName: 'Daily Journal', markdown: '## Reflections\n\nA good day.' },
+	];
+
+	it('renders a Template outputs block with one subsection per output', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes },
+		);
+		expect(md).toContain('## Template outputs');
+		expect(md).toContain('### Key Points');
+		expect(md).toContain('### Daily Journal');
+		// Bodies are embedded as native Markdown, not re-quoted into a callout.
+		expect(md).toContain('- First point');
+		// A body heading is demoted to nest under its `### <tab>` title (the
+		// shallowest body heading lands at H4) so it cannot end the fold early.
+		expect(md.split('\n')).toContain('#### Reflections');
+		expect(md.split('\n')).not.toContain('## Reflections');
+	});
+
+	it('renders no block when there are no template outputs', () => {
+		const md = formatMarkdown(makeRecording(), makeTranscript(), makeSummary());
+		expect(md).not.toContain('## Template outputs');
+	});
+
+	it('renders no block when consumerNotes is an empty array', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [] },
+		);
+		expect(md).not.toContain('## Template outputs');
+	});
+
+	it('places the block after the Summary and before the transcript', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes },
+		);
+		const summaryAt = md.indexOf('## Summary');
+		const templatesAt = md.indexOf('## Template outputs');
+		const transcriptAt = md.indexOf('> [!note]- Transcript');
+		expect(summaryAt).toBeLessThan(templatesAt);
+		expect(templatesAt).toBeLessThan(transcriptAt);
+	});
+
+	it('does not de-duplicate a transcript-style tab against the pipeline transcript', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Verbatim Transcript', markdown: 'Speaker 1: hello' }] },
+		);
+		// The user's "Verbatim Transcript" template renders as its own section...
+		expect(md).toContain('### Verbatim Transcript');
+		expect(md).toContain('Speaker 1: hello');
+		// ...while the pipeline transcript callout is still present below it.
+		expect(md).toContain('> [!note]- Transcript');
+	});
+
+	it('falls back to a generic title when a tab name is blank', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: '   ', markdown: 'body' }] },
+		);
+		expect(md).toContain('### Template output');
+	});
+
+	it('demotes a top-level body heading so it nests under its tab title', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Outline', markdown: '# Top\n\n## Sub' }] },
+		);
+		const lines = md.split('\n');
+		// Shallowest body heading (H1) shifts to H4; the H2 shifts in step to H5.
+		expect(lines).toContain('#### Top');
+		expect(lines).toContain('##### Sub');
+		expect(lines).not.toContain('# Top');
+	});
+
+	it('leaves a # inside a fenced code block untouched while demoting real headings', () => {
+		const body = '## Real heading\n\n```\n# not a heading\n```';
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Mixed', markdown: body }] },
+		);
+		const lines = md.split('\n');
+		expect(lines).toContain('#### Real heading');
+		expect(lines).toContain('# not a heading');
+	});
+
+	it('leaves a body whose headings are already H4 or deeper unchanged', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Deep', markdown: '#### Already deep\n\ntext' }] },
+		);
+		expect(md.split('\n')).toContain('#### Already deep');
+	});
+
+	it('neutralizes a dash separator in a body so it is not read as a setext heading', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Notes', markdown: 'Action items\n---\nFollow up' }] },
+		);
+		const lines = md.split('\n');
+		const idx = lines.indexOf('Action items');
+		expect(idx).toBeGreaterThan(-1);
+		// The line after the paragraph is a thematic break, not a setext underline,
+		// so 'Action items' renders as a paragraph rather than a giant H2.
+		expect(lines[idx + 1]).toBe('***');
+	});
+
+	it('preserves a dash line inside a fenced code block (does not rewrite it to ***)', () => {
+		const body = 'Config example:\n\n```yaml\n---\nname: x\n---\n```';
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Config', markdown: body }] },
+		);
+		// The literal YAML `---` lines inside the fence stay verbatim; the setext
+		// rewrite is fence-aware, so no `***` is produced from this body.
+		expect(md).toContain('name: x');
+		expect(md).not.toContain('***');
+	});
+});
+
+describe('findTemplateOutputsHeadingLine', () => {
+	it('returns the 0-based line index of the Template outputs heading', () => {
+		const md = formatMarkdown(
+			makeRecording(),
+			makeTranscript(),
+			makeSummary(),
+			undefined,
+			{ consumerNotes: [{ tabName: 'Key Points', markdown: 'body' }] },
+		);
+		const line = findTemplateOutputsHeadingLine(md);
+		expect(line).not.toBeNull();
+		expect(md.split('\n')[line as number]).toBe('## Template outputs');
+	});
+
+	it('returns null when the note has no Template outputs block', () => {
+		const md = formatMarkdown(makeRecording(), makeTranscript(), makeSummary());
+		expect(findTemplateOutputsHeadingLine(md)).toBeNull();
 	});
 });

--- a/__tests__/plaud-client-re.test.ts
+++ b/__tests__/plaud-client-re.test.ts
@@ -5,6 +5,7 @@ import {
 	ReverseEngineeredPlaudClient,
 	findAiKeywords,
 	findAttachmentAssets,
+	findConsumerNoteEntries,
 	findNewerSummaryMarkdown,
 	findOutlineLink,
 	findTransactionPolishLink,
@@ -3415,5 +3416,162 @@ describe('parseOutlineBody', () => {
 			{ title: 'First', startSeconds: 0 },
 			{ title: 'Second', startSeconds: 60 },
 		]);
+	});
+});
+
+describe('findConsumerNoteEntries', () => {
+	function fileDetail(contentList: unknown[]): Record<string, unknown> {
+		return {
+			status: 0,
+			data: { file_id: 'abc123', content_list: contentList },
+		};
+	}
+
+	const KEY_POINTS_LINK =
+		'https://s3.amazonaws.com/key-points.md?X-Amz-Signature=fake';
+
+	function consumerNoteItem(
+		overrides: Record<string, unknown> = {},
+	): Record<string, unknown> {
+		return {
+			data_id: 'note:899720e9:abc123',
+			data_type: 'consumer_note',
+			task_status: 1,
+			data_tab_name: 'Key Points',
+			data_title: 'Key Points for the meeting',
+			data_link: KEY_POINTS_LINK,
+			extra: {
+				used_template: { template_name: 'Key Points', template_type: 'official' },
+			},
+			...overrides,
+		};
+	}
+
+	it('returns the tab name and link for each ready entry, in order', () => {
+		const journalLink = 'https://s3.amazonaws.com/journal.md?X-Amz-Signature=fake';
+		const raw = fileDetail([
+			consumerNoteItem(),
+			consumerNoteItem({ data_tab_name: 'Daily Journal', data_link: journalLink }),
+		]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
+			{ tabName: 'Key Points', dataLink: KEY_POINTS_LINK },
+			{ tabName: 'Daily Journal', dataLink: journalLink },
+		]);
+	});
+
+	it('skips entries that are not yet ready (task_status !== 1)', () => {
+		const raw = fileDetail([consumerNoteItem({ task_status: 0 })]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([]);
+	});
+
+	it('skips entries with no usable data_link', () => {
+		const raw = fileDetail([consumerNoteItem({ data_link: '' })]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([]);
+	});
+
+	it('ignores content types other than consumer_note', () => {
+		const raw = fileDetail([
+			{
+				data_type: 'transaction',
+				task_status: 1,
+				data_link: 'https://s3.amazonaws.com/raw.json?X-Amz-Signature=fake',
+			},
+			consumerNoteItem(),
+		]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
+			{ tabName: 'Key Points', dataLink: KEY_POINTS_LINK },
+		]);
+	});
+
+	it('falls back to data_title, then a generic label, when data_tab_name is absent', () => {
+		const secondLink = 'https://s3.amazonaws.com/x2.md?X-Amz-Signature=fake';
+		const raw = fileDetail([
+			consumerNoteItem({ data_tab_name: undefined }),
+			consumerNoteItem({
+				data_tab_name: undefined,
+				data_title: undefined,
+				data_link: secondLink,
+			}),
+		]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
+			{ tabName: 'Key Points for the meeting', dataLink: KEY_POINTS_LINK },
+			{ tabName: 'Template output', dataLink: secondLink },
+		]);
+	});
+
+	it('de-duplicates entries that share a data_link', () => {
+		const raw = fileDetail([consumerNoteItem(), consumerNoteItem()]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toHaveLength(1);
+	});
+
+	it('returns [] when content_list is absent', () => {
+		const raw = { status: 0, data: { file_id: 'abc123' } };
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([]);
+	});
+
+	it('is excluded from findAttachmentAssets so it never downloads as a binary file', () => {
+		const raw = fileDetail([
+			consumerNoteItem(),
+			{
+				data_type: 'screenshot',
+				task_status: 1,
+				data_link: 'https://s3.amazonaws.com/shot.png?X-Amz-Signature=fake',
+			},
+		]);
+		const dataTypes = findAttachmentAssets(raw, '/file/detail/abc123').map(
+			(asset) => asset.dataType,
+		);
+		expect(dataTypes).not.toContain('consumer_note');
+		expect(dataTypes).toContain('screenshot');
+	});
+});
+
+describe('getTranscriptAndSummary consumer_note template outputs', () => {
+	it('fetches each consumer_note body and surfaces it on the returned bundle', async () => {
+		// Regression guard: the bundle assembled inside fetchFileDetailBundle
+		// must actually be surfaced on the TranscriptAndSummary return. Because
+		// consumerNotes is optional, an omission compiles clean — this end-to-end
+		// test is what proves the field reaches the caller.
+		const detail = ok({
+			status: 0,
+			msg: 'success',
+			data: {
+				file_id: 'abc123',
+				content_list: [
+					{
+						data_type: 'consumer_note',
+						task_status: 1,
+						data_tab_name: 'Key Points',
+						data_link: 'https://s3/key-points.md?sig=x',
+					},
+				],
+			},
+		});
+		const { fetcher } = routeFetcher({
+			transsumm: ok(transsummEnvelope()),
+			detail,
+			// The consumer_note body is the only non-transsumm/non-detail fetch,
+			// so it routes here; served as raw text/plain Markdown, not JSON.
+			polish: { status: 200, json: null, text: '- Point one\n- Point two' },
+		});
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+
+		const result = await client.getTranscriptAndSummary(ID);
+
+		expect(result.consumerNotes).toEqual([
+			{ tabName: 'Key Points', markdown: '- Point one\n- Point two' },
+		]);
+	});
+
+	it('omits consumerNotes when the recording has none', async () => {
+		const { fetcher } = routeFetcher({
+			transsumm: ok(transsummEnvelope()),
+			detail: ok({ status: 0, data: { file_id: 'abc123', content_list: [] } }),
+		});
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+
+		const result = await client.getTranscriptAndSummary(ID);
+
+		expect(result.consumerNotes).toBeUndefined();
 	});
 });

--- a/__tests__/plaud-client-re.test.ts
+++ b/__tests__/plaud-client-re.test.ts
@@ -3447,15 +3447,30 @@ describe('findConsumerNoteEntries', () => {
 		};
 	}
 
-	it('returns the tab name and link for each ready entry, in order', () => {
+	it('returns the template name and link for each ready entry, in order', () => {
 		const journalLink = 'https://s3.amazonaws.com/journal.md?X-Amz-Signature=fake';
 		const raw = fileDetail([
 			consumerNoteItem(),
-			consumerNoteItem({ data_tab_name: 'Daily Journal', data_link: journalLink }),
+			consumerNoteItem({
+				data_link: journalLink,
+				extra: { used_template: { template_name: 'Daily Journal' } },
+			}),
 		]);
 		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
-			{ tabName: 'Key Points', dataLink: KEY_POINTS_LINK },
-			{ tabName: 'Daily Journal', dataLink: journalLink },
+			{ heading: 'Key Points', dataLink: KEY_POINTS_LINK },
+			{ heading: 'Daily Journal', dataLink: journalLink },
+		]);
+	});
+
+	it('uses the template name as the heading, even when the tab label differs', () => {
+		const raw = fileDetail([
+			consumerNoteItem({
+				data_tab_name: 'Note',
+				extra: { used_template: { template_name: 'Meeting Summary' } },
+			}),
+		]);
+		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
+			{ heading: 'Meeting Summary', dataLink: KEY_POINTS_LINK },
 		]);
 	});
 
@@ -3479,23 +3494,30 @@ describe('findConsumerNoteEntries', () => {
 			consumerNoteItem(),
 		]);
 		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
-			{ tabName: 'Key Points', dataLink: KEY_POINTS_LINK },
+			{ heading: 'Key Points', dataLink: KEY_POINTS_LINK },
 		]);
 	});
 
-	it('falls back to data_title, then a generic label, when data_tab_name is absent', () => {
-		const secondLink = 'https://s3.amazonaws.com/x2.md?X-Amz-Signature=fake';
+	it('falls back to tab label, then title, then a generic label, when no template name', () => {
+		const link2 = 'https://s3.amazonaws.com/x2.md?X-Amz-Signature=fake';
+		const link3 = 'https://s3.amazonaws.com/x3.md?X-Amz-Signature=fake';
 		const raw = fileDetail([
-			consumerNoteItem({ data_tab_name: undefined }),
+			// No used_template -> fall back to the tab label.
+			consumerNoteItem({ extra: {} }),
+			// No template name and no tab label -> fall back to the entry title.
+			consumerNoteItem({ extra: {}, data_tab_name: undefined, data_link: link2 }),
+			// Nothing usable -> generic label.
 			consumerNoteItem({
+				extra: {},
 				data_tab_name: undefined,
 				data_title: undefined,
-				data_link: secondLink,
+				data_link: link3,
 			}),
 		]);
 		expect(findConsumerNoteEntries(raw, '/file/detail/abc123')).toEqual([
-			{ tabName: 'Key Points for the meeting', dataLink: KEY_POINTS_LINK },
-			{ tabName: 'Template output', dataLink: secondLink },
+			{ heading: 'Key Points', dataLink: KEY_POINTS_LINK },
+			{ heading: 'Key Points for the meeting', dataLink: link2 },
+			{ heading: 'Template output', dataLink: link3 },
 		]);
 	});
 
@@ -3559,7 +3581,7 @@ describe('getTranscriptAndSummary consumer_note template outputs', () => {
 		const result = await client.getTranscriptAndSummary(ID);
 
 		expect(result.consumerNotes).toEqual([
-			{ tabName: 'Key Points', markdown: '- Point one\n- Point two' },
+			{ heading: 'Key Points', markdown: '- Point one\n- Point two' },
 		]);
 	});
 

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -211,7 +211,7 @@ export class AttachmentImporter {
 						continue;
 				}
 				const bodyText = blob.text ?? '';
-				const ext = this.inferAssetExtension(asset, bodyText, contentType ?? '');
+				const ext = inferAssetExtension(asset, bodyText, contentType ?? '');
 				this.logAttachmentDebug('resolved primary attachment extension', {
 					assetLabel,
 						candidate: this.sanitizeUrlForDebug(candidate),
@@ -531,38 +531,6 @@ export class AttachmentImporter {
 			return new TextEncoder().encode(response.text).buffer;
 		}
 		return null;
-	}
-
-	private inferAssetExtension(
-		asset: AttachmentAsset,
-		bodyText: string,
-		responseContentType: string,
-	): string {
-		const fromMime = `${asset.mimeType ?? ''};${responseContentType}`.toLowerCase();
-		if (fromMime.includes('text/html') || fromMime.includes('application/xhtml+xml')) {
-			return 'html';
-		}
-		if (fromMime.includes('png')) return 'png';
-		if (fromMime.includes('jpeg') || fromMime.includes('jpg')) return 'jpg';
-		if (fromMime.includes('webp')) return 'webp';
-		if (fromMime.includes('gif')) return 'gif';
-		if (fromMime.includes('svg')) return 'svg';
-		if (fromMime.includes('pdf')) return 'pdf';
-
-		try {
-			const pathname = new URL(asset.url).pathname.toLowerCase();
-			const m = pathname.match(/\.([a-z0-9]{2,6})$/);
-			if (m) {
-				return m[1];
-			}
-		} catch {
-			// ignore parse failures and use fallbacks below
-		}
-
-		if (bodyText.trim().startsWith('{') || bodyText.trim().startsWith('[')) {
-			return 'json';
-		}
-		return 'bin';
 	}
 
 	private isImageExtension(ext: string): boolean {
@@ -1119,14 +1087,67 @@ export class AttachmentImporter {
 	}
 
 	private insertManagedAttachmentsSection(content: string, section: string): string {
-		const transcriptMatch = content.match(/\n#{1,6} Transcript\s*\n/);
-		if (transcriptMatch && transcriptMatch.index !== undefined) {
-			const insertAt = transcriptMatch.index;
+		// Anchor on the LAST `Transcript` heading: it is always the real
+		// transcript (the final section). A consumer_note template output that
+		// renders a `### Transcript`/`#### Transcript` heading earlier in the
+		// note must not capture the anchor and split the Template outputs block.
+		const re = /\n#{1,6} Transcript\s*\n/g;
+		let insertAt = -1;
+		let match: RegExpExecArray | null;
+		while ((match = re.exec(content)) !== null) {
+			insertAt = match.index;
+		}
+		if (insertAt !== -1) {
 			const before = content.slice(0, insertAt).replace(/\s+$/, '');
 			const after = content.slice(insertAt).replace(/^\s*/, '');
 			return `${before}\n\n${section}\n\n${after}\n`;
 		}
 		return `${content}\n\n${section}\n`;
 	}
+}
+
+/**
+ * Choose a file extension for a downloaded attachment from its MIME hint,
+ * URL, and body. Mime wins, then a real extension on the URL, then a JSON
+ * body sniff; anything else is treated as opaque binary (`bin`). Exported as
+ * a pure function so the extension logic is unit-testable independent of the
+ * vault/network plumbing in AttachmentImporter.
+ */
+export function inferAssetExtension(
+	asset: AttachmentAsset,
+	bodyText: string,
+	responseContentType: string,
+): string {
+	const fromMime = `${asset.mimeType ?? ''};${responseContentType}`.toLowerCase();
+	if (fromMime.includes('text/html') || fromMime.includes('application/xhtml+xml')) {
+		return 'html';
+	}
+	if (fromMime.includes('png')) return 'png';
+	if (fromMime.includes('jpeg') || fromMime.includes('jpg')) return 'jpg';
+	if (fromMime.includes('webp')) return 'webp';
+	if (fromMime.includes('gif')) return 'gif';
+	if (fromMime.includes('svg')) return 'svg';
+	if (fromMime.includes('pdf')) return 'pdf';
+	// Defensive: a text/plain or Markdown body must not fall through to the
+	// terminal `.bin`. consumer_note outputs are folded into the note before
+	// they reach here, but any other text asset should still be readable.
+	if (fromMime.includes('text/plain') || fromMime.includes('markdown')) {
+		return 'md';
+	}
+
+	try {
+		const pathname = new URL(asset.url).pathname.toLowerCase();
+		const m = pathname.match(/\.([a-z0-9]{2,6})$/);
+		if (m) {
+			return m[1];
+		}
+	} catch {
+		// ignore parse failures and use fallbacks below
+	}
+
+	if (bodyText.trim().startsWith('{') || bodyText.trim().startsWith('[')) {
+		return 'json';
+	}
+	return 'bin';
 }
 

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -1119,6 +1119,7 @@ export function inferAssetExtension(
 	responseContentType: string,
 ): string {
 	const fromMime = `${asset.mimeType ?? ''};${responseContentType}`.toLowerCase();
+	const isPlainTextMime = fromMime.includes('text/plain');
 	if (fromMime.includes('text/html') || fromMime.includes('application/xhtml+xml')) {
 		return 'html';
 	}
@@ -1128,10 +1129,10 @@ export function inferAssetExtension(
 	if (fromMime.includes('gif')) return 'gif';
 	if (fromMime.includes('svg')) return 'svg';
 	if (fromMime.includes('pdf')) return 'pdf';
-	// Defensive: a text/plain or Markdown body must not fall through to the
-	// terminal `.bin`. consumer_note outputs are folded into the note before
-	// they reach here, but any other text asset should still be readable.
-	if (fromMime.includes('text/plain') || fromMime.includes('markdown')) {
+	// An explicit markdown MIME is unambiguously text -> md. A generic
+	// text/plain is handled AFTER the JSON-body sniff below, so a JSON envelope
+	// served as text/plain still resolves to json (and its nested images import).
+	if (fromMime.includes('markdown')) {
 		return 'md';
 	}
 
@@ -1147,6 +1148,11 @@ export function inferAssetExtension(
 
 	if (bodyText.trim().startsWith('{') || bodyText.trim().startsWith('[')) {
 		return 'json';
+	}
+	// text/plain that is not JSON-shaped: prefer md over the terminal bin so a
+	// stray text asset stays readable instead of an unopenable `.bin`.
+	if (isPlainTextMime) {
+		return 'md';
 	}
 	return 'bin';
 }

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -17,6 +17,7 @@ import {
 	type DuplicatePolicy,
 	type DuplicatePromptCallback,
 	findTranscriptHeadingLine,
+	findTemplateOutputsHeadingLine,
 } from './note-writer';
 import { runImport } from './import-runner';
 import { buildPlaudIdIndex, type ImportedRecord } from './vault-index';
@@ -1462,7 +1463,7 @@ export class ImportModal extends Modal {
 			attachments: this.attachments,
 			options: this.noteWriterOptions,
 			fetchArtifacts: (id) => this.ensureArtifactsForRecording(id),
-			applyFold: (filePath) => this.applyTranscriptFold(filePath),
+			applyFold: (filePath) => this.applyNoteFolds(filePath),
 			observer: {
 				onRecordingStart: (index, total) => {
 					if (this.importButton) {
@@ -1572,13 +1573,13 @@ export class ImportModal extends Modal {
 	}
 
 	/**
-	 * Persist fold state for the wrapping transcript heading in a
-	 * freshly-written note so the chaptered transcript renders
-	 * collapsed by default while the external chapters callout stays
-	 * visible above it. Uses Obsidian's undocumented but stable
-	 * internal `app.foldManager.save` API (type-augmented in
-	 * `types.d.ts`) plus a best-effort same-session apply via the
-	 * active MarkdownView's `applyFoldInfo` when the file happens to
+	 * Persist fold state for the wrapping section headings in a
+	 * freshly-written note so the chaptered transcript and the
+	 * `## Template outputs` block render collapsed by default while the
+	 * summary and chapters callout above them stay visible. Uses Obsidian's
+	 * undocumented but stable internal `app.foldManager.save` API
+	 * (type-augmented in `types.d.ts`) plus a best-effort same-session apply
+	 * via the active MarkdownView's `applyFoldInfo` when the file happens to
 	 * already be open in a leaf.
 	 *
 	 * Failure is swallowed with a console warning: a missing
@@ -1587,7 +1588,7 @@ export class ImportModal extends Modal {
 	 * breaks the import. This method must never throw into the
 	 * import loop.
 	 */
-	private async applyTranscriptFold(path: string): Promise<void> {
+	private async applyNoteFolds(path: string): Promise<void> {
 		try {
 			const file = this.app.vault.getFileByPath(path);
 			if (!(file instanceof TFile)) {
@@ -1595,18 +1596,26 @@ export class ImportModal extends Modal {
 			}
 			const body = await this.app.vault.read(file);
 			const headerLevel = this.noteWriterOptions.transcriptHeaderLevel ?? 4;
+			// Fold the wrapping headings so the note opens with its bulky
+			// sections collapsed: the chaptered transcript and, when present,
+			// the `## Template outputs` block of extra AI outputs. Each is a
+			// single heading whose section Obsidian collapses by document
+			// structure, so folding the wrapper hides everything beneath it.
+			const foldLines: number[] = [];
+			const templateOutputsLine = findTemplateOutputsHeadingLine(body);
+			if (templateOutputsLine !== null) {
+				foldLines.push(templateOutputsLine);
+			}
 			const transcriptHeadingLine = findTranscriptHeadingLine(body, headerLevel);
-			if (transcriptHeadingLine === null) {
+			if (transcriptHeadingLine !== null) {
+				foldLines.push(transcriptHeadingLine);
+			}
+			if (foldLines.length === 0) {
 				return;
 			}
 			const totalLines = body.split('\n').length;
 			const foldInfo = {
-				folds: [
-					{
-						from: transcriptHeadingLine,
-						to: transcriptHeadingLine,
-					},
-				],
+				folds: foldLines.map((line) => ({ from: line, to: line })),
 				lines: totalLines,
 			};
 			// Persist the fold state so the next file-open applies it.
@@ -1634,7 +1643,7 @@ export class ImportModal extends Modal {
 			}
 		} catch (err) {
 			console.warn(
-				`Plaud importer: failed to apply transcript fold state for ${path}`,
+				`Plaud importer: failed to apply fold state for ${path}`,
 				err,
 			);
 		}

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -17,7 +17,6 @@ import {
 	type DuplicatePolicy,
 	type DuplicatePromptCallback,
 	findTranscriptHeadingLine,
-	findTemplateOutputsHeadingLine,
 } from './note-writer';
 import { runImport } from './import-runner';
 import { buildPlaudIdIndex, type ImportedRecord } from './vault-index';
@@ -1573,14 +1572,15 @@ export class ImportModal extends Modal {
 	}
 
 	/**
-	 * Persist fold state for the wrapping section headings in a
-	 * freshly-written note so the chaptered transcript and the
-	 * `## Template outputs` block render collapsed by default while the
-	 * summary and chapters callout above them stay visible. Uses Obsidian's
-	 * undocumented but stable internal `app.foldManager.save` API
-	 * (type-augmented in `types.d.ts`) plus a best-effort same-session apply
-	 * via the active MarkdownView's `applyFoldInfo` when the file happens to
-	 * already be open in a leaf.
+	 * Persist fold state for the wrapping transcript heading in a
+	 * freshly-written note so the chaptered transcript renders collapsed by
+	 * default while the summary, template outputs, and chapters callout above
+	 * it stay visible. The `## Template outputs` block is deliberately NOT
+	 * folded: it is an H2 and the transcript heading is deeper, so folding it
+	 * would subsume the transcript. Uses Obsidian's undocumented but stable
+	 * internal `app.foldManager.save` API (type-augmented in `types.d.ts`) plus
+	 * a best-effort same-session apply via the active MarkdownView's
+	 * `applyFoldInfo` when the file happens to already be open in a leaf.
 	 *
 	 * Failure is swallowed with a console warning: a missing
 	 * foldManager (older Obsidian) or an applyFoldInfo rejection
@@ -1596,23 +1596,16 @@ export class ImportModal extends Modal {
 			}
 			const body = await this.app.vault.read(file);
 			const headerLevel = this.noteWriterOptions.transcriptHeaderLevel ?? 4;
-			// Fold the wrapping headings so the note opens with its bulky
-			// sections collapsed: the chaptered transcript and, when present,
-			// the `## Template outputs` block of extra AI outputs. Each is a
-			// single heading whose section Obsidian collapses by document
-			// structure, so folding the wrapper hides everything beneath it.
-			const foldLines: number[] = [];
-			const templateOutputsLine = findTemplateOutputsHeadingLine(body);
-			if (templateOutputsLine !== null) {
-				foldLines.push(templateOutputsLine);
-			}
+			// Fold the wrapping transcript heading so the chaptered transcript
+			// opens collapsed. The transcript is the final section, so this
+			// single heading-fold collapses it to end-of-note. Template outputs
+			// stay expanded (folding their shallower H2 would subsume the
+			// deeper transcript heading).
 			const transcriptHeadingLine = findTranscriptHeadingLine(body, headerLevel);
-			if (transcriptHeadingLine !== null) {
-				foldLines.push(transcriptHeadingLine);
-			}
-			if (foldLines.length === 0) {
+			if (transcriptHeadingLine === null) {
 				return;
 			}
+			const foldLines = [transcriptHeadingLine];
 			const totalLines = body.split('\n').length;
 			const foldInfo = {
 				folds: foldLines.map((line) => ({ from: line, to: line })),

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -184,6 +184,7 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 				chapters,
 				attachments,
 				nestedAssetLinks,
+				consumerNotes,
 			} = await deps.fetchArtifacts(recording.id);
 			const summaryLinkedAttachments = deps.attachments.extractAttachmentAssetsFromSummaryMarkdown(
 				summary?.text ?? null,
@@ -211,6 +212,7 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 				includeTranscript: selection.includeTranscript,
 				includeSummary: selection.includeSummary,
 				keywords: tagResult.keywords,
+				consumerNotes,
 			};
 			const selectedChapters = selection.includeTranscript
 				? chapters

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -1211,7 +1211,7 @@ export function findTemplateOutputsHeadingLine(markdown: string): number | null 
 function formatConsumerNotesSection(consumerNotes: readonly ConsumerNote[]): string {
 	const parts: string[] = [TEMPLATE_OUTPUTS_HEADING, ''];
 	for (const note of consumerNotes) {
-		const title = note.tabName.trim() || 'Template output';
+		const title = note.heading.trim() || 'Template output';
 		// One fence-aware pass nests the body's ATX headings under the `### <tab>`
 		// title and rewrites bare `---` separators (which would otherwise render
 		// as setext headings) to `***`, while leaving code-fence content intact.

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -27,6 +27,7 @@
 
 import type {
 	Chapter,
+	ConsumerNote,
 	Recording,
 	Summary,
 	Transcript,
@@ -905,7 +906,7 @@ function formatSummaryBody(summary: Summary | null): string {
 			.map((section) => `### ${section.heading}\n\n${section.body.trim()}`)
 			.join('\n\n');
 	}
-	return normalizeSummaryMarkdown(stripLeadingSummaryHeading(summary.text.trim()));
+	return neutralizeSetextDashes(stripLeadingSummaryHeading(summary.text.trim()));
 }
 
 function stripLeadingSummaryHeading(text: string): string {
@@ -916,11 +917,12 @@ function stripLeadingSummaryHeading(text: string): string {
 	return withoutHeading.trim().length > 0 ? withoutHeading.trim() : text;
 }
 
-function normalizeSummaryMarkdown(text: string): string {
+function neutralizeSetextDashes(text: string): string {
 	// A line of dashes directly after a paragraph is interpreted as a setext
 	// heading underline in markdown, which incorrectly turns the preceding
 	// paragraph into a giant heading. Convert dashed separators to `***`
-	// thematic breaks to preserve normal paragraph rendering.
+	// thematic breaks to preserve normal paragraph rendering. The consumer_note
+	// path uses normalizeConsumerNoteBody (fence-aware) instead of this helper.
 	return text.replace(/^-{3,}\s*$/gm, '***');
 }
 
@@ -1162,12 +1164,126 @@ export function findTranscriptHeadingLine(
 ): number | null {
 	const prefix = `${'#'.repeat(headerLevel)} Transcript`;
 	const lines = markdown.split('\n');
-	for (let i = 0; i < lines.length; i++) {
+	// Search from the end: the transcript is always the final section, so the
+	// last exact match is the real wrapping heading. A consumer_note body
+	// heading that demotes to the same text (e.g. `#### Transcript`) renders
+	// earlier in the note and must not shadow the real fold target.
+	for (let i = lines.length - 1; i >= 0; i--) {
 		if (lines[i] === prefix) {
 			return i;
 		}
 	}
 	return null;
+}
+
+/**
+ * The fixed H2 heading that wraps all consumer_note template outputs. Defined
+ * once so the renderer and the fold-line finder agree on the exact string.
+ */
+const TEMPLATE_OUTPUTS_HEADING = '## Template outputs';
+
+/**
+ * Find the 0-based line number of the `## Template outputs` heading in a
+ * rendered note, or null when the note has no template outputs. import-modal
+ * folds this one heading so the whole block opens collapsed by default,
+ * mirroring how the wrapping transcript heading is folded.
+ */
+export function findTemplateOutputsHeadingLine(markdown: string): number | null {
+	const lines = markdown.split('\n');
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i] === TEMPLATE_OUTPUTS_HEADING) {
+			return i;
+		}
+	}
+	return null;
+}
+
+/**
+ * Render the user's extra Plaud AI template outputs as a single
+ * `## Template outputs` block, one `### <tab name>` subsection per output
+ * with its Markdown body verbatim. Bodies are trusted Markdown from Plaud and
+ * embedded as-is (no callout re-quoting) so headings, lists, and tables
+ * render natively. import-modal folds the wrapping H2 so the block opens
+ * collapsed. Inclusion mirrors the user's Plaud-side template selection, so a
+ * transcript-style tab is rendered too and never de-duplicated against the
+ * pipeline transcript.
+ */
+function formatConsumerNotesSection(consumerNotes: readonly ConsumerNote[]): string {
+	const parts: string[] = [TEMPLATE_OUTPUTS_HEADING, ''];
+	for (const note of consumerNotes) {
+		const title = note.tabName.trim() || 'Template output';
+		// One fence-aware pass nests the body's ATX headings under the `### <tab>`
+		// title and rewrites bare `---` separators (which would otherwise render
+		// as setext headings) to `***`, while leaving code-fence content intact.
+		const body = normalizeConsumerNoteBody(note.markdown.trim());
+		parts.push(`### ${title}`, '', body, '');
+	}
+	// The block always starts with the heading (no leading whitespace), so
+	// trim() only strips the trailing blank line; formatMarkdown adds its own
+	// separator after the section.
+	return parts.join('\n').trim();
+}
+
+/** True for a line that opens or closes a fenced code block (``` or ~~~). */
+function isCodeFenceLine(line: string): boolean {
+	return /^\s*(?:```|~~~)/.test(line);
+}
+
+/**
+ * Normalize a consumer_note body for embedding under its `### <tab>` title in a
+ * single fence-aware pass:
+ *  - Re-level ATX headings so the shallowest sits at H4 (one below the tab
+ *    title). Without this a body `#`/`##`/`###` would end the
+ *    `## Template outputs` fold early and pollute the note outline as a sibling
+ *    of Summary.
+ *  - Rewrite a bare `---` dash run (which after a paragraph renders as a giant
+ *    setext heading) to a `***` thematic break.
+ * Both transforms skip fenced code blocks, so a `#` comment or a literal `---`
+ * inside a ``` block is preserved verbatim. This is the fence-aware counterpart
+ * of the summary path's neutralizeSetextDashes. Heading text and code content
+ * are preserved; only heading depth and bare dash separators change.
+ */
+function normalizeConsumerNoteBody(markdown: string): string {
+	const lines = markdown.split('\n');
+	// First pass: shallowest ATX heading level outside code fences.
+	let inFence = false;
+	let minLevel = 7;
+	for (const line of lines) {
+		if (isCodeFenceLine(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) {
+			continue;
+		}
+		const m = line.match(/^(#{1,6})\s/);
+		if (m) {
+			minLevel = Math.min(minLevel, m[1].length);
+		}
+	}
+	const shift = minLevel < 4 ? 4 - minLevel : 0;
+	// Second pass: outside fences, demote headings and neutralize setext dashes.
+	inFence = false;
+	const out = lines.map((line) => {
+		if (isCodeFenceLine(line)) {
+			inFence = !inFence;
+			return line;
+		}
+		if (inFence) {
+			return line;
+		}
+		if (shift > 0) {
+			const heading = line.match(/^(#{1,6})(\s.*)$/);
+			if (heading !== null) {
+				return `${'#'.repeat(Math.min(6, heading[1].length + shift))}${heading[2]}`;
+			}
+		}
+		if (/^-{3,}\s*$/.test(line)) {
+			return '***';
+		}
+		return line;
+	});
+	return out.join('\n');
 }
 
 function formatTranscriptLine(segment: TranscriptSegment): string {
@@ -1208,6 +1324,13 @@ export interface FormatMarkdownOptions {
 	 * from `tags:` and the keep-as-property setting is on.
 	 */
 	readonly keywords?: readonly string[];
+	/**
+	 * Extra Plaud AI template outputs (Key Points, Daily Journal, etc.) to
+	 * fold into the note as a `## Template outputs` block. Empty or omitted
+	 * renders no block. Independent of `includeSummary`: these mirror the
+	 * user's own Plaud-side template selection.
+	 */
+	readonly consumerNotes?: readonly ConsumerNote[];
 }
 
 export function formatMarkdown(
@@ -1258,6 +1381,10 @@ export function formatMarkdown(
 			).trim();
 			parts.push('## AI Suggestions', '', renderedSuggestion, '');
 		}
+	}
+	const consumerNotes = options.consumerNotes ?? [];
+	if (consumerNotes.length > 0) {
+		parts.push(formatConsumerNotesSection(consumerNotes), '');
 	}
 	if (transcriptSection.length > 0) {
 		parts.push('---', '', transcriptSection, '');

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -1183,30 +1183,14 @@ export function findTranscriptHeadingLine(
 const TEMPLATE_OUTPUTS_HEADING = '## Template outputs';
 
 /**
- * Find the 0-based line number of the `## Template outputs` heading in a
- * rendered note, or null when the note has no template outputs. import-modal
- * folds this one heading so the whole block opens collapsed by default,
- * mirroring how the wrapping transcript heading is folded.
- */
-export function findTemplateOutputsHeadingLine(markdown: string): number | null {
-	const lines = markdown.split('\n');
-	for (let i = 0; i < lines.length; i++) {
-		if (lines[i] === TEMPLATE_OUTPUTS_HEADING) {
-			return i;
-		}
-	}
-	return null;
-}
-
-/**
  * Render the user's extra Plaud AI template outputs as a single
- * `## Template outputs` block, one `### <tab name>` subsection per output
- * with its Markdown body verbatim. Bodies are trusted Markdown from Plaud and
- * embedded as-is (no callout re-quoting) so headings, lists, and tables
- * render natively. import-modal folds the wrapping H2 so the block opens
- * collapsed. Inclusion mirrors the user's Plaud-side template selection, so a
- * transcript-style tab is rendered too and never de-duplicated against the
- * pipeline transcript.
+ * `## Template outputs` block, one `### <template name>` subsection per output
+ * with its Markdown body. Bodies are trusted Markdown from Plaud and embedded
+ * natively (no callout re-quoting) so headings, lists, and tables render. The
+ * block is left expanded: it sits above the (collapsed) transcript, and folding
+ * its H2 would subsume the deeper transcript heading. Inclusion mirrors the
+ * user's Plaud-side template selection, so a transcript-style template is
+ * rendered too and never de-duplicated against the pipeline transcript.
  */
 function formatConsumerNotesSection(consumerNotes: readonly ConsumerNote[]): string {
 	const parts: string[] = [TEMPLATE_OUTPUTS_HEADING, ''];
@@ -1224,36 +1208,63 @@ function formatConsumerNotesSection(consumerNotes: readonly ConsumerNote[]): str
 	return parts.join('\n').trim();
 }
 
-/** True for a line that opens or closes a fenced code block (``` or ~~~). */
-function isCodeFenceLine(line: string): boolean {
-	return /^\s*(?:```|~~~)/.test(line);
+interface CodeFence {
+	readonly marker: '`' | '~';
+	readonly length: number;
+}
+
+/** Parse a line that opens or closes a fenced code block into its marker. */
+function parseCodeFence(line: string): CodeFence | null {
+	const match = line.match(/^\s*(`{3,}|~{3,})/);
+	if (match === null) {
+		return null;
+	}
+	const run = match[1];
+	return { marker: run[0] === '`' ? '`' : '~', length: run.length };
 }
 
 /**
- * Normalize a consumer_note body for embedding under its `### <tab>` title in a
- * single fence-aware pass:
- *  - Re-level ATX headings so the shallowest sits at H4 (one below the tab
- *    title). Without this a body `#`/`##`/`###` would end the
- *    `## Template outputs` fold early and pollute the note outline as a sibling
- *    of Summary.
+ * Advance fenced-code state by one line. A fence closes only on a line whose
+ * marker matches the opener and whose run is at least as long, so a shorter or
+ * different-marker fence line inside a block (e.g. ``` inside a ~~~ block) stays
+ * content rather than ending the block prematurely.
+ */
+function nextFenceState(active: CodeFence | null, line: string): CodeFence | null {
+	const fence = parseCodeFence(line);
+	if (fence === null) {
+		return active;
+	}
+	if (active === null) {
+		return fence;
+	}
+	return fence.marker === active.marker && fence.length >= active.length
+		? null
+		: active;
+}
+
+/**
+ * Normalize a consumer_note body for embedding under its `### <template>` title
+ * in a single fence-aware pass:
+ *  - Re-level ATX headings so the shallowest sits at H4 (one below the title).
+ *    Without this a body `#`/`##`/`###` would pollute the note outline as a
+ *    sibling of Summary.
  *  - Rewrite a bare `---` dash run (which after a paragraph renders as a giant
  *    setext heading) to a `***` thematic break.
  * Both transforms skip fenced code blocks, so a `#` comment or a literal `---`
- * inside a ``` block is preserved verbatim. This is the fence-aware counterpart
+ * inside a code fence is preserved verbatim. This is the fence-aware counterpart
  * of the summary path's neutralizeSetextDashes. Heading text and code content
  * are preserved; only heading depth and bare dash separators change.
  */
 function normalizeConsumerNoteBody(markdown: string): string {
 	const lines = markdown.split('\n');
 	// First pass: shallowest ATX heading level outside code fences.
-	let inFence = false;
+	let activeFence: CodeFence | null = null;
 	let minLevel = 7;
 	for (const line of lines) {
-		if (isCodeFenceLine(line)) {
-			inFence = !inFence;
-			continue;
-		}
-		if (inFence) {
+		const prevFence = activeFence;
+		activeFence = nextFenceState(prevFence, line);
+		// Skip fence delimiter lines and anything inside a fence.
+		if (prevFence !== null || activeFence !== null) {
 			continue;
 		}
 		const m = line.match(/^(#{1,6})\s/);
@@ -1263,13 +1274,11 @@ function normalizeConsumerNoteBody(markdown: string): string {
 	}
 	const shift = minLevel < 4 ? 4 - minLevel : 0;
 	// Second pass: outside fences, demote headings and neutralize setext dashes.
-	inFence = false;
+	activeFence = null;
 	const out = lines.map((line) => {
-		if (isCodeFenceLine(line)) {
-			inFence = !inFence;
-			return line;
-		}
-		if (inFence) {
+		const prevFence = activeFence;
+		activeFence = nextFenceState(prevFence, line);
+		if (prevFence !== null || activeFence !== null) {
 			return line;
 		}
 		if (shift > 0) {
@@ -1326,7 +1335,7 @@ export interface FormatMarkdownOptions {
 	readonly keywords?: readonly string[];
 	/**
 	 * Extra Plaud AI template outputs (Key Points, Daily Journal, etc.) to
-	 * fold into the note as a `## Template outputs` block. Empty or omitted
+	 * render in the note as a `## Template outputs` block. Empty or omitted
 	 * renders no block. Independent of `includeSummary`: these mirror the
 	 * user's own Plaud-side template selection.
 	 */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs",
+		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -11,6 +11,7 @@
 import type {
 	AttachmentAsset,
 	Chapter,
+	ConsumerNote,
 	PlaudClient,
 	PlaudRecordingId,
 	Recording,
@@ -292,6 +293,7 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 			nestedAssetLinks: {},
 			detailDataTypes: [],
 			attachmentDataTypes: [],
+			consumerNotes: [],
 		};
 		let bundleError: unknown = null;
 		try {
@@ -367,6 +369,8 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 			chapters: bundle.chapters.length > 0 ? bundle.chapters : undefined,
 			attachments:
 				bundle.attachments.length > 0 ? bundle.attachments : undefined,
+			consumerNotes:
+				bundle.consumerNotes.length > 0 ? bundle.consumerNotes : undefined,
 		};
 	}
 
@@ -507,6 +511,25 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 			}
 		}
 
+		// Additional AI template outputs (Key Points, Daily Journal, etc.) live
+		// as `consumer_note` content_list entries whose S3 links serve text/plain
+		// Markdown. Fetch each body now so note-writer can fold them into the
+		// note. Isolated like the newer-summary extraction: a failure here must
+		// never abort the bundle and drag the transcript/summary down with it.
+		let consumerNotes: readonly ConsumerNote[] = [];
+		try {
+			consumerNotes = await this.fetchConsumerNotes(rawDetail, detailEndpoint, id);
+		} catch (err) {
+			if (this.debugLogger?.enabled === true) {
+				this.debugLogger.log({
+					kind: 'parsed',
+					endpoint: detailEndpoint,
+					message: `consumer_note extraction failed for ${id}; continuing without template outputs: ${describeUnknownError(err)}`,
+					payload: { consumerNoteError: describeUnknownError(err) },
+				});
+			}
+		}
+
 		if (this.debugLogger?.enabled === true) {
 			this.debugLogger.log({
 				kind: 'parsed',
@@ -534,7 +557,82 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 			nestedAssetLinks,
 			detailDataTypes,
 			attachmentDataTypes,
+			consumerNotes,
 		};
+	}
+
+	/**
+	 * Fetch the Markdown body of every `consumer_note` template output on a
+	 * recording. Each entry's `data_link` is a short-lived pre-signed S3 URL
+	 * serving `text/plain`, so the fetch is authless (the URL carries its own
+	 * signature) and best-effort: a dead link or empty body drops that one
+	 * section, never the whole bundle. Fetched sequentially to match the
+	 * back-to-back transcript/outline pattern above and avoid hammering S3.
+	 */
+	private async fetchConsumerNotes(
+		rawDetail: unknown,
+		detailEndpoint: string,
+		id: PlaudRecordingId,
+	): Promise<readonly ConsumerNote[]> {
+		const refs = findConsumerNoteEntries(rawDetail, detailEndpoint);
+		const notes: ConsumerNote[] = [];
+		for (let i = 0; i < refs.length; i++) {
+			const ref = refs[i];
+			const noteEndpoint = `/s3/file_consumer_note_${i}/${encodeURIComponent(id)}`;
+			const body = await this.fetchTextBody(ref.dataLink, noteEndpoint);
+			if (body === null || body.trim().length === 0) {
+				if (this.debugLogger?.enabled === true) {
+					this.debugLogger.log({
+						kind: 'parsed',
+						endpoint: noteEndpoint,
+						message: `consumer_note "${ref.tabName}" body empty for ${id}; skipping section`,
+					});
+				}
+				continue;
+			}
+			notes.push({ tabName: ref.tabName, markdown: body.trim() });
+		}
+		return notes;
+	}
+
+	/**
+	 * Fetch a pre-signed S3 URL as raw text. Unlike `fetchJson`, this asserts
+	 * nothing about the body shape (consumer_note bodies are Markdown, not
+	 * JSON), so it must not route through the JSON parser. Authless: the URL
+	 * carries its own `X-Amz-Signature` and a Bearer token would be rejected.
+	 * Returns null on any network or non-2xx failure so callers stay
+	 * best-effort.
+	 */
+	private async fetchTextBody(
+		url: string,
+		endpoint: string,
+	): Promise<string | null> {
+		let response: PlaudHttpResponse;
+		try {
+			response = await this.fetcher({
+				url,
+				method: 'GET',
+				headers: {
+					Accept: 'text/plain, text/markdown, */*',
+					'User-Agent': USER_AGENT,
+				},
+			});
+		} catch (err) {
+			if (this.debugLogger?.enabled === true) {
+				this.debugLogger.log({
+					kind: 'error',
+					endpoint,
+					message: `GET ${endpoint} fetcher rejected: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				});
+			}
+			return null;
+		}
+		if (response.status < 200 || response.status >= 300) {
+			return null;
+		}
+		return response.text ?? null;
 	}
 
 	private async fetchJson(
@@ -1189,6 +1287,7 @@ export interface FileDetailBundle {
 	readonly nestedAssetLinks: Readonly<Record<string, string>>;
 	readonly detailDataTypes: readonly string[];
 	readonly attachmentDataTypes: readonly string[];
+	readonly consumerNotes: readonly ConsumerNote[];
 }
 
 /**
@@ -1452,6 +1551,65 @@ export function findOutlineLink(
 }
 
 /**
+ * Reference to one `consumer_note` template output discovered in a
+ * `/file/detail/{id}` response: the section label plus the pre-signed S3
+ * link whose body is the Markdown. The body itself is fetched separately
+ * because it is text/plain, not part of the detail JSON envelope.
+ */
+interface ConsumerNoteRef {
+	readonly tabName: string;
+	readonly dataLink: string;
+}
+
+/**
+ * Scan a `/file/detail/{id}` response's `content_list` for `consumer_note`
+ * entries — the extra AI template outputs (Key Points, Daily Journal, etc.)
+ * the user generated in Plaud. Each carries a `data_tab_name` section label
+ * and a pre-signed `data_link` whose body is text/plain Markdown. Only ready
+ * entries (`task_status === 1`) that carry a link are returned; the body is
+ * fetched downstream. Distinct from `findAttachmentAssets`, which excludes
+ * `consumer_note` so these never get saved as unreadable binary attachments.
+ */
+export function findConsumerNoteEntries(
+	raw: unknown,
+	endpoint: string,
+): readonly ConsumerNoteRef[] {
+	const data = requireDataEnvelope(raw, endpoint);
+	const out: ConsumerNoteRef[] = [];
+	const seen = new Set<string>();
+	const list = data.content_list;
+	if (!Array.isArray(list)) {
+		return out;
+	}
+	for (const item of list) {
+		if (!isRecord(item)) {
+			continue;
+		}
+		if (pickNonEmptyString(item.data_type) !== 'consumer_note') {
+			continue;
+		}
+		// task_status 1 = ready. Skip in-flight or errored outputs so a
+		// half-generated template never lands a broken section in the note.
+		if (item.task_status !== undefined && item.task_status !== 1) {
+			continue;
+		}
+		const links = collectAttachmentUrls(item.data_link);
+		if (links.length === 0) {
+			continue;
+		}
+		const dataLink = links[0];
+		if (seen.has(dataLink)) {
+			continue;
+		}
+		seen.add(dataLink);
+		const tabName =
+			pickNonEmptyString(item.data_tab_name, item.data_title) ?? 'Template output';
+		out.push({ tabName, dataLink });
+	}
+	return out;
+}
+
+/**
  * Discover downloadable supplemental assets from `/file/detail/{id}`.
  *
  * We scan both `content_list` and `pre_download_content_list` for entries
@@ -1471,6 +1629,10 @@ export function findAttachmentAssets(
 		'transaction_polish',
 		'outline',
 		'auto_sum_note',
+		// consumer_note bodies are text/plain Markdown folded into the note by
+		// note-writer (see findConsumerNoteEntries); never download them as
+		// binary attachments or they land as unreadable `.bin` files.
+		'consumer_note',
 	]);
 
 	const collectFrom = (list: unknown): void => {

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -585,12 +585,12 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 					this.debugLogger.log({
 						kind: 'parsed',
 						endpoint: noteEndpoint,
-						message: `consumer_note "${ref.tabName}" body empty for ${id}; skipping section`,
+						message: `consumer_note "${ref.heading}" body empty for ${id}; skipping section`,
 					});
 				}
 				continue;
 			}
-			notes.push({ tabName: ref.tabName, markdown: body.trim() });
+			notes.push({ heading: ref.heading, markdown: body.trim() });
 		}
 		return notes;
 	}
@@ -1557,18 +1557,20 @@ export function findOutlineLink(
  * because it is text/plain, not part of the detail JSON envelope.
  */
 interface ConsumerNoteRef {
-	readonly tabName: string;
+	readonly heading: string;
 	readonly dataLink: string;
 }
 
 /**
  * Scan a `/file/detail/{id}` response's `content_list` for `consumer_note`
  * entries — the extra AI template outputs (Key Points, Daily Journal, etc.)
- * the user generated in Plaud. Each carries a `data_tab_name` section label
- * and a pre-signed `data_link` whose body is text/plain Markdown. Only ready
- * entries (`task_status === 1`) that carry a link are returned; the body is
- * fetched downstream. Distinct from `findAttachmentAssets`, which excludes
- * `consumer_note` so these never get saved as unreadable binary attachments.
+ * the user generated in Plaud. Each is headed by its generating template's
+ * name (`extra.used_template.template_name`, falling back to the tab label
+ * then the entry title) and carries a pre-signed `data_link` whose body is
+ * text/plain Markdown. Only ready entries (`task_status === 1`) that carry a
+ * link are returned; the body is fetched downstream. Distinct from
+ * `findAttachmentAssets`, which excludes `consumer_note` so these never get
+ * saved as unreadable binary attachments.
  */
 export function findConsumerNoteEntries(
 	raw: unknown,
@@ -1602,9 +1604,19 @@ export function findConsumerNoteEntries(
 			continue;
 		}
 		seen.add(dataLink);
-		const tabName =
-			pickNonEmptyString(item.data_tab_name, item.data_title) ?? 'Template output';
-		out.push({ tabName, dataLink });
+		// Prefer the generating template's name (extra.used_template.template_name)
+		// for the section header; fall back to the tab label then the entry title.
+		const usedTemplate =
+			isRecord(item.extra) && isRecord(item.extra.used_template)
+				? item.extra.used_template
+				: undefined;
+		const heading =
+			pickNonEmptyString(
+				usedTemplate?.template_name,
+				item.data_tab_name,
+				item.data_title,
+			) ?? 'Template output';
+		out.push({ heading, dataLink });
 	}
 	return out;
 }

--- a/plaud-client.ts
+++ b/plaud-client.ts
@@ -79,12 +79,14 @@ export interface TranscriptAndSummary {
 
 /**
  * One AI template output ("consumer note") attached to a recording in Plaud.
- * `tabName` is the section label Plaud shows for it (`data_tab_name`, e.g.
- * "Key Points"); `markdown` is the fetched body. These mirror the user's
- * own Plaud-side template selection, so inclusion is their choice, not ours.
+ * `heading` is the section title, taken from the generating template's name
+ * (`extra.used_template.template_name`, e.g. "Meeting Summary") and falling
+ * back to the tab label then the entry title; `markdown` is the fetched body.
+ * These mirror the user's own Plaud-side template selection, so inclusion is
+ * their choice, not ours.
  */
 export interface ConsumerNote {
-	readonly tabName: string;
+	readonly heading: string;
 	readonly markdown: string;
 }
 

--- a/plaud-client.ts
+++ b/plaud-client.ts
@@ -65,6 +65,27 @@ export interface TranscriptAndSummary {
 	 * links expire quickly.
 	 */
 	readonly attachments?: readonly AttachmentAsset[];
+	/**
+	 * Additional AI template outputs the user generated in Plaud (Key Points,
+	 * Daily Journal, Meeting Summary, etc.). Each is a `content_list` entry of
+	 * `data_type: consumer_note` whose pre-signed S3 link serves a `text/plain`
+	 * Markdown body. The RE client fetches each body during the detail pass and
+	 * surfaces it here so note-writer can fold it into the note as a section
+	 * rather than the import pipeline saving it as an unreadable `.bin`
+	 * attachment. Left undefined when the recording has none.
+	 */
+	readonly consumerNotes?: readonly ConsumerNote[];
+}
+
+/**
+ * One AI template output ("consumer note") attached to a recording in Plaud.
+ * `tabName` is the section label Plaud shows for it (`data_tab_name`, e.g.
+ * "Key Points"); `markdown` is the fetched body. These mirror the user's
+ * own Plaud-side template selection, so inclusion is their choice, not ours.
+ */
+export interface ConsumerNote {
+	readonly tabName: string;
+	readonly markdown: string;
 }
 
 /**


### PR DESCRIPTION
## Problem

Extra AI template outputs generated in Plaud (Key Points, Daily Journal, Meeting Summary, etc.) were saved as unreadable `.bin` files in the note's `-assets` folder. They are served as `text/plain` Markdown, but the attachment extension inference had no text branch, so they fell to the terminal `.bin`.

## Fix

Route them to readable note content:

- Parse the template-output entries from the recording detail; fetch each body as raw text (best-effort and isolated, so a dead link never sinks the import). Exclude them from the attachment path so they are no longer downloaded as binary files. Surface the bodies on the artifact bundle.
- Render a `## Template outputs` section below the summary, one `### <template name>` per output (header taken from the generating template's name, falling back to the tab label then the entry title). A single fence-aware pass demotes each body's headings to nest under its title and neutralizes `---` setext separators, leaving fenced code verbatim. The block renders expanded; the transcript below stays collapsed by default (folding the section's H2 would have subsumed the deeper transcript heading).
- `inferAssetExtension` lifted to a tested module-level function: an explicit markdown MIME resolves to `md`, while a generic `text/plain` body is resolved after the JSON-body sniff so a JSON envelope served as text/plain still imports its nested images.

Template outputs are always included as note content (no picker toggle), mirroring the user's Plaud-side template selection. A verbatim-transcript template renders as its own section and is not de-duplicated against the pipeline transcript.

## Testing

`npm run lint && npm run build && npm test` green. 654 tests (was 623), including an end-to-end guard that the fetched bodies reach the rendered note, plus regression tests for the MIME ordering and code-fence handling. Not yet hands-on validated in Obsidian against a live recording.
