### PR TITLE
Bump eslint-plugin-obsidianmd to 0.4.x (stricter prefer-create-el)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Development tooling: updated the Obsidian marketplace lint plugin to its 0.4 line and adopted the `createSpan`/`createDiv` DOM helpers it now prefers over `createEl('span'/'div')`. No behavior change.
+
 ## [0.18.0] - 2026-07-02
 
 ### Added

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -2135,7 +2135,7 @@ export class ImportModal extends Modal {
 				}
 				const li = list.createEl('li');
 				li.createEl('strong', { text: f.recording.title });
-				li.createEl('span', {
+				li.createSpan({
 					text: ` (${f.recording.id})`,
 					cls: 'plaud-importer-failure-id',
 				});
@@ -2187,7 +2187,7 @@ export class ImportModal extends Modal {
 				}
 				const li = list.createEl('li');
 				li.createEl('strong', { text: r.recording.title });
-				li.createEl('span', {
+				li.createSpan({
 					text: ` (${r.recording.id})`,
 					cls: 'plaud-importer-failure-id',
 				});
@@ -2220,7 +2220,7 @@ export class ImportModal extends Modal {
 				}
 				const li = list.createEl('li');
 				li.createEl('strong', { text: r.recording.title });
-				li.createEl('span', {
+				li.createSpan({
 					text: ` (${r.recording.id})`,
 					cls: 'plaud-importer-failure-id',
 				});

--- a/main.ts
+++ b/main.ts
@@ -1674,21 +1674,21 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 	// DOM fresh on each call avoids any DocumentFragment-reuse pitfalls.
 	private renderSubfolderTemplateControl(setting: Setting): void {
 		const docEl = setting.descEl.createDiv();
-		docEl.createEl("div", { text: SUBFOLDER_TEMPLATE_TOKENS_HEADING });
+		docEl.createDiv({ text: SUBFOLDER_TEMPLATE_TOKENS_HEADING });
 		const tokenList = docEl.createEl("ul");
 		for (const [token, meaning] of SUBFOLDER_TEMPLATE_TOKENS) {
 			const item = tokenList.createEl("li");
 			item.createEl("code", { text: token });
 			item.createSpan({ text: ` ${meaning}` });
 		}
-		docEl.createEl("div", { text: SUBFOLDER_TEMPLATE_EXAMPLES_HEADING });
+		docEl.createDiv({ text: SUBFOLDER_TEMPLATE_EXAMPLES_HEADING });
 		const exampleList = docEl.createEl("ul");
 		for (const [template, result] of SUBFOLDER_TEMPLATE_EXAMPLES) {
 			const item = exampleList.createEl("li");
 			item.createEl("code", { text: template });
 			item.createSpan({ text: ` → ${result}` });
 		}
-		docEl.createEl("div", { text: SUBFOLDER_TEMPLATE_FOOTNOTE });
+		docEl.createDiv({ text: SUBFOLDER_TEMPLATE_FOOTNOTE });
 
 		setting.addText((text) =>
 			text

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"bestzip": "^2.2.3",
 				"esbuild": "^0.28.1",
 				"eslint": "^9.39.2",
-				"eslint-plugin-obsidianmd": "^0.3.0",
+				"eslint-plugin-obsidianmd": "^0.4.0",
 				"globals": "^17.1.0",
 				"jest": "^30.2.0",
 				"obsidian": "^1.13.0",
@@ -1041,6 +1041,26 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+			"integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"ignore": "^7.0.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -4855,12 +4875,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
-			"integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+			"integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
@@ -4869,7 +4890,7 @@
 				"@types/node": "20.12.12",
 				"@typescript-eslint/types": "^8.33.1",
 				"@typescript-eslint/utils": "^8.33.1",
-				"eslint": ">=9.0.0",
+				"eslint": ">=9.19.0",
 				"eslint-plugin-depend": "1.3.1",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-json-schema-validator": "5.1.0",
@@ -4890,7 +4911,7 @@
 			"peerDependencies": {
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
-				"eslint": ">=9.0.0",
+				"eslint": ">=9.19.0",
 				"obsidian": "1.8.7",
 				"typescript-eslint": "^8.35.1"
 			}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"bestzip": "^2.2.3",
 		"esbuild": "^0.28.1",
 		"eslint": "^9.39.2",
-		"eslint-plugin-obsidianmd": "^0.3.0",
+		"eslint-plugin-obsidianmd": "^0.4.0",
 		"globals": "^17.1.0",
 		"jest": "^30.2.0",
 		"obsidian": "^1.13.0",


### PR DESCRIPTION
## What

Bumps the Obsidian marketplace lint plugin from `^0.3.0` to `^0.4.0` (resolves 0.4.1) and adopts the stricter `prefer-create-el` rule.

## Why

The 0.4 line tightens `prefer-create-el` to flag `createEl('span'/'div', ...)` in favor of the `createSpan` / `createDiv` helpers. Our config spreads `...obsidianmd.configs.recommended`, so the bump adopts the new rules automatically; the two genuinely-new rules (`prefer-setting-definitions`, `no-deprecated-display`) flag nothing here because the plugin already uses declarative settings.

## Changes

- `package.json` / `package-lock.json`: `eslint-plugin-obsidianmd` `^0.3.0` -> `^0.4.0`.
- `import-modal.ts`: 3x `li.createEl('span', {...})` -> `li.createSpan({...})`.
- `main.ts`: 3x `docEl.createEl("div", {...})` -> `docEl.createDiv({...})`.
- `CHANGELOG.md`: Unreleased note.

Dev tooling plus semantically-identical DOM helper swaps. No behavior change. Local `lint && build && test` green (725 tests).

Part of a workspace-wide 0.4.x rollout; the other plugins and the template are tracked separately.