### PR TITLE
Phase 1: optional audio download as an import artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Optionally download the original recording audio into your vault. A new **Audio** artifact appears in the import picker and as an **Audio** default in settings, both off by default. When you turn it on, each imported recording's audio file is saved next to the note and embedded as a playable clip under an **Audio** heading, so you can listen inline. Audio is large, roughly 15 MB per hour of recording, and it can grow your vault by gigabytes and slow Obsidian Sync and backups, so it stays off unless you opt in. Missing or expired audio never fails an import; the note and transcript still land.
+
 ## [0.16.0] - 2026-06-30
 
 ### Fixed

--- a/__tests__/import-runner.test.ts
+++ b/__tests__/import-runner.test.ts
@@ -120,6 +120,7 @@ const SELECTION: ArtifactSelection = {
 	includeAttachments: true,
 	includeMindmap: true,
 	includeCard: true,
+	includeAudio: false,
 };
 
 const OPTIONS: ImportModalOptions = {
@@ -130,20 +131,26 @@ const OPTIONS: ImportModalOptions = {
 function makeAttachmentStub(): {
 	pipeline: AttachmentPipeline;
 	importCalls: Array<{ notePath: string; replaceExisting: boolean; recordingId: string }>;
+	audioCalls: Array<{ notePath: string; audioUrl: string }>;
 } {
 	const importCalls: Array<{
 		notePath: string;
 		replaceExisting: boolean;
 		recordingId: string;
 	}> = [];
+	const audioCalls: Array<{ notePath: string; audioUrl: string }> = [];
 	const pipeline: AttachmentPipeline = {
 		extractAttachmentAssetsFromSummaryMarkdown: () => [],
 		mergeAttachmentAssets: (base, extra) => [...base, ...extra],
 		importAttachmentsForNote: async (notePath, _attachments, _selection, replaceExisting, recordingId) => {
 			importCalls.push({ notePath, replaceExisting, recordingId });
 		},
+		importAudioForNote: async (notePath, audioUrl) => {
+			audioCalls.push({ notePath, audioUrl });
+			return 1234;
+		},
 	};
-	return { pipeline, importCalls };
+	return { pipeline, importCalls, audioCalls };
 }
 
 function makeFetch(
@@ -782,5 +789,109 @@ describe('runImport', () => {
 		]);
 		// All three were fetched: the batch did not abort at recB.
 		expect(calls).toEqual([recA.id, recB.id, recC.id]);
+	});
+});
+
+describe('runImport audio artifact', () => {
+	const withAudio: ArtifactSelection = { ...SELECTION, includeAudio: true };
+	const AUDIO_URL = 'https://s3.example/audio.ogg?X-Amz-Signature=abc';
+
+	it('fetches the temp-url and imports audio when includeAudio is on', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { pipeline, audioCalls } = makeAttachmentStub();
+		const audioFetches: PlaudRecordingId[] = [];
+
+		const outcome = await runImport({
+			recordings: [recording],
+			selection: withAudio,
+			writer: makeWriter(vault),
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			fetchAudioUrl: async (id) => {
+				audioFetches.push(id);
+				return AUDIO_URL;
+			},
+		});
+
+		expect(outcome.stop).toBe('completed');
+		expect(audioFetches).toEqual([recording.id]);
+		expect(audioCalls).toHaveLength(1);
+		expect(audioCalls[0].audioUrl).toBe(AUDIO_URL);
+	});
+
+	it('does not fetch or import audio when includeAudio is off', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { pipeline, audioCalls } = makeAttachmentStub();
+		let audioFetchCount = 0;
+
+		await runImport({
+			recordings: [recording],
+			selection: SELECTION, // includeAudio: false
+			writer: makeWriter(vault),
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			fetchAudioUrl: async () => {
+				audioFetchCount += 1;
+				return AUDIO_URL;
+			},
+		});
+
+		expect(audioFetchCount).toBe(0);
+		expect(audioCalls).toEqual([]);
+	});
+
+	it('writes no audio when Plaud exposes no temp-url', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { pipeline, audioCalls } = makeAttachmentStub();
+
+		await runImport({
+			recordings: [recording],
+			selection: withAudio,
+			writer: makeWriter(vault),
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			fetchAudioUrl: async () => null,
+		});
+
+		expect(audioCalls).toEqual([]);
+	});
+
+	it('imports no audio for a note skipped by the duplicate policy', async () => {
+		const vault = makeFakeVault();
+		const recording = makeRecording();
+		const writer = makeWriter(vault, { onDuplicate: 'skip' });
+		const { fetchArtifacts } = makeFetch(
+			new Map([[recording.id, makeArtifacts(recording)]]),
+		);
+		const { pipeline, audioCalls } = makeAttachmentStub();
+		const deps: ImportRunDeps = {
+			recordings: [recording],
+			selection: withAudio,
+			writer,
+			attachments: pipeline,
+			options: OPTIONS,
+			fetchArtifacts,
+			fetchAudioUrl: async () => AUDIO_URL,
+		};
+
+		await runImport(deps); // first run: note created, audio imported
+		expect(audioCalls).toHaveLength(1);
+		await runImport(deps); // second run: note skipped, no new audio
+		expect(audioCalls).toHaveLength(1);
 	});
 });

--- a/__tests__/plaud-client-re.test.ts
+++ b/__tests__/plaud-client-re.test.ts
@@ -3603,17 +3603,16 @@ describe('getTranscriptAndSummary consumer_note template outputs', () => {
 // getAudioTempUrl: GET /file/temp-url/{id}
 // ---------------------------------------------------------------------------
 
+// The real /file/temp-url response carries temp_url at the TOP LEVEL, not
+// inside a { data: {...} } envelope (confirmed from a live capture 2026-07-01).
 function audioTempUrlEnvelope(
 	overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
 	return {
 		status: 0,
-		msg: 'success',
-		data: {
-			temp_url: 'https://s3.amazonaws.com/rec.ogg?X-Amz-Signature=fake',
-			temp_url_opus: '',
-			...overrides,
-		},
+		temp_url: 'https://plaud-bucket.s3.amazonaws.com/audiofiles/rec.ogg?AWSAccessKeyId=x&Signature=y%3D&Expires=1',
+		temp_url_opus: null,
+		...overrides,
 	};
 }
 
@@ -3641,13 +3640,15 @@ describe('getAudioTempUrl request shape', () => {
 		);
 	});
 
-	it('returns the presigned temp_url from the data envelope', async () => {
+	it('returns the top-level presigned temp_url', async () => {
 		const { fetcher } = captureFetcher(ok(audioTempUrlEnvelope()));
 		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
 
 		const url = await client.getAudioTempUrl(ID);
 
-		expect(url).toBe('https://s3.amazonaws.com/rec.ogg?X-Amz-Signature=fake');
+		expect(url).toBe(
+			'https://plaud-bucket.s3.amazonaws.com/audiofiles/rec.ogg?AWSAccessKeyId=x&Signature=y%3D&Expires=1',
+		);
 	});
 
 	it('returns null when temp_url is missing or empty', async () => {
@@ -3659,23 +3660,26 @@ describe('getAudioTempUrl request shape', () => {
 });
 
 describe('parseAudioTempUrl', () => {
-	it('extracts temp_url from a well-formed envelope', () => {
+	it('extracts temp_url from the top level of the response', () => {
 		expect(
-			parseAudioTempUrl(
-				{ data: { temp_url: 'https://s3/audio.ogg' } },
-				'/file/temp-url/x',
-			),
+			parseAudioTempUrl({ status: 0, temp_url: 'https://s3/audio.ogg' }, '/file/temp-url/x'),
+		).toBe('https://s3/audio.ogg');
+	});
+
+	it('falls back to a data-wrapped temp_url defensively', () => {
+		expect(
+			parseAudioTempUrl({ data: { temp_url: 'https://s3/audio.ogg' } }, '/file/temp-url/x'),
 		).toBe('https://s3/audio.ogg');
 	});
 
 	it('returns null for a missing, empty, or non-string temp_url', () => {
-		expect(parseAudioTempUrl({ data: {} }, '/file/temp-url/x')).toBeNull();
-		expect(parseAudioTempUrl({ data: { temp_url: '   ' } }, '/file/temp-url/x')).toBeNull();
-		expect(parseAudioTempUrl({ data: { temp_url: 42 } }, '/file/temp-url/x')).toBeNull();
+		expect(parseAudioTempUrl({ status: 0 }, '/file/temp-url/x')).toBeNull();
+		expect(parseAudioTempUrl({ temp_url: '   ' }, '/file/temp-url/x')).toBeNull();
+		expect(parseAudioTempUrl({ temp_url: 42 }, '/file/temp-url/x')).toBeNull();
 	});
 
-	it('throws PlaudParseError on a structurally invalid envelope', () => {
-		expect(() => parseAudioTempUrl({}, '/file/temp-url/x')).toThrow(PlaudParseError);
+	it('throws PlaudParseError only when the body is not an object', () => {
 		expect(() => parseAudioTempUrl(null, '/file/temp-url/x')).toThrow(PlaudParseError);
+		expect(() => parseAudioTempUrl('nope', '/file/temp-url/x')).toThrow(PlaudParseError);
 	});
 });

--- a/__tests__/plaud-client-re.test.ts
+++ b/__tests__/plaud-client-re.test.ts
@@ -9,6 +9,7 @@ import {
 	findNewerSummaryMarkdown,
 	findOutlineLink,
 	findTransactionPolishLink,
+	parseAudioTempUrl,
 	parseOutlineBody,
 	type PlaudHttpFetcher,
 	type PlaudHttpRequest,
@@ -3595,5 +3596,86 @@ describe('getTranscriptAndSummary consumer_note template outputs', () => {
 		const result = await client.getTranscriptAndSummary(ID);
 
 		expect(result.consumerNotes).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getAudioTempUrl: GET /file/temp-url/{id}
+// ---------------------------------------------------------------------------
+
+function audioTempUrlEnvelope(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		status: 0,
+		msg: 'success',
+		data: {
+			temp_url: 'https://s3.amazonaws.com/rec.ogg?X-Amz-Signature=fake',
+			temp_url_opus: '',
+			...overrides,
+		},
+	};
+}
+
+describe('getAudioTempUrl request shape', () => {
+	it('issues an authenticated GET against /file/temp-url/{id}', async () => {
+		const { fetcher, lastRequest } = captureFetcher(ok(audioTempUrlEnvelope()));
+		const client = new ReverseEngineeredPlaudClient(() => 'my-jwt', fetcher);
+
+		await client.getAudioTempUrl(ID);
+
+		const req = lastRequest();
+		expect(req?.method ?? 'GET').toBe('GET');
+		expect(req?.url).toBe('https://api.plaud.ai/file/temp-url/rec-abc-123');
+		expect(req?.headers.Authorization).toBe('Bearer my-jwt');
+	});
+
+	it('URL-encodes the recording id', async () => {
+		const { fetcher, lastRequest } = captureFetcher(ok(audioTempUrlEnvelope()));
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+
+		await client.getAudioTempUrl('id with/slash' as PlaudRecordingId);
+
+		expect(lastRequest()?.url).toBe(
+			'https://api.plaud.ai/file/temp-url/id%20with%2Fslash',
+		);
+	});
+
+	it('returns the presigned temp_url from the data envelope', async () => {
+		const { fetcher } = captureFetcher(ok(audioTempUrlEnvelope()));
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+
+		const url = await client.getAudioTempUrl(ID);
+
+		expect(url).toBe('https://s3.amazonaws.com/rec.ogg?X-Amz-Signature=fake');
+	});
+
+	it('returns null when temp_url is missing or empty', async () => {
+		const { fetcher } = captureFetcher(ok(audioTempUrlEnvelope({ temp_url: '' })));
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+
+		expect(await client.getAudioTempUrl(ID)).toBeNull();
+	});
+});
+
+describe('parseAudioTempUrl', () => {
+	it('extracts temp_url from a well-formed envelope', () => {
+		expect(
+			parseAudioTempUrl(
+				{ data: { temp_url: 'https://s3/audio.ogg' } },
+				'/file/temp-url/x',
+			),
+		).toBe('https://s3/audio.ogg');
+	});
+
+	it('returns null for a missing, empty, or non-string temp_url', () => {
+		expect(parseAudioTempUrl({ data: {} }, '/file/temp-url/x')).toBeNull();
+		expect(parseAudioTempUrl({ data: { temp_url: '   ' } }, '/file/temp-url/x')).toBeNull();
+		expect(parseAudioTempUrl({ data: { temp_url: 42 } }, '/file/temp-url/x')).toBeNull();
+	});
+
+	it('throws PlaudParseError on a structurally invalid envelope', () => {
+		expect(() => parseAudioTempUrl({}, '/file/temp-url/x')).toThrow(PlaudParseError);
+		expect(() => parseAudioTempUrl(null, '/file/temp-url/x')).toThrow(PlaudParseError);
 	});
 });

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -510,22 +510,30 @@ export class AttachmentImporter {
 
 	/**
 	 * Download one recording's original audio into the note's `-assets` folder
-	 * as `<note-basename>.ogg` and embed a playable transclude under a managed
+	 * as `<idPrefix>-audio.ogg` and embed a playable transclude under a managed
 	 * `## Audio` section. Returns the number of bytes written, or null when the
 	 * download failed or produced no bytes, so the note is left intact and a
 	 * missing or expired audio URL never breaks an import.
+	 *
+	 * The filename uses the short recording-id prefix (same scheme as image
+	 * attachments), NOT the note title. The `-assets` folder is already named
+	 * after the (often long) note title, so repeating the title in the audio
+	 * filename pushed the absolute path over Windows' 260-char limit, and
+	 * Obsidian's audio player then served no data (player stuck at 0:00). A
+	 * short filename keeps the path well under the limit.
 	 *
 	 * Kept separate from importAttachmentsForNote because audio is not a
 	 * file-detail asset: it comes from a dedicated temp-url, embeds as
 	 * `![[...]]` (an inline player) rather than a file link, and is off by
 	 * default. This never clears the assets folder (attachments own the
 	 * overwrite-clear and run first in the import loop); on an overwrite it
-	 * replaces only its own `<basename>.ogg` in place, so re-imports never
-	 * accumulate `<name>-2.ogg` duplicates of the same recording.
+	 * replaces its own `<idPrefix>-audio.ogg` in place, so re-imports never
+	 * accumulate duplicate copies of the same recording.
 	 */
 	async importAudioForNote(
 		notePath: string,
 		audioUrl: string,
+		recordingId: string,
 	): Promise<number | null> {
 		const noteFile = this.app.vault.getFileByPath(notePath);
 		if (!(noteFile instanceof TFile)) {
@@ -539,7 +547,9 @@ export class AttachmentImporter {
 			await this.app.vault.createFolder(folderPath);
 			this.logAttachmentDebug('created attachment folder for audio', { folderPath });
 		}
-		const audioPath = `${folderPath}/${noteFile.basename}.ogg`;
+		const idPrefix = this.getAttachmentIdPrefix(recordingId);
+		const audioBase = idPrefix.length > 0 ? `${idPrefix}-audio` : 'audio';
+		const audioPath = `${folderPath}/${audioBase}.ogg`;
 
 		const headers: Record<string, string> = { Accept: '*/*' };
 		const token = this.resolveAuthToken()?.trim();

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -545,9 +545,17 @@ export class AttachmentImporter {
 		const token = this.resolveAuthToken()?.trim();
 		// The temp-url is a presigned S3 link carrying its own signature;
 		// shouldSendAuthHeader returns false for it so no bearer is attached.
-		if (token && token.length > 0 && this.shouldSendAuthHeader(audioUrl)) {
+		const sendAuth =
+			!!token && token.length > 0 && this.shouldSendAuthHeader(audioUrl);
+		if (sendAuth && token) {
 			headers.Authorization = `Bearer ${token}`;
 		}
+		this.logAttachmentDebug('downloading audio', {
+			notePath,
+			audioPath,
+			url: this.sanitizeUrlForDebug(audioUrl),
+			sendAuth,
+		});
 		let response: RequestUrlResponse;
 		try {
 			response = await requestUrl({
@@ -564,6 +572,13 @@ export class AttachmentImporter {
 			});
 			return null;
 		}
+		const bytes = this.responseToArrayBuffer(response);
+		this.logAttachmentDebug('audio download response', {
+			notePath,
+			status: response.status,
+			contentType: this.getResponseHeader(response, 'content-type') ?? null,
+			byteLength: bytes?.byteLength ?? 0,
+		});
 		if (response.status < 200 || response.status >= 300) {
 			this.logAttachmentDebug('audio download returned non-2xx status', {
 				notePath,
@@ -572,31 +587,43 @@ export class AttachmentImporter {
 			});
 			return null;
 		}
-		const bytes = this.responseToArrayBuffer(response);
 		if (bytes === null || bytes.byteLength === 0) {
 			this.logAttachmentDebug('audio download produced no bytes', { notePath });
 			return null;
 		}
 
-		const existing = this.app.vault.getFileByPath(audioPath);
-		if (existing instanceof TFile) {
-			await this.app.vault.modifyBinary(existing, bytes);
-		} else {
-			await this.app.vault.createBinary(audioPath, bytes);
-		}
+		// Vault writes can throw (path issues, a racing external edit). Keep
+		// audio best-effort: log and return null rather than letting the throw
+		// escape into the runner, which would otherwise surface only in the
+		// DevTools console and never in the exportable debug session.
+		try {
+			const existing = this.app.vault.getFileByPath(audioPath);
+			if (existing instanceof TFile) {
+				await this.app.vault.modifyBinary(existing, bytes);
+			} else {
+				await this.app.vault.createBinary(audioPath, bytes);
+			}
 
-		await this.app.vault.process(noteFile, (content) => {
-			const withoutManaged = this.stripManagedAudioSection(content);
-			const trimmed = withoutManaged.replace(/\s+$/, '');
-			const section = [
-				'## Audio',
-				'',
-				'_Original recording audio downloaded from Plaud at import time._',
-				'',
-				`![[${audioPath}]]`,
-			].join('\n');
-			return this.insertSectionBeforeTranscript(trimmed, section);
-		});
+			await this.app.vault.process(noteFile, (content) => {
+				const withoutManaged = this.stripManagedAudioSection(content);
+				const trimmed = withoutManaged.replace(/\s+$/, '');
+				const section = [
+					'## Audio',
+					'',
+					'_Original recording audio downloaded from Plaud at import time._',
+					'',
+					`![[${audioPath}]]`,
+				].join('\n');
+				return this.insertSectionBeforeTranscript(trimmed, section);
+			});
+		} catch (err) {
+			this.logAttachmentDebug('audio write failed', {
+				notePath,
+				audioPath,
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return null;
+		}
 		this.logAttachmentDebug('audio section appended to note', {
 			notePath,
 			audioPath,

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -508,6 +508,103 @@ export class AttachmentImporter {
 		});
 	}
 
+	/**
+	 * Download one recording's original audio into the note's `-assets` folder
+	 * as `<note-basename>.ogg` and embed a playable transclude under a managed
+	 * `## Audio` section. Returns the number of bytes written, or null when the
+	 * download failed or produced no bytes, so the note is left intact and a
+	 * missing or expired audio URL never breaks an import.
+	 *
+	 * Kept separate from importAttachmentsForNote because audio is not a
+	 * file-detail asset: it comes from a dedicated temp-url, embeds as
+	 * `![[...]]` (an inline player) rather than a file link, and is off by
+	 * default. This never clears the assets folder (attachments own the
+	 * overwrite-clear and run first in the import loop); on an overwrite it
+	 * replaces only its own `<basename>.ogg` in place, so re-imports never
+	 * accumulate `<name>-2.ogg` duplicates of the same recording.
+	 */
+	async importAudioForNote(
+		notePath: string,
+		audioUrl: string,
+	): Promise<number | null> {
+		const noteFile = this.app.vault.getFileByPath(notePath);
+		if (!(noteFile instanceof TFile)) {
+			this.logAttachmentDebug('audio import aborted: note file not found', {
+				notePath,
+			});
+			return null;
+		}
+		const folderPath = notePath.replace(/\.md$/i, '-assets');
+		if (this.app.vault.getFolderByPath(folderPath) === null) {
+			await this.app.vault.createFolder(folderPath);
+			this.logAttachmentDebug('created attachment folder for audio', { folderPath });
+		}
+		const audioPath = `${folderPath}/${noteFile.basename}.ogg`;
+
+		const headers: Record<string, string> = { Accept: '*/*' };
+		const token = this.resolveAuthToken()?.trim();
+		// The temp-url is a presigned S3 link carrying its own signature;
+		// shouldSendAuthHeader returns false for it so no bearer is attached.
+		if (token && token.length > 0 && this.shouldSendAuthHeader(audioUrl)) {
+			headers.Authorization = `Bearer ${token}`;
+		}
+		let response: RequestUrlResponse;
+		try {
+			response = await requestUrl({
+				url: audioUrl,
+				method: 'GET',
+				throw: false,
+				headers,
+			});
+		} catch (err) {
+			this.logAttachmentDebug('audio download threw', {
+				notePath,
+				url: this.sanitizeUrlForDebug(audioUrl),
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return null;
+		}
+		if (response.status < 200 || response.status >= 300) {
+			this.logAttachmentDebug('audio download returned non-2xx status', {
+				notePath,
+				url: this.sanitizeUrlForDebug(audioUrl),
+				status: response.status,
+			});
+			return null;
+		}
+		const bytes = this.responseToArrayBuffer(response);
+		if (bytes === null || bytes.byteLength === 0) {
+			this.logAttachmentDebug('audio download produced no bytes', { notePath });
+			return null;
+		}
+
+		const existing = this.app.vault.getFileByPath(audioPath);
+		if (existing instanceof TFile) {
+			await this.app.vault.modifyBinary(existing, bytes);
+		} else {
+			await this.app.vault.createBinary(audioPath, bytes);
+		}
+
+		await this.app.vault.process(noteFile, (content) => {
+			const withoutManaged = this.stripManagedAudioSection(content);
+			const trimmed = withoutManaged.replace(/\s+$/, '');
+			const section = [
+				'## Audio',
+				'',
+				'_Original recording audio downloaded from Plaud at import time._',
+				'',
+				`![[${audioPath}]]`,
+			].join('\n');
+			return this.insertSectionBeforeTranscript(trimmed, section);
+		});
+		this.logAttachmentDebug('audio section appended to note', {
+			notePath,
+			audioPath,
+			byteLength: bytes.byteLength,
+		});
+		return bytes.byteLength;
+	}
+
 	private async clearAttachmentFolder(folder: TFolder): Promise<void> {
 		const children = [...folder.children];
 		for (const child of children) {
@@ -1087,10 +1184,18 @@ export class AttachmentImporter {
 	}
 
 	private insertManagedAttachmentsSection(content: string, section: string): string {
-		// Anchor on the LAST `Transcript` heading: it is always the real
-		// transcript (the final section). A consumer_note template output that
-		// renders a `### Transcript`/`#### Transcript` heading earlier in the
-		// note must not capture the anchor and split the Template outputs block.
+		return this.insertSectionBeforeTranscript(content, section);
+	}
+
+	/**
+	 * Insert a managed section just before the note's real transcript.
+	 * Anchors on the LAST `Transcript` heading: it is always the real
+	 * transcript (the final section). A consumer_note template output that
+	 * renders a `### Transcript`/`#### Transcript` heading earlier in the
+	 * note must not capture the anchor and split the Template outputs block.
+	 * Shared by the attachments and audio sections.
+	 */
+	private insertSectionBeforeTranscript(content: string, section: string): string {
 		const re = /\n#{1,6} Transcript\s*\n/g;
 		let insertAt = -1;
 		let match: RegExpExecArray | null;
@@ -1103,6 +1208,16 @@ export class AttachmentImporter {
 			return `${before}\n\n${section}\n\n${after}\n`;
 		}
 		return `${content}\n\n${section}\n`;
+	}
+
+	private stripManagedAudioSection(content: string): string {
+		// Precise-shape match (NOT greedy-to-EOF like the attachments strip)
+		// so a re-import replaces only the managed Audio block and never eats
+		// the neighbouring attachments or transcript sections.
+		return content.replace(
+			/\n## Audio\n\n_Original recording audio downloaded from Plaud at import time\._\n\n!\[\[[^\n]*\]\]\n?/,
+			'\n',
+		);
 	}
 }
 

--- a/import-core.ts
+++ b/import-core.ts
@@ -75,6 +75,7 @@ export interface ImportModalOptions extends NoteWriterOptions {
 	readonly defaultIncludeAttachments?: boolean;
 	readonly defaultIncludeMindmap?: boolean;
 	readonly defaultIncludeCard?: boolean;
+	readonly defaultIncludeAudio?: boolean;
 	/**
 	 * Optional token provider used for follow-up attachment fetches that
 	 * may require authenticated Plaud API calls (for example, image paths
@@ -574,6 +575,7 @@ export interface ArtifactSelection {
 	readonly includeAttachments: boolean;
 	readonly includeMindmap: boolean;
 	readonly includeCard: boolean;
+	readonly includeAudio: boolean;
 }
 
 /**

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -113,6 +113,11 @@ interface ArtifactAvailability {
 	readonly attachmentsCount: number;
 	readonly mindmapCount: number;
 	readonly cardCount: number;
+	// Unlike the other artifacts, audio is not discovered from the preflight
+	// bundle: Plaud serves original audio for every recording, and the
+	// temp-url is resolved lazily at import time (and null-handled if absent).
+	// So this equals the selected count rather than a per-bundle probe.
+	readonly audioCount: number;
 }
 
 class ArtifactSelectionModal extends Modal {
@@ -157,6 +162,7 @@ class ArtifactSelectionModal extends Modal {
 			'includeAttachments',
 			this.availability.attachmentsCount,
 		);
+		this.renderOption(contentEl, 'Audio (large)', 'includeAudio', this.availability.audioCount);
 
 		const buttonRow = contentEl.createDiv({ cls: 'plaud-importer-buttons' });
 		const importButton = buttonRow.createEl('button', {
@@ -1031,6 +1037,9 @@ export class ImportModal extends Modal {
 			includeAttachments: this.noteWriterOptions.defaultIncludeAttachments !== false,
 			includeMindmap: this.noteWriterOptions.defaultIncludeMindmap !== false,
 			includeCard: this.noteWriterOptions.defaultIncludeCard !== false,
+			// Opt-in: audio defaults OFF unless the user turned the setting on,
+			// so use === true rather than the "on unless false" idiom above.
+			includeAudio: this.noteWriterOptions.defaultIncludeAudio === true,
 		};
 	}
 
@@ -1055,6 +1064,7 @@ export class ImportModal extends Modal {
 					defaults.includeAttachments && availability.attachmentsCount > 0,
 				includeMindmap: defaults.includeMindmap && availability.mindmapCount > 0,
 				includeCard: defaults.includeCard && availability.cardCount > 0,
+				includeAudio: defaults.includeAudio && availability.audioCount > 0,
 			};
 			const selection = await this.promptArtifactSelection(availability, initialSelection);
 			if (selection === null) {
@@ -1131,6 +1141,10 @@ export class ImportModal extends Modal {
 			attachmentsCount,
 			mindmapCount,
 			cardCount,
+			// Every recording has downloadable audio in Plaud; the temp-url is
+			// resolved lazily at import (and null-handled), so all selected
+			// recordings count as audio-available.
+			audioCount: selected.length,
 		};
 	}
 
@@ -1603,6 +1617,7 @@ export class ImportModal extends Modal {
 			attachments: this.attachments,
 			options: this.noteWriterOptions,
 			fetchArtifacts: (id) => this.ensureArtifactsForRecording(id),
+			fetchAudioUrl: (id) => this.client.getAudioTempUrl(id),
 			applyFold: (filePath) => this.applyNoteFolds(filePath),
 			observer: {
 				onRecordingStart: (index, total) => {

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -57,6 +57,7 @@ export interface AttachmentPipeline {
 		recordingId: string,
 		nestedAssetLinks?: Readonly<Record<string, string>>,
 	): Promise<void>;
+	importAudioForNote(notePath: string, audioUrl: string): Promise<number | null>;
 }
 
 /**
@@ -96,6 +97,12 @@ export interface ImportRunDeps {
 	 * artifacts" preflight is not re-fetched.
 	 */
 	fetchArtifacts(recordingId: PlaudRecordingId): Promise<TranscriptAndSummary>;
+	/**
+	 * Resolves one recording's original-audio download URL, or null when Plaud
+	 * exposes none. Only invoked when `selection.includeAudio` is set, so a
+	 * caller that never imports audio (or a headless auto-sync) may omit it.
+	 */
+	fetchAudioUrl?(recordingId: PlaudRecordingId): Promise<string | null>;
 	/** Optional post-write transcript fold. Omitted by headless callers. */
 	applyFold?(path: string): Promise<void>;
 	readonly observer?: ImportRunObserver;
@@ -281,6 +288,48 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 							? 'note skipped by duplicate policy'
 							: 'no attachments in transcript bundle',
 				});
+			}
+			// Audio download is a separate, opt-in artifact: it is not a
+			// file-detail attachment (dedicated temp-url), embeds as an
+			// inline player, and is off by default. Runs after attachments
+			// so the assets folder already exists, and before the fold so
+			// the managed section is in place when heading lines are saved.
+			if (
+				selection.includeAudio &&
+				writeOutcome.status !== 'skipped' &&
+				deps.fetchAudioUrl !== undefined
+			) {
+				try {
+					const audioUrl = await deps.fetchAudioUrl(recording.id);
+					if (audioUrl !== null) {
+						const audioBytes = await deps.attachments.importAudioForNote(
+							writeOutcome.path,
+							audioUrl,
+						);
+						emitImportDebug(options, 'audio import outcome', {
+							recordingId: recording.id,
+							bytesWritten: audioBytes,
+						});
+					} else {
+						emitImportDebug(options, 'audio import skipped: no temp-url', {
+							recordingId: recording.id,
+						});
+					}
+				} catch (audioErr) {
+					// Audio is best-effort: the note and transcript already
+					// landed, so a download/write failure must not fail the
+					// recording. But a mid-batch auth expiry is batch-terminal
+					// (every later recording fails the same way), so rethrow
+					// those to the outer handler that stops the batch and
+					// offers inline re-auth.
+					if (categoryAllowsReauth(classifyError(audioErr).category)) {
+						throw audioErr;
+					}
+					console.error(
+						`Plaud importer: audio import failed for recording ${recording.id} "${recording.title}"`,
+						audioErr,
+					);
+				}
 			}
 			// Apply transcript folding AFTER all post-write mutations
 			// (including attachment section insertion) so the saved

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -325,10 +325,16 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 					if (categoryAllowsReauth(classifyError(audioErr).category)) {
 						throw audioErr;
 					}
-					console.error(
-						`Plaud importer: audio import failed for recording ${recording.id} "${recording.title}"`,
-						audioErr,
-					);
+					// Log into the debug session (not just the DevTools console)
+					// so an exported session shows why audio was skipped.
+					emitImportDebug(options, 'audio import failed', {
+						recordingId: recording.id,
+						recordingTitle: recording.title,
+						error:
+							audioErr instanceof Error
+								? audioErr.message
+								: String(audioErr),
+					});
 				}
 			}
 			// Apply transcript folding AFTER all post-write mutations

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -57,7 +57,11 @@ export interface AttachmentPipeline {
 		recordingId: string,
 		nestedAssetLinks?: Readonly<Record<string, string>>,
 	): Promise<void>;
-	importAudioForNote(notePath: string, audioUrl: string): Promise<number | null>;
+	importAudioForNote(
+		notePath: string,
+		audioUrl: string,
+		recordingId: string,
+	): Promise<number | null>;
 }
 
 /**
@@ -305,6 +309,7 @@ export async function runImport(deps: ImportRunDeps): Promise<ImportRunOutcome> 
 						const audioBytes = await deps.attachments.importAudioForNote(
 							writeOutcome.path,
 							audioUrl,
+							recording.id,
 						);
 						emitImportDebug(options, 'audio import outcome', {
 							recordingId: recording.id,

--- a/main.ts
+++ b/main.ts
@@ -174,6 +174,11 @@ interface PlaudImporterSettings {
 	defaultIncludeAttachments: boolean;
 	defaultIncludeMindmap: boolean;
 	defaultIncludeCard: boolean;
+	// Download the original recording audio (Opus/Ogg) as a note attachment.
+	// Off by default and the only default-false artifact: audio is large
+	// (~15 MB per recording-hour) and grows the vault fast, so it is strictly
+	// opt-in per import and per default.
+	defaultIncludeAudio: boolean;
 	foldTranscript: boolean;
 	transcriptHeaderLevel: 1 | 2 | 3 | 4 | 5 | 6;
 	tagMode: TagMode;
@@ -206,6 +211,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	defaultIncludeAttachments: true,
 	defaultIncludeMindmap: true,
 	defaultIncludeCard: true,
+	defaultIncludeAudio: false,
 	foldTranscript: true,
 	transcriptHeaderLevel: 4,
 	// 'plaud' keeps human-set Plaud tags but drops the AI keyword guesses
@@ -473,6 +479,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			defaultIncludeAttachments: this.settings.defaultIncludeAttachments,
 			defaultIncludeMindmap: this.settings.defaultIncludeMindmap,
 			defaultIncludeCard: this.settings.defaultIncludeCard,
+			defaultIncludeAudio: this.settings.defaultIncludeAudio,
 			tagMode: this.settings.tagMode,
 			customTags: this.settings.customTags,
 			aiKeywordsAsProperty: this.settings.aiKeywordsAsProperty,
@@ -877,6 +884,12 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 			"Card",
 			"Checked by default in import actions when a card artifact is available.",
 			"defaultIncludeCard",
+		);
+		this.addToggleRow(
+			containerEl,
+			"Audio",
+			"Off by default. Downloads the original recording audio (about 15 MB per hour) for every recording you import, which can grow your vault by gigabytes and slow Obsidian Sync and backups. Leave off unless you want the audio in your vault.",
+			"defaultIncludeAudio",
 		);
 
 		new Setting(containerEl).setName("Tags").setHeading();
@@ -1427,6 +1440,11 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 						name: "Card",
 						desc: "Checked by default in import actions when a card artifact is available.",
 						control: { type: "toggle", key: "defaultIncludeCard" },
+					},
+					{
+						name: "Audio",
+						desc: "Off by default. Downloads the original recording audio (about 15 MB per hour) for every recording you import, which can grow your vault by gigabytes and slow Obsidian Sync and backups. Leave off unless you want the audio in your vault.",
+						control: { type: "toggle", key: "defaultIncludeAudio" },
 					},
 				],
 			},

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -1349,8 +1349,18 @@ export interface FileDetailBundle {
  * extraction is unit-testable without the fetch plumbing.
  */
 export function parseAudioTempUrl(raw: unknown, endpoint: string): string | null {
-	const data = requireDataEnvelope(raw, endpoint);
-	const tempUrl = data.temp_url;
+	if (!isRecord(raw)) {
+		throw new PlaudParseError(
+			`Response body for ${endpoint} is not an object`,
+			endpoint,
+		);
+	}
+	// Unlike /file/detail this endpoint returns temp_url at the TOP LEVEL of
+	// the response ({ status, temp_url, temp_url_opus }), NOT inside the usual
+	// { data: {...} } envelope. Read the top level; fall back to a data-wrapped
+	// value defensively in case Plaud ever normalizes the shape.
+	const dataRecord = isRecord(raw.data) ? raw.data : undefined;
+	const tempUrl = raw.temp_url ?? dataRecord?.temp_url;
 	if (typeof tempUrl !== 'string' || tempUrl.trim().length === 0) {
 		return null;
 	}

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -375,6 +375,23 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 	}
 
 	/**
+	 * Resolve a recording's original-audio download URL via
+	 * `GET /file/temp-url/{id}`. The response envelope carries `temp_url`
+	 * (a presigned S3 link to the Opus/Ogg audio) and a mostly-empty legacy
+	 * `temp_url_opus`. Returns null (not an error) when the recording has
+	 * no usable `temp_url`, so a missing URL never fails an import. The
+	 * metadata call itself is authenticated (bearer); the presigned URL it
+	 * returns must be downloaded WITHOUT the bearer (it carries its own
+	 * signature), which AttachmentImporter enforces via shouldSendAuthHeader.
+	 */
+	async getAudioTempUrl(id: PlaudRecordingId): Promise<string | null> {
+		const endpoint = `/file/temp-url/${encodeURIComponent(id)}`;
+		const url = `${this.baseUrl}${endpoint}`;
+		const raw = await this.fetchJson(url, endpoint);
+		return parseAudioTempUrl(raw, endpoint);
+	}
+
+	/**
 	 * Fetch the raw transcript + summary bundle via the legacy POST
 	 * /ai/transsumm/{id} endpoint. This is the original path the plugin
 	 * has always used. It returns the RAW transcript — speaker renames
@@ -1324,6 +1341,22 @@ export interface FileDetailBundle {
  * the body must be an object carrying an object `data` field; anything
  * else is structurally corrupt and surfaces as a PlaudParseError.
  */
+/**
+ * Extract the original-audio download URL from a `/file/temp-url/{id}`
+ * response. The envelope's `data.temp_url` is the presigned S3 link; a
+ * missing, non-string, or empty value means no audio URL is available and
+ * returns null (not an error). Exported as a pure function so the URL
+ * extraction is unit-testable without the fetch plumbing.
+ */
+export function parseAudioTempUrl(raw: unknown, endpoint: string): string | null {
+	const data = requireDataEnvelope(raw, endpoint);
+	const tempUrl = data.temp_url;
+	if (typeof tempUrl !== 'string' || tempUrl.trim().length === 0) {
+		return null;
+	}
+	return tempUrl;
+}
+
 function requireDataEnvelope(
 	raw: unknown,
 	endpoint: string,

--- a/plaud-client.ts
+++ b/plaud-client.ts
@@ -129,6 +129,14 @@ export interface AttachmentAsset {
 export interface PlaudClient {
 	listRecordings(filter?: RecordingFilter): Promise<readonly Recording[]>;
 	getTranscriptAndSummary(id: PlaudRecordingId): Promise<TranscriptAndSummary>;
+	/**
+	 * Resolve the pre-signed download URL for a recording's original audio
+	 * (Opus in an Ogg container). Returns null when Plaud exposes no audio
+	 * URL for the recording, so callers treat audio as best-effort and never
+	 * fail an import over a missing URL. The returned URL is a presigned S3
+	 * link carrying its own signature, so download it WITHOUT the Plaud bearer.
+	 */
+	getAudioTempUrl(id: PlaudRecordingId): Promise<string | null>;
 }
 
 export interface RecordingFilter {


### PR DESCRIPTION
## Summary

Adds an opt-in **Audio** artifact that downloads a recording's original audio (Opus/Ogg) into the note's `-assets` folder and embeds it as a playable transclude under a managed `## Audio` heading. Off by default.

- **Client**: `getAudioTempUrl(id)` hits `GET /file/temp-url/{id}`. The response carries `temp_url` at the top level (not under a `data` envelope), returned as-is or null. Pure `parseAudioTempUrl` exported for tests. The presigned S3 URL is downloaded without the bearer via the existing `shouldSendAuthHeader` rule.
- **Settings**: `defaultIncludeAudio` (default false) in both the imperative and declarative paths, with a vault-size warning (~15 MB/hr, grows vault, slows Sync/backups).
- **Picker**: an Audio checkbox, opt-in (`=== true`), always available.
- **Runner**: audio is fetched lazily only when selected, after the note and attachments land and before the transcript fold. Best-effort: a download or write failure never fails the recording; a mid-batch auth expiry still stops the batch for inline re-auth. Failures are logged into the debug session, not just the DevTools console.
- **File naming**: `<idPrefix>-audio.ogg` (short, same scheme as image attachments) rather than the note title, so the absolute path stays under Windows' 260-char limit. The audio is a normal vault file + `![[...]]` embed, so move/rename link-updates work like any attachment.

Deferred (plan-optional): `audioMaxMB` skip threshold, per-import total-bytes Notice, and `convertAudioToM4a` transcode (needs ffmpeg).

## Testing

- `npm run lint && npm run build && npm test` green (682 tests).
- Manual smoke in a real vault: the `.ogg` downloads, embeds, and plays inline; validated against live recordings, including the path-length and top-level-`temp_url` fixes found during smoke testing.