### PR TITLE
A2: abort import on mid-batch token expiry and offer resume (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- If your Plaud session expired partway through a multi-select import, every remaining recording failed with the same "Plaud rejected your token" error and the run still reported as completed. The import now stops at the first recording that fails to authenticate, keeps the recordings it already imported, and shows how many were done. You can sign in again right there (email or Google/Apple), then a **Resume remaining** button finishes the recordings that were left, picking up exactly where it stopped.
+
 ## [0.15.0] - 2026-06-30
 
 ### Added

--- a/__tests__/import-runner.test.ts
+++ b/__tests__/import-runner.test.ts
@@ -6,7 +6,7 @@ import {
 	type VaultLike,
 	type DuplicatePromptDecision,
 } from '../note-writer';
-import { PlaudApiError } from '../plaud-client-re';
+import { PlaudApiError, PlaudAuthError } from '../plaud-client-re';
 import type { ArtifactSelection, ImportModalOptions } from '../import-core';
 import type {
 	PlaudRecordingId,
@@ -636,5 +636,151 @@ describe('runImport', () => {
 		// Second run skips the duplicate; fold must NOT run on a skip.
 		await runImport(deps);
 		expect(foldPaths).toHaveLength(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// A2: mid-batch token-expiry abort (issue #14). A rejected token part-way
+	// through a multi-select import is a batch-terminal condition: the loop must
+	// stop on the FIRST auth failure (stop:'auth-failed') instead of failing
+	// every remaining recording, and the pre-expiry results must survive so the
+	// modal can resume the unprocessed tail.
+	// -------------------------------------------------------------------------
+
+	it('stops with auth-failed on the first token rejection and does not touch later recordings', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const recC = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>([
+				[recA.id, makeArtifacts(recA)],
+				[recB.id, (): never => {
+					throw new PlaudAuthError('token_rejected', 'rejected', '/ai/transsumm');
+				}],
+				[recC.id, makeArtifacts(recC)],
+			]),
+		);
+		const { observer, starts, written } = makeObserver();
+
+		const outcome = await runImport({
+			recordings: [recA, recB, recC],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('auth-failed');
+		// recA finished; recB is the failing index, never written. processed = 1.
+		expect(outcome.processed).toBe(1);
+		expect(outcome.results).toHaveLength(1);
+		expect(outcome.results[0]).toMatchObject({
+			kind: 'written',
+			recording: { id: recA.id },
+		});
+		// The runner did NOT classify recB or recC as a per-recording 'failed'.
+		expect(outcome.results.some((r) => r.kind === 'failed')).toBe(false);
+		// recC was never fetched: the loop returned at recB.
+		expect(calls).toEqual([recA.id, recB.id]);
+		// recB's progress started (fires before the fetch); recC's never did.
+		expect(starts).toEqual([[1, 3], [2, 3]]);
+		expect(written).toEqual([recA.id]);
+	});
+
+	it('reports processed 0 and retains no results when the first recording is rejected', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>([
+				[recA.id, (): never => {
+					throw new PlaudAuthError('token_rejected', 'rejected', '/ai/transsumm');
+				}],
+				[recB.id, makeArtifacts(recB)],
+			]),
+		);
+		const { observer, starts } = makeObserver();
+
+		const outcome = await runImport({
+			recordings: [recA, recB],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			observer,
+		});
+
+		expect(outcome.stop).toBe('auth-failed');
+		expect(outcome.processed).toBe(0);
+		expect(outcome.results).toHaveLength(0);
+		// recB was never touched.
+		expect(calls).toEqual([recA.id]);
+		expect(starts).toEqual([[1, 2]]);
+	});
+
+	it('aborts on a not-configured auth error too (categoryAllowsReauth, not just token_rejected)', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>([
+				[recA.id, makeArtifacts(recA)],
+				[recB.id, (): never => {
+					throw new PlaudAuthError('not_configured', 'no token', '/ai/transsumm');
+				}],
+			]),
+		);
+
+		const outcome = await runImport({
+			recordings: [recA, recB],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+		});
+
+		expect(outcome.stop).toBe('auth-failed');
+		expect(outcome.processed).toBe(1);
+		expect(outcome.results).toHaveLength(1);
+	});
+
+	it('keeps the partial-success semantic for a non-auth failure (continues the batch)', async () => {
+		const vault = makeFakeVault();
+		const recA = makeRecording();
+		const recB = makeRecording();
+		const recC = makeRecording();
+		const { fetchArtifacts, calls } = makeFetch(
+			new Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>([
+				[recA.id, makeArtifacts(recA)],
+				[recB.id, (): never => {
+					throw new Error('transient network blip');
+				}],
+				[recC.id, makeArtifacts(recC)],
+			]),
+		);
+
+		const outcome = await runImport({
+			recordings: [recA, recB, recC],
+			selection: SELECTION,
+			writer: makeWriter(vault),
+			attachments: makeAttachmentStub().pipeline,
+			options: { ...OPTIONS, writePlaceholderForUnprocessed: false },
+			fetchArtifacts,
+		});
+
+		// A generic failure stays per-recording: the loop runs to completion.
+		expect(outcome.stop).toBe('completed');
+		expect(outcome.processed).toBe(3);
+		expect(outcome.results.map((r) => r.kind)).toEqual([
+			'written',
+			'failed',
+			'written',
+		]);
+		// All three were fetched: the batch did not abort at recB.
+		expect(calls).toEqual([recA.id, recB.id, recC.id]);
 	});
 });

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -703,18 +703,11 @@ export class ImportModal extends Modal {
 		// re-auth callbacks, offer a "Sign in" CTA (and the SSO expander below)
 		// instead. The CTA leads so it reads as the primary next action.
 		const options = this.noteWriterOptions;
-		const reauthAvailable =
-			categoryAllowsReauth(classification.category) &&
-			options.onReauth !== undefined;
-		if (reauthAvailable) {
-			const signInButton = buttonRow.createEl('button', {
-				text: SIGN_IN_LABEL,
-				cls: 'mod-cta',
-			});
-			signInButton.addEventListener('click', () => {
-				void this.handleReauth(signInButton);
-			});
-		}
+		const reauthAvailable = this.appendSignInCta(
+			buttonRow,
+			classification.category,
+			() => this.refresh(),
+		);
 
 		const copyButton = buttonRow.createEl('button', { text: 'Copy error' });
 		copyButton.addEventListener('click', () => {
@@ -738,8 +731,36 @@ export class ImportModal extends Modal {
 		closeButton.addEventListener('click', () => this.close());
 
 		if (reauthAvailable && options.onReauthSso) {
-			this.renderReauthSsoExpander(contentEl, options.onReauthSso);
+			this.renderReauthSsoExpander(contentEl, options.onReauthSso, () =>
+				this.refresh(),
+			);
 		}
+	}
+
+	// Adds the leading "Sign in" CTA to an error/interrupt button row when the
+	// host wired re-auth and the category is auth-related. onSuccess runs after a
+	// token is captured (the error screen reloads the list; the auth-interrupted
+	// screen advances to the resume prompt). Returns whether the CTA was added,
+	// so the caller can gate the SSO expander on the same condition.
+	private appendSignInCta(
+		buttonRow: HTMLElement,
+		category: ErrorCategory,
+		onSuccess: () => Promise<void>,
+	): boolean {
+		const reauthAvailable =
+			categoryAllowsReauth(category) &&
+			this.noteWriterOptions.onReauth !== undefined;
+		if (!reauthAvailable) {
+			return false;
+		}
+		const signInButton = buttonRow.createEl('button', {
+			text: SIGN_IN_LABEL,
+			cls: 'mod-cta',
+		});
+		signInButton.addEventListener('click', () => {
+			void this.handleReauth(signInButton, onSuccess);
+		});
+		return true;
 	}
 
 	// Builds the collapsed "Other sign-in methods" disclosure used for Google /
@@ -751,6 +772,7 @@ export class ImportModal extends Modal {
 	private renderReauthSsoExpander(
 		parent: HTMLElement,
 		sso: NonNullable<ImportModalOptions['onReauthSso']>,
+		onSuccess: () => Promise<void>,
 	): void {
 		const details = parent.createEl('details');
 		details.createEl('summary', { text: OTHER_SIGNIN_LABEL });
@@ -766,15 +788,20 @@ export class ImportModal extends Modal {
 
 		const pasteButton = row.createEl('button', { text: PASTE_TOKEN_LABEL });
 		pasteButton.addEventListener('click', () => {
-			void this.handleSsoPaste();
+			void this.handleSsoPaste(onSuccess);
 		});
 	}
 
-	// Runs the inline email/password re-auth from the error screen. On success
-	// the recording list reloads in place via refresh() (token reads are live
-	// closures, so no client reconstruction is needed); on a closed window or an
-	// unavailable login API, a Notice makes clear nothing changed.
-	private async handleReauth(button: HTMLButtonElement): Promise<void> {
+	// Runs the inline email/password re-auth from an error/interrupt screen. On
+	// success the caller-supplied onSuccess runs: the error screen reloads the
+	// list, the auth-interrupted screen advances to the resume prompt. Token
+	// reads are live closures, so no client reconstruction is needed. On a
+	// closed window or an unavailable login API, a Notice makes clear nothing
+	// changed.
+	private async handleReauth(
+		button: HTMLButtonElement,
+		onSuccess: () => Promise<void>,
+	): Promise<void> {
 		const onReauth = this.noteWriterOptions.onReauth;
 		if (!onReauth) {
 			return;
@@ -783,7 +810,7 @@ export class ImportModal extends Modal {
 		try {
 			const ok = await onReauth();
 			if (ok) {
-				await this.refresh();
+				await onSuccess();
 			} else {
 				new Notice('Plaud sign-in closed — no token captured.');
 			}
@@ -795,13 +822,14 @@ export class ImportModal extends Modal {
 		}
 	}
 
-	// Stores a clipboard token from the SSO expander and reloads the list on
-	// success. The failure Notices for an invalid/missing token live in the
-	// host's pasteToken callback, so a false result is already explained. A
-	// thrown error (a saveSettings or refresh failure) is routed through
-	// renderError like the inline re-auth and retry paths, since the click
-	// handler fires this with `void` and would otherwise drop the rejection.
-	private async handleSsoPaste(): Promise<void> {
+	// Stores a clipboard token from the SSO expander and runs onSuccess on
+	// success (the error screen reloads the list; the auth-interrupted screen
+	// advances to the resume prompt). The failure Notices for an invalid/missing
+	// token live in the host's pasteToken callback, so a false result is already
+	// explained. A thrown error (a saveSettings or refresh failure) is routed
+	// through renderError like the inline re-auth and retry paths, since the
+	// click handler fires this with `void` and would otherwise drop the rejection.
+	private async handleSsoPaste(onSuccess: () => Promise<void>): Promise<void> {
 		const sso = this.noteWriterOptions.onReauthSso;
 		if (!sso) {
 			return;
@@ -809,7 +837,7 @@ export class ImportModal extends Modal {
 		try {
 			const ok = await sso.pasteToken();
 			if (ok) {
-				await this.refresh();
+				await onSuccess();
 			}
 		} catch (err) {
 			console.error('Plaud importer: SSO token paste failed', err);
@@ -1523,36 +1551,6 @@ export class ImportModal extends Modal {
 		this.stickyDuplicateDecision = null;
 		this.currentBatchSize = selected.length;
 
-		// Construct the writer lazily. A NoteWriterError here means the
-		// user's config is bad ("..", invalid onDuplicate) — surface via
-		// the error state with the config-error classification so the UI
-		// points at Settings rather than saying "unknown error please
-		// report this." Anything else is a real code bug; re-throw so the
-		// outer click handler's .catch picks it up honestly.
-		let writer: NoteWriter;
-		try {
-			writer = new NoteWriter(this.app.vault, {
-				...this.noteWriterOptions,
-				onDuplicate: duplicatePolicy,
-				promptOnDuplicate:
-					duplicatePolicy === 'prompt' ? this.handleDuplicatePrompt : undefined,
-				// Cross-folder dedup: let the writer find a prior import of the
-				// same recording that lives in a different subfolder (for
-				// example after the subfolder template changed) so it never
-				// writes a second copy. Backed by the vault index, read live so
-				// it reflects notes written earlier in this same run.
-				existingPathForPlaudId: (id) =>
-					this.importedIndex.get(id as PlaudRecordingId)?.path ?? null,
-			});
-		} catch (err) {
-			if (err instanceof NoteWriterError) {
-				console.error('Plaud importer: NoteWriter construction failed', err);
-				this.renderError(classifyError(err));
-				return;
-			}
-			throw err;
-		}
-
 		// Disable the Import button so rapid double-clicks don't queue a
 		// second run against the same selection.
 		if (this.importButton) {
@@ -1560,14 +1558,41 @@ export class ImportModal extends Modal {
 			this.importButton.textContent = `Importing 0 of ${selected.length}…`;
 		}
 
-		// Delegate the per-recording loop to the headless runner. The modal
-		// keeps every UI concern: the observer updates the button text and
-		// refreshes row badges, and the outcome drives the summary or the
-		// partial-cancel Notice. fetchArtifacts reuses the warm artifact
-		// cache so a prior "review artifacts" preflight is not re-fetched;
-		// applyFold persists the post-write transcript fold.
+		// Delegate the per-recording loop AND the terminal UI to the shared
+		// batch runner. isInitial=true keeps the issue #12 cancelled-path button
+		// reset (the modal stays on the selection screen here) and starts the
+		// run with an empty prior-results accumulator.
+		await this.runImportBatch(selected, selection, duplicatePolicy, [], true);
+	}
+
+	/**
+	 * Run the import loop over `recordings` and render the terminal UI. Shared
+	 * by the initial Import click (`isInitial` true: a live Import button, the
+	 * selection screen stays put on a cancel) and the post-re-auth resume
+	 * (`isInitial` false: a state screen, no button). `priorResults` carries the
+	 * results of earlier sub-batches so the final summary and the partial Notice
+	 * count the whole run, not just this slice. On a mid-batch token rejection
+	 * the runner returns stop:'auth-failed'; the modal then surfaces A1's inline
+	 * re-auth and offers to resume the unprocessed tail.
+	 */
+	private async runImportBatch(
+		recordings: Recording[],
+		selection: ArtifactSelection,
+		duplicatePolicy: DuplicatePolicy,
+		priorResults: ImportResult[],
+		isInitial: boolean,
+	): Promise<void> {
+		const writer = this.buildImportWriter(duplicatePolicy);
+		if (!writer) {
+			return;
+		}
+
+		// The observer keeps every UI concern: it updates the (initial-screen)
+		// button text and refreshes row badges. fetchArtifacts reuses the warm
+		// artifact cache so a prior "review artifacts" preflight is not
+		// re-fetched; applyFold persists the post-write transcript fold.
 		const outcome = await runImport({
-			recordings: selected,
+			recordings,
 			selection,
 			writer,
 			attachments: this.attachments,
@@ -1587,26 +1612,208 @@ export class ImportModal extends Modal {
 			},
 		});
 
-		if (outcome.stop !== 'completed') {
-			// 'aborted' (modal closed mid-run) and 'cancelled' (per-file
-			// duplicate prompt dismissed) both surface the same partial
-			// Notice the inline loop used to fire at each stop site.
-			new Notice(
-				`${formatImportNotice(tallyImportResults(outcome.results))} (cancelled at ${outcome.processed}/${selected.length})`,
-			);
-			// For 'cancelled' the modal stays open with a live button, but the
-			// loop left it disabled and labeled "Importing X of Y…". Restore the
-			// initial label and re-enable it (respecting the empty-selection
-			// guard). 'aborted' is the modal closing, so its button DOM is gone
-			// and needs no reset. (issue #12)
-			if (outcome.stop === 'cancelled' && this.importButton) {
-				this.importButton.textContent = IMPORT_BUTTON_LABEL;
-				this.updateImportButtonState();
-			}
+		// Accumulate across resumes so the summary and the partial Notice
+		// reflect the whole run. Every processed recording yields exactly one
+		// result (the auth-failed recording yields none), so combined.length is
+		// the running processed count and combined.length + tail.length equals
+		// the original total.
+		const combined = [...priorResults, ...outcome.results];
+
+		if (outcome.stop === 'auth-failed') {
+			// The token was rejected mid-batch. recordings[processed] onward
+			// were never attempted; carry that tail so a successful re-auth can
+			// resume exactly where the run stopped.
+			const tail = recordings.slice(outcome.processed);
+			this.renderAuthInterrupted(tail, selection, duplicatePolicy, combined);
 			return;
 		}
 
-		this.renderSummary(tallyImportResults(outcome.results));
+		if (outcome.stop !== 'completed') {
+			// 'aborted' (modal closed mid-run) and 'cancelled' (per-file
+			// duplicate prompt dismissed) both surface the same partial Notice.
+			const total = priorResults.length + recordings.length;
+			new Notice(
+				`${formatImportNotice(tallyImportResults(combined))} (cancelled at ${combined.length}/${total})`,
+			);
+			if (outcome.stop === 'cancelled') {
+				// issue #12: on the initial selection screen the loop left the
+				// Import button disabled and labeled "Importing X of Y…"; restore
+				// the initial label and re-enable it.
+				if (isInitial && this.importButton) {
+					this.importButton.textContent = IMPORT_BUTTON_LABEL;
+					this.updateImportButtonState();
+				} else if (!isInitial) {
+					// A resumed batch has no selection screen to fall back to. The
+					// user stopped at a duplicate prompt, so re-offer the still
+					// unprocessed tail (resume or go back to the list) rather than
+					// rendering a success summary, which would auto-close the modal
+					// and fire a second Notice. recordings[processed] (the one they
+					// cancelled on) is included so resuming re-attempts it.
+					const remaining = recordings.slice(outcome.processed);
+					this.renderResumeReady(
+						remaining,
+						selection,
+						duplicatePolicy,
+						combined,
+						`Import stopped. ${remaining.length} recordings remain.`,
+					);
+				}
+			}
+			// 'aborted' is the modal closing; nothing to render in either case.
+			return;
+		}
+
+		this.renderSummary(tallyImportResults(combined));
+	}
+
+	/**
+	 * Build the per-run NoteWriter. A NoteWriterError means the user's config is
+	 * bad ("..", invalid onDuplicate): surface it via the error screen pointing
+	 * at Settings (not "unknown error please report this") and return null so
+	 * the caller stops. Anything else is a real code bug; re-throw so the outer
+	 * click handler's .catch reports it honestly. Shared by the initial import
+	 * and a resumed batch so both wire the same duplicate policy, prompt
+	 * callback, and cross-folder dedup lookup.
+	 */
+	private buildImportWriter(duplicatePolicy: DuplicatePolicy): NoteWriter | null {
+		try {
+			return new NoteWriter(this.app.vault, {
+				...this.noteWriterOptions,
+				onDuplicate: duplicatePolicy,
+				promptOnDuplicate:
+					duplicatePolicy === 'prompt' ? this.handleDuplicatePrompt : undefined,
+				// Cross-folder dedup: let the writer find a prior import of the
+				// same recording that lives in a different subfolder (for example
+				// after the subfolder template changed) so it never writes a
+				// second copy. Backed by the vault index, read live so it reflects
+				// notes written earlier in this same run.
+				existingPathForPlaudId: (id) =>
+					this.importedIndex.get(id as PlaudRecordingId)?.path ?? null,
+			});
+		} catch (err) {
+			if (err instanceof NoteWriterError) {
+				console.error('Plaud importer: NoteWriter construction failed', err);
+				this.renderError(classifyError(err));
+				return null;
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * The token was rejected mid-batch (an expired/revoked ~24h session). Show
+	 * how much completed and surface A1's inline re-auth (the Sign-in CTA and the
+	 * SSO expander). A successful sign-in does NOT auto-resume; it advances to
+	 * renderResumeReady so the user explicitly chooses to resume the unprocessed
+	 * tail or go back to the list.
+	 */
+	private renderAuthInterrupted(
+		tail: Recording[],
+		selection: ArtifactSelection,
+		duplicatePolicy: DuplicatePolicy,
+		priorResults: ImportResult[],
+	): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		const box = contentEl.createDiv({ cls: 'plaud-importer-state' });
+		const processed = priorResults.length;
+		const total = processed + tail.length;
+		box.createEl('p', {
+			text: `Your Plaud session expired during the import. ${processed} of ${total} recordings were processed before it stopped. Sign in to resume the remaining ${tail.length}.`,
+			cls: 'plaud-importer-error-message',
+		});
+		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });
+
+		const onSuccess = (): Promise<void> => {
+			this.renderResumeReady(
+				tail,
+				selection,
+				duplicatePolicy,
+				priorResults,
+				`Signed back in. ${tail.length} recordings remain.`,
+			);
+			return Promise.resolve();
+		};
+		const reauthAvailable = this.appendSignInCta(
+			buttonRow,
+			'token-rejected',
+			onSuccess,
+		);
+
+		const closeButton = buttonRow.createEl('button', { text: 'Close' });
+		closeButton.addEventListener('click', () => this.close());
+
+		const sso = this.noteWriterOptions.onReauthSso;
+		if (reauthAvailable && sso) {
+			this.renderReauthSsoExpander(contentEl, sso, onSuccess);
+		}
+	}
+
+	/**
+	 * After a successful re-auth on the auth-interrupted screen, offer the
+	 * explicit choice: resume the unprocessed tail, or go back to the list
+	 * (re-run). Explicit rather than auto-resume so the user confirms before
+	 * another network batch starts.
+	 */
+	private renderResumeReady(
+		tail: Recording[],
+		selection: ArtifactSelection,
+		duplicatePolicy: DuplicatePolicy,
+		priorResults: ImportResult[],
+		headline: string,
+	): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		const box = contentEl.createDiv({ cls: 'plaud-importer-state' });
+		box.createEl('p', {
+			text: `${headline} Resume the import, or go back to the list.`,
+			cls: 'plaud-importer-loading',
+		});
+		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });
+
+		const resumeButton = buttonRow.createEl('button', {
+			text: `Resume remaining (${tail.length})`,
+			cls: 'mod-cta',
+		});
+		resumeButton.addEventListener('click', () => {
+			resumeButton.disabled = true;
+			// The resumed batch has no Import button to carry the progress
+			// counter, so show a lightweight progress state in its place.
+			this.renderImporting(tail.length);
+			this.runImportBatch(
+				tail,
+				selection,
+				duplicatePolicy,
+				priorResults,
+				false,
+			).catch((err) => {
+				console.error('Plaud importer: resume import failed', err);
+				this.renderError(classifyError(err));
+			});
+		});
+
+		const backButton = buttonRow.createEl('button', { text: 'Back to list' });
+		backButton.addEventListener('click', () => {
+			this.refresh().catch((err) => {
+				console.error('Plaud importer: reload after re-auth failed', err);
+				this.renderError(classifyError(err));
+			});
+		});
+	}
+
+	/**
+	 * Minimal work-in-progress state shown while a resumed batch runs. The
+	 * resume path has no Import button to carry the "Importing i of n" counter,
+	 * so this stands in until the summary replaces it.
+	 */
+	private renderImporting(count: number): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		const box = contentEl.createDiv({ cls: 'plaud-importer-state' });
+		box.createEl('p', {
+			text: `Importing ${count} remaining recordings…`,
+			cls: 'plaud-importer-loading',
+		});
 	}
 
 	private async resolveDuplicatePolicyForImport(

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -1547,9 +1547,9 @@ export class ImportModal extends Modal {
 
 		// Reset sticky state so choices from a prior run do not leak into
 		// this batch. Only 'prompt' mode consumes this field, but
-		// resetting unconditionally keeps the invariant simple.
+		// resetting unconditionally keeps the invariant simple. currentBatchSize
+		// is set inside runImportBatch so it tracks the slice actually being run.
 		this.stickyDuplicateDecision = null;
-		this.currentBatchSize = selected.length;
 
 		// Disable the Import button so rapid double-clicks don't queue a
 		// second run against the same selection.
@@ -1582,6 +1582,11 @@ export class ImportModal extends Modal {
 		priorResults: ImportResult[],
 		isInitial: boolean,
 	): Promise<void> {
+		// Track the size of THIS batch (the full selection initially, the tail on
+		// a resume). The duplicate prompt gates its batch-level "all remaining"
+		// options on currentBatchSize > 1, so a resumed run must refresh it or a
+		// single-item tail would wrongly offer "overwrite/skip all remaining".
+		this.currentBatchSize = recordings.length;
 		const writer = this.buildImportWriter(duplicatePolicy);
 		if (!writer) {
 			return;
@@ -1719,7 +1724,7 @@ export class ImportModal extends Modal {
 		const processed = priorResults.length;
 		const total = processed + tail.length;
 		box.createEl('p', {
-			text: `Your Plaud session expired during the import. ${processed} of ${total} recordings were processed before it stopped. Sign in to resume the remaining ${tail.length}.`,
+			text: `Plaud rejected your sign-in during the import. ${processed} of ${total} recordings were processed before it stopped. Sign in to resume the remaining ${tail.length}.`,
 			cls: 'plaud-importer-error-message',
 		});
 		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -29,6 +29,7 @@ import {
 } from './note-writer';
 import {
 	classifyError,
+	categoryAllowsReauth,
 	isPlaudUnprocessedError,
 	type ImportResult,
 	type ArtifactSelection,
@@ -105,11 +106,17 @@ export interface ImportRunDeps {
  *   - 'completed': every selected recording was processed.
  *   - 'aborted': `observer.shouldAbort()` was truthy (modal closed mid-run).
  *   - 'cancelled': the user cancelled a per-file duplicate prompt.
+ *   - 'auth-failed': the token was rejected mid-batch (an expired or revoked
+ *     ~24h session). The loop stops on the FIRST auth failure instead of
+ *     failing every remaining recording with the same error; the modal offers
+ *     inline re-auth + resume on this stop.
  * 'aborted' and 'cancelled' both produce the modal's "(cancelled at x/y)"
  * partial Notice; they are distinguished so headless callers can tell a
- * user-driven stop from an interrupted one.
+ * user-driven stop from an interrupted one. 'auth-failed' is a batch-terminal
+ * condition a headless caller (auto-sync, Phase 2) can use to drive an
+ * auth-pause state machine.
  */
-export type ImportRunStop = 'completed' | 'aborted' | 'cancelled';
+export type ImportRunStop = 'completed' | 'aborted' | 'cancelled' | 'auth-failed';
 
 export interface ImportRunOutcome {
 	readonly results: ImportResult[];
@@ -306,6 +313,21 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 				err,
 			);
 			const classification = classifyError(err);
+
+			// A rejected token mid-batch (an expired or revoked ~24h session) is
+			// a batch-level terminal condition, not a per-recording failure:
+			// continuing the loop would fail every remaining recording with the
+			// same auth error and still report stop:'completed'. Stop on the
+			// FIRST one so the modal can offer inline re-auth + resume.
+			// recordings[i] was not written, so processed = i and the unprocessed
+			// tail (this recording included) is recordings.slice(i). The pre-auth
+			// results stay in `results` for the caller's partial summary.
+			// categoryAllowsReauth is the same predicate the modal's A1 Sign-in
+			// gate uses, kept single-sourced so the runner-abort and the
+			// modal-reauth conditions cannot drift apart.
+			if (categoryAllowsReauth(classification.category)) {
+				return { results, stop: 'auth-failed', processed: i };
+			}
 
 			// Plaud confirmed (in-band) it has no transcript/summary for this
 			// recording yet. Rather than a bare failure, write a placeholder

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -106,10 +106,11 @@ export interface ImportRunDeps {
  *   - 'completed': every selected recording was processed.
  *   - 'aborted': `observer.shouldAbort()` was truthy (modal closed mid-run).
  *   - 'cancelled': the user cancelled a per-file duplicate prompt.
- *   - 'auth-failed': the token was rejected mid-batch (an expired or revoked
- *     ~24h session). The loop stops on the FIRST auth failure instead of
- *     failing every remaining recording with the same error; the modal offers
- *     inline re-auth + resume on this stop.
+ *   - 'auth-failed': a re-authable auth failure happened mid-batch, i.e. one
+ *     where `categoryAllowsReauth` is true (a rejected/expired ~24h token, or
+ *     a token that went missing). The loop stops on the FIRST such failure
+ *     instead of failing every remaining recording with the same error; the
+ *     modal offers inline re-auth + resume on this stop.
  * 'aborted' and 'cancelled' both produce the modal's "(cancelled at x/y)"
  * partial Notice; they are distinguished so headless callers can tell a
  * user-driven stop from an interrupted one. 'auth-failed' is a batch-terminal


### PR DESCRIPTION
## What and why

Closes #14. Fast-follow on A1 (#13, 0.15.0).

Before this change, if the Plaud token expired **mid-batch** during a multi-select import, `runImport` classified the `PlaudAuthError` (`token_rejected`) as a plain per-recording `kind:'failed'` and **continued the loop**, so every remaining recording failed with the same auth error and the run still reported `stop:'completed'`. Now the run stops at the first auth failure and the modal offers inline re-auth plus resume.

## Changes

**Runner (`import-runner.ts`)** — stays obsidian-free.
- New `ImportRunStop` value `'auth-failed'`.
- In the catch, after `classifyError`, an auth dead-end (`categoryAllowsReauth(classification.category)`) returns `{ results, stop: 'auth-failed', processed: i }` before the placeholder/`failed` path. `recordings[i]` was not written, so `processed = i` and the unprocessed tail is `recordings.slice(i)`. Pre-expiry results are retained.

**Modal (`import-modal.ts`)**
- Extracted the writer build + loop + terminal UI into `runImportBatch(recordings, selection, duplicatePolicy, priorResults, isInitial)` and `buildImportWriter`. The initial click calls it with the full selection; a re-auth resume calls it with the tail and the accumulated `priorResults`.
- `'auth-failed'` renders `renderAuthInterrupted` (A1 Sign-in CTA + SSO expander). A successful sign-in advances to `renderResumeReady` with an explicit **Resume remaining (N)** button (or Back to list), then `renderImporting` while the tail runs.
- The A1 helpers (`handleReauth`, `handleSsoPaste`, `renderReauthSsoExpander`) now take an `onSuccess` callback so the same controls serve both "reload list" (error screen) and "advance to resume" (auth-interrupted screen). The A1 error-screen path is behaviorally unchanged.
- The #12 cancelled-path button reset is preserved on the initial screen. A cancel during a resumed batch re-offers the tail instead of auto-closing a summary.

**Tests (`__tests__/import-runner.test.ts`, +4)**
- Stops on the first `token_rejected`; does not push failures for later recordings; outcome carries `auth-failed` + correct `processed`; pre-expiry results retained.
- `processed: 0` when the first recording is rejected.
- A `not_configured` mid-batch also aborts (documents the `categoryAllowsReauth` breadth).
- A non-auth failure still continues the batch (regression guard that the abort is auth-specific).

## Design decisions (confirmed with Charles)
- **Abort trigger:** `categoryAllowsReauth` (token-rejected OR not-configured), single-sourced with the modal's A1 re-auth gate, rather than a second hardcoded check.
- **Resume UX:** explicit **Resume remaining** button (not auto-resume). No setting for auto-vs-explicit (one click in a rare event; speculative config).

## Adversarial self-review (pre-PR)
Ran a 3-lens review (accounting, state-machine, parity/scorecard) with per-finding verification. It caught and I fixed:
- **Blocker:** the new tests built heterogeneous `new Map([...])` literals; tsc inferred the value type from the first entry and rejected the thrower entries, so `npm run build` was red even though `npm test` (jest, transpile-only) passed. Annotated each `new Map<PlaudRecordingId, TranscriptAndSummary | (() => never)>([...])`.
- **2 minors:** a cancel during a resumed batch routed into `renderSummary`, which auto-closed the modal (treating a cancel as success) and fired a second Notice. Rerouted to re-offer the tail (`renderResumeReady`), so a resumed cancel fires one Notice and does not auto-close.

## Gates
`npm run lint` pass, `npm run build` exit 0, `npm test` 670 passing (was 666). CI runs on this PR.

## Hands-on smoke test (needs the running app)
Not yet validated by hand. Suggested checks in the test vault:
1. Multi-select import, force a token expiry partway (or revoke the token mid-run): the run stops at the first failure, shows "N of M processed", and a **Sign in** button.
2. Sign in (email): the **Resume remaining (K)** screen appears; clicking it imports only the remaining recordings; the final summary counts the whole run.
3. **Back to list** after sign-in reloads the recording list.
4. Regression: a normal completed import still shows the summary; a single non-auth failure still shows partial success and continues; the #12 cancelled button reset still works on the initial screen.
