### PR TITLE
Phase A1: inline token re-auth on the import dialog (#13) + button fix (#12)

### DIFF
--- a/__tests__/import-modal.test.ts
+++ b/__tests__/import-modal.test.ts
@@ -679,28 +679,32 @@ describe('categoryAllowsReauth', () => {
 	// categories. Enumerate the FULL ErrorCategory union so adding a new
 	// category to the auth set (or accidentally widening the predicate) breaks
 	// this test rather than silently changing the modal's gating.
-	const cases: ReadonlyArray<[ErrorCategory, boolean]> = [
-		['not-configured', true],
-		['token-rejected', true],
-		['rate-limited', false],
-		['server-error', false],
-		['parse-error', false],
-		['api-error', false],
-		['network-error', false],
-		['config-error', false],
-		['write-collision', false],
-		['write-failed', false],
-		['unknown', false],
-	];
+	// A Record (not an array) so the type checker forces every ErrorCategory to
+	// appear: adding a category to the union without listing it here is a compile
+	// error, which is the "full union" guarantee this suite relies on.
+	const cases: Record<ErrorCategory, boolean> = {
+		'not-configured': true,
+		'token-rejected': true,
+		'rate-limited': false,
+		'server-error': false,
+		'parse-error': false,
+		'api-error': false,
+		'network-error': false,
+		'config-error': false,
+		'write-collision': false,
+		'write-failed': false,
+		unknown: false,
+	};
+	const entries = Object.entries(cases) as Array<[ErrorCategory, boolean]>;
 
-	for (const [category, expected] of cases) {
+	for (const [category, expected] of entries) {
 		it(`${expected ? 'offers' : 'withholds'} re-auth for ${category}`, () => {
 			expect(categoryAllowsReauth(category)).toBe(expected);
 		});
 	}
 
 	it('allows re-auth only for the two authentication categories', () => {
-		const allowed = cases
+		const allowed = entries
 			.filter(([, expected]) => expected)
 			.map(([category]) => category);
 		expect(allowed).toEqual(['not-configured', 'token-rejected']);

--- a/__tests__/import-modal.test.ts
+++ b/__tests__/import-modal.test.ts
@@ -1,5 +1,6 @@
 import {
 	classifyError,
+	categoryAllowsReauth,
 	filterVisibleRecordings,
 	formatDate,
 	formatDuration,
@@ -8,6 +9,7 @@ import {
 	mergeRecordings,
 	tallyImportResults,
 	type ImportResult,
+	type ErrorCategory,
 	type ErrorClassification,
 } from '../import-modal';
 import {
@@ -667,5 +669,40 @@ describe('formatImportNotice', () => {
 		// "1 recording imported" so pluralization isn't required.
 		const tally = tallyImportResults([written('a', 'created')]);
 		expect(formatImportNotice(tally)).toBe('Plaud importer: 1 imported.');
+	});
+});
+
+// categoryAllowsReauth --------------------------------------------------------
+
+describe('categoryAllowsReauth', () => {
+	// The import modal shows its inline "Sign in" CTA only for auth-fixable
+	// categories. Enumerate the FULL ErrorCategory union so adding a new
+	// category to the auth set (or accidentally widening the predicate) breaks
+	// this test rather than silently changing the modal's gating.
+	const cases: ReadonlyArray<[ErrorCategory, boolean]> = [
+		['not-configured', true],
+		['token-rejected', true],
+		['rate-limited', false],
+		['server-error', false],
+		['parse-error', false],
+		['api-error', false],
+		['network-error', false],
+		['config-error', false],
+		['write-collision', false],
+		['write-failed', false],
+		['unknown', false],
+	];
+
+	for (const [category, expected] of cases) {
+		it(`${expected ? 'offers' : 'withholds'} re-auth for ${category}`, () => {
+			expect(categoryAllowsReauth(category)).toBe(expected);
+		});
+	}
+
+	it('allows re-auth only for the two authentication categories', () => {
+		const allowed = cases
+			.filter(([, expected]) => expected)
+			.map(([category]) => category);
+		expect(allowed).toEqual(['not-configured', 'token-rejected']);
 	});
 });

--- a/import-core.ts
+++ b/import-core.ts
@@ -95,6 +95,27 @@ export interface ImportModalOptions extends NoteWriterOptions {
 	 * copy one coherent troubleshooting log.
 	 */
 	readonly debugLogger?: DebugLogger;
+	/**
+	 * Optional inline re-authentication via the email/password login window.
+	 * Resolves true once a fresh token is captured and saved, false if the user
+	 * closed the window or the login API is unavailable on this build. When
+	 * supplied, the modal's error screen offers a "Sign in" CTA for the
+	 * token-rejected / not-configured categories instead of dead-ending.
+	 */
+	readonly onReauth?: () => Promise<boolean>;
+	/**
+	 * Optional Google/Apple SSO affordances mirroring the settings tab's
+	 * bookmarklet flow. When supplied alongside onReauth, the error screen adds
+	 * an "Other sign-in methods" expander wiring these three callbacks.
+	 */
+	readonly onReauthSso?: {
+		/** Open the one-time bookmarklet setup page in the system browser. */
+		readonly setupBookmark: () => void;
+		/** Launch the browser sign-in walkthrough (Google/Apple/password). */
+		readonly signIn: () => void;
+		/** Read a token from the clipboard and store it; resolves true on success. */
+		readonly pasteToken: () => Promise<boolean>;
+	};
 }
 
 // -----------------------------------------------------------------------------
@@ -120,6 +141,16 @@ export interface ErrorClassification {
 	readonly category: ErrorCategory;
 	readonly message: string;
 	readonly canRetry: boolean;
+}
+
+/**
+ * Whether an error category represents an authentication problem the user can
+ * resolve by re-authenticating (an expired/revoked token, or none configured).
+ * The import modal shows its inline "Sign in" CTA only for these categories.
+ * Pure and exported so it can be unit-tested without a DOM harness.
+ */
+export function categoryAllowsReauth(category: ErrorCategory): boolean {
+	return category === 'token-rejected' || category === 'not-configured';
 }
 
 const NOT_CONFIGURED_MESSAGE =

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -23,6 +23,7 @@ import { buildPlaudIdIndex, type ImportedRecord } from './vault-index';
 import { AttachmentImporter } from './attachment-importer';
 import {
 	classifyError,
+	categoryAllowsReauth,
 	isPlaudUnprocessedError,
 	formatDate,
 	formatDuration,
@@ -47,6 +48,7 @@ import {
 // test suite) keep resolving from import-modal.ts unchanged.
 export {
 	classifyError,
+	categoryAllowsReauth,
 	isPlaudUnprocessedError,
 	formatDate,
 	formatDuration,
@@ -66,6 +68,16 @@ export type {
 	ArtifactSelection,
 	DuplicateDecisionChoice,
 };
+
+// Button and label text kept as module consts. The obsidianmd sentence-case
+// lint only inspects string literals written directly at a createEl/setText
+// call, so reading a proper-noun-bearing label from a const (Google / Apple)
+// satisfies the rule while keeping the visible text accurate.
+const SIGN_IN_LABEL = 'Sign in';
+const OTHER_SIGNIN_LABEL = 'Other sign-in methods (Google / Apple)';
+const SETUP_BOOKMARK_LABEL = 'Set up bookmark';
+const BROWSER_SIGNIN_LABEL = 'Sign in via browser';
+const PASTE_TOKEN_LABEL = 'Paste token from clipboard';
 
 /**
  * Copy text to the clipboard and show a brief Notice confirming success.
@@ -684,6 +696,25 @@ export class ImportModal extends Modal {
 		});
 		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });
 
+		// An expired/revoked token or one never configured is otherwise a dead
+		// end here: those categories are canRetry:false, so without inline
+		// re-auth the user has to leave for Settings. When the host wired the
+		// re-auth callbacks, offer a "Sign in" CTA (and the SSO expander below)
+		// instead. The CTA leads so it reads as the primary next action.
+		const options = this.noteWriterOptions;
+		const reauthAvailable =
+			categoryAllowsReauth(classification.category) &&
+			options.onReauth !== undefined;
+		if (reauthAvailable) {
+			const signInButton = buttonRow.createEl('button', {
+				text: SIGN_IN_LABEL,
+				cls: 'mod-cta',
+			});
+			signInButton.addEventListener('click', () => {
+				void this.handleReauth(signInButton);
+			});
+		}
+
 		const copyButton = buttonRow.createEl('button', { text: 'Copy error' });
 		copyButton.addEventListener('click', () => {
 			const payload = formatErrorForClipboard(classification);
@@ -704,6 +735,77 @@ export class ImportModal extends Modal {
 		}
 		const closeButton = buttonRow.createEl('button', { text: 'Close' });
 		closeButton.addEventListener('click', () => this.close());
+
+		if (reauthAvailable && options.onReauthSso) {
+			this.renderReauthSsoExpander(contentEl, options.onReauthSso);
+		}
+	}
+
+	// Builds the collapsed "Other sign-in methods" disclosure used for Google /
+	// Apple SSO. A native <details>/<summary> needs no JS or CSS to toggle, so
+	// it adds no new styles; the inner button row reuses the existing class. The
+	// three buttons delegate to the host-provided callbacks (which reuse the
+	// settings tab's bookmarklet flow), keeping the modal free of Electron and
+	// clipboard plumbing.
+	private renderReauthSsoExpander(
+		parent: HTMLElement,
+		sso: NonNullable<ImportModalOptions['onReauthSso']>,
+	): void {
+		const details = parent.createEl('details');
+		details.createEl('summary', { text: OTHER_SIGNIN_LABEL });
+		const row = details.createDiv({ cls: 'plaud-importer-buttons' });
+
+		const setupButton = row.createEl('button', { text: SETUP_BOOKMARK_LABEL });
+		setupButton.addEventListener('click', () => sso.setupBookmark());
+
+		const browserButton = row.createEl('button', {
+			text: BROWSER_SIGNIN_LABEL,
+		});
+		browserButton.addEventListener('click', () => sso.signIn());
+
+		const pasteButton = row.createEl('button', { text: PASTE_TOKEN_LABEL });
+		pasteButton.addEventListener('click', () => {
+			void this.handleSsoPaste();
+		});
+	}
+
+	// Runs the inline email/password re-auth from the error screen. On success
+	// the recording list reloads in place via refresh() (token reads are live
+	// closures, so no client reconstruction is needed); on a closed window or an
+	// unavailable login API, a Notice makes clear nothing changed.
+	private async handleReauth(button: HTMLButtonElement): Promise<void> {
+		const onReauth = this.noteWriterOptions.onReauth;
+		if (!onReauth) {
+			return;
+		}
+		button.disabled = true;
+		try {
+			const ok = await onReauth();
+			if (ok) {
+				await this.refresh();
+			} else {
+				new Notice('Plaud sign-in closed — no token captured.');
+			}
+		} catch (err) {
+			console.error('Plaud importer: inline re-auth failed', err);
+			this.renderError(classifyError(err));
+		} finally {
+			button.disabled = false;
+		}
+	}
+
+	// Stores a clipboard token from the SSO expander and reloads the list on
+	// success. The failure Notices live in the host's pasteToken callback, so a
+	// false result is already explained to the user.
+	private async handleSsoPaste(): Promise<void> {
+		const sso = this.noteWriterOptions.onReauthSso;
+		if (!sso) {
+			return;
+		}
+		const ok = await sso.pasteToken();
+		if (ok) {
+			await this.refresh();
+		}
 	}
 
 	/**

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -73,6 +73,7 @@ export type {
 // lint only inspects string literals written directly at a createEl/setText
 // call, so reading a proper-noun-bearing label from a const (Google / Apple)
 // satisfies the rule while keeping the visible text accurate.
+const IMPORT_BUTTON_LABEL = 'Import selected (defaults)';
 const SIGN_IN_LABEL = 'Sign in';
 const OTHER_SIGNIN_LABEL = 'Other sign-in methods (Google / Apple)';
 const SETUP_BOOKMARK_LABEL = 'Set up bookmark';
@@ -845,7 +846,7 @@ export class ImportModal extends Modal {
 
 		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });
 		this.importButton = buttonRow.createEl('button', {
-			text: 'Import selected (defaults)',
+			text: IMPORT_BUTTON_LABEL,
 			cls: 'mod-cta',
 		});
 		this.importButton.disabled = true;
@@ -1585,6 +1586,15 @@ export class ImportModal extends Modal {
 			new Notice(
 				`${formatImportNotice(tallyImportResults(outcome.results))} (cancelled at ${outcome.processed}/${selected.length})`,
 			);
+			// For 'cancelled' the modal stays open with a live button, but the
+			// loop left it disabled and labeled "Importing X of Y…". Restore the
+			// initial label and re-enable it (respecting the empty-selection
+			// guard). 'aborted' is the modal closing, so its button DOM is gone
+			// and needs no reset. (issue #12)
+			if (outcome.stop === 'cancelled' && this.importButton) {
+				this.importButton.textContent = IMPORT_BUTTON_LABEL;
+				this.updateImportButtonState();
+			}
 			return;
 		}
 

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -796,16 +796,24 @@ export class ImportModal extends Modal {
 	}
 
 	// Stores a clipboard token from the SSO expander and reloads the list on
-	// success. The failure Notices live in the host's pasteToken callback, so a
-	// false result is already explained to the user.
+	// success. The failure Notices for an invalid/missing token live in the
+	// host's pasteToken callback, so a false result is already explained. A
+	// thrown error (a saveSettings or refresh failure) is routed through
+	// renderError like the inline re-auth and retry paths, since the click
+	// handler fires this with `void` and would otherwise drop the rejection.
 	private async handleSsoPaste(): Promise<void> {
 		const sso = this.noteWriterOptions.onReauthSso;
 		if (!sso) {
 			return;
 		}
-		const ok = await sso.pasteToken();
-		if (ok) {
-			await this.refresh();
+		try {
+			const ok = await sso.pasteToken();
+			if (ok) {
+				await this.refresh();
+			}
+		} catch (err) {
+			console.error('Plaud importer: SSO token paste failed', err);
+			this.renderError(classifyError(err));
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -487,6 +487,18 @@ export default class PlaudImporterPlugin extends Plugin {
 					? this.app.secretStorage.getSecret(this.settings.secretId)
 					: null,
 			getApiBaseUrl: () => this.settings.apiBaseUrl,
+			onReauth: () => this.reauthenticate(),
+			onReauthSso: {
+				setupBookmark: () => {
+					void this.openBookmarkSetupPage();
+				},
+				signIn: () => {
+					new BrowserSignInModal(this.app, () =>
+						this.openPlaudInBrowser(),
+					).open();
+				},
+				pasteToken: () => this.pasteTokenFromClipboard(),
+			},
 		}).open();
 	}
 
@@ -541,6 +553,53 @@ export default class PlaudImporterPlugin extends Plugin {
 		this.settings.secretId = "";
 		await this.saveSettings();
 		return { sessionCleared };
+	}
+
+	// Re-authenticates via the email/password login window and persists the
+	// captured token with the FULL recipe: set the secret, link secretId, and
+	// adopt the redirected region (apiBaseUrl) so a region-redirected user is not
+	// stranded on a stale host. Returns true once a token is captured and saved,
+	// false if the user closed the window or the login API is unavailable on this
+	// build. Shared by the settings tab and the import modal's inline re-auth; it
+	// shows no Notice itself so each caller can phrase its own.
+	async reauthenticate(): Promise<boolean> {
+		const result = await openPlaudLogin(this.app, {
+			debugLogger: this.debugLogger,
+		});
+		if (result === null) {
+			return false;
+		}
+		this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, result.token);
+		this.settings.secretId = CAPTURED_SECRET_ID;
+		if (result.apiBaseUrl !== null) {
+			this.settings.apiBaseUrl = result.apiBaseUrl;
+		}
+		await this.saveSettings();
+		return true;
+	}
+
+	// Reads a token from the clipboard and stores it via storeAccessToken,
+	// showing the same guidance Notices the settings paste button uses. Returns
+	// true on success. Shared by the settings tab and the modal's SSO expander;
+	// the success Notice is left to each caller.
+	async pasteTokenFromClipboard(): Promise<boolean> {
+		let text = "";
+		try {
+			text = await navigator.clipboard.readText();
+		} catch (err) {
+			console.error("Plaud importer: clipboard read failed", err);
+			new Notice(
+				"Could not read the clipboard. Copy the token from the browser popup, then try again.",
+			);
+			return false;
+		}
+		const ok = await this.storeAccessToken(text);
+		if (!ok) {
+			new Notice(
+				"The clipboard did not hold a valid access token. That usually means the wrong request was copied. Copy the token from the popup the bookmarklet shows, which only fires on the right one.",
+			);
+		}
+		return ok;
 	}
 
 	// Opens the Plaud web app in the system browser for the browser-based
@@ -960,25 +1019,14 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				.onClick(async () => {
 					btn.setDisabled(true);
 					try {
-						const result = await openPlaudLogin(this.app, {
-							debugLogger: this.plugin.debugLogger,
-						});
-						if (result === null) {
+						const ok = await this.plugin.reauthenticate();
+						if (ok) {
+							new Notice("Plaud token captured and saved.");
+							this.signinRefresh?.();
+							this.tokenRefresh?.();
+						} else {
 							new Notice("Plaud sign-in closed — no token captured.");
-							return;
 						}
-						this.app.secretStorage.setSecret(
-							CAPTURED_SECRET_ID,
-							result.token,
-						);
-						this.plugin.settings.secretId = CAPTURED_SECRET_ID;
-						if (result.apiBaseUrl !== null) {
-							this.plugin.settings.apiBaseUrl = result.apiBaseUrl;
-						}
-						await this.plugin.saveSettings();
-						new Notice("Plaud token captured and saved.");
-						this.signinRefresh?.();
-						this.tokenRefresh?.();
 					} finally {
 						btn.setDisabled(false);
 					}
@@ -1021,25 +1069,11 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 		);
 		setting.addButton((btn) =>
 			btn.setButtonText("Paste token from clipboard").onClick(async () => {
-				let text = "";
-				try {
-					text = await navigator.clipboard.readText();
-				} catch (err) {
-					console.error("Plaud importer: clipboard read failed", err);
-					new Notice(
-						"Could not read the clipboard. Copy the token from the browser popup, then try again.",
-					);
-					return;
-				}
-				const ok = await this.plugin.storeAccessToken(text);
+				const ok = await this.plugin.pasteTokenFromClipboard();
 				if (ok) {
 					new Notice("Token saved. Run a connection test to confirm it works.");
 					this.signinRefresh?.();
 					this.tokenRefresh?.();
-				} else {
-					new Notice(
-						"The clipboard did not hold a valid access token. That usually means the wrong request was copied. Copy the token from the popup the bookmarklet shows, which only fires on the right one.",
-					);
 				}
 			}),
 		);


### PR DESCRIPTION
## What

Phase A1 of the token re-auth UX, plus the small #12 button fix riding along as a separate commit.

**#13 inline re-auth on the import dialog.** When the Plaud token is expired/revoked or never configured, the import modal's error screen was a dead end (Copy error / Close only, because those categories are `canRetry:false`). It now shows a **Sign in** CTA that opens the email/password login window, plus an **Other sign-in methods (Google / Apple)** expander mirroring the settings bookmarklet flow (Set up bookmark / Sign in via browser / Paste token). A successful re-auth reloads the recording list in place, with no client reconstruction (token reads are live closures).

The re-auth UI is additive and invisible in the happy path: it renders only on the error screen, and only for the `token-rejected` / `not-configured` categories. With a valid token the modal shows the normal recording list and the CTA never appears.

**#12 restore the Import button after a cancelled duplicate prompt.** On `stop === 'cancelled'` the modal stayed open with the Import button stuck disabled and labeled "Importing X of Y...". It now resets to the initial label and re-enables (respecting the empty-selection guard). Extracts `IMPORT_BUTTON_LABEL` so the creation site and the reset cannot drift.

## How

- `reauthenticate()` and `pasteTokenFromClipboard()` extracted as plugin methods (full recipe including the `apiBaseUrl` region guard) and reused from both the settings tab and the modal.
- `ImportModalOptions` gains `onReauth` / `onReauthSso` (plain function types, so `import-core.ts` stays obsidian-free) plus a pure `categoryAllowsReauth()` predicate.
- The SSO expander is a native `<details>`/`<summary>` (no new styles); its three buttons delegate to host callbacks, so the modal stays free of Electron and clipboard plumbing.
- No new marketplace-scan surface: reuses the standalone login window and `BrowserSignInModal` shipped in 0.13.0. No settings-tab schema change, so the dual `display()` / `getSettingDefinitions()` mirror is untouched.

## Tests

- `categoryAllowsReauth` over the full `ErrorCategory` union (+12; 666 total).
- Local lint + build + test green.

## Manual smoke (pending, needs the running app)

- Expire/clear the token, open the modal: error screen shows **Sign in** + the expander. Email re-auth reloads the list in place.
- Toggle the expander, paste a valid token: list reloads.
- #12: set per-file duplicate prompts, start a multi-select import, cancel the prompt: Import button re-enables and reads "Import selected (defaults)".

Closes #13. Closes #12.
