### PR TITLE
Fix auto-sync stranding transcribed and backlogged recordings (0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Plaud Importer will be documented in this file.
 
 - Development tooling: updated the Obsidian marketplace lint plugin to its 0.4 line and adopted the `createSpan`/`createDiv` DOM helpers it now prefers over `createEl('span'/'div')`. No behavior change.
 
+### Fixed
+
+- Background auto-sync now imports a recording as soon as its transcript and summary are ready, instead of waiting for Plaud to finish pulling the original audio off the device. A recording could stay un-imported for a long time (sometimes hours) even though it was fully transcribed, because the plugin was gating on a device-sync flag that clears much later. Transcribed recordings now sync on the next check; if you import audio, a recording whose audio is not ready yet still imports and its audio lands on a later sync.
+- Background auto-sync no longer stops scanning at the first already-synced recording. When several recordings piled up while sync was paused (for example after your Plaud session expired), a newer-imported recording could sit above older un-imported ones and cause auto-sync to stop before reaching them, so they were never imported. Auto-sync now scans each check until it reaches a page with nothing new, so a backlog drains fully.
+
 ## [0.18.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Fixed
 
-- Background auto-sync now imports a recording as soon as its transcript and summary are ready, instead of waiting for Plaud to finish pulling the original audio off the device. A recording could stay un-imported for a long time (sometimes hours) even though it was fully transcribed, because the plugin was gating on a device-sync flag that clears much later. Transcribed recordings now sync on the next check; if you import audio, a recording whose audio is not ready yet still imports and its audio lands on a later sync.
+- Background auto-sync now imports a recording as soon as its transcript or summary is ready, instead of waiting for Plaud to finish pulling the original audio off the device. A recording could stay un-imported for a long time (sometimes hours) even though it was fully transcribed, because the plugin was gating on a device-sync flag that clears much later. Transcribed recordings now sync on the next check; if you import audio, a recording whose audio is not ready yet still imports and its audio lands on a later sync.
 - Background auto-sync no longer stops scanning at the first already-synced recording. When several recordings piled up while sync was paused (for example after your Plaud session expired), a newer-imported recording could sit above older un-imported ones and cause auto-sync to stop before reaching them, so they were never imported. Auto-sync now scans each check until it reaches a page with nothing new, so a backlog drains fully.
 
 ## [0.18.0] - 2026-07-02

--- a/__tests__/auto-sync-runner.test.ts
+++ b/__tests__/auto-sync-runner.test.ts
@@ -60,7 +60,7 @@ function deps(
 }
 
 describe('runAutoSyncTick', () => {
-	it('stops at the up-to-date boundary in a single page and splits new/changed', async () => {
+	it('scans the whole page (splitting new/changed) instead of stopping at an up-to-date one', async () => {
 		const index = idx([
 			['changed', 500],
 			['boundary', 900],
@@ -72,34 +72,44 @@ describe('runAutoSyncTick', () => {
 				[
 					rec('new1', 1000),
 					rec('changed', 600), // > stored 500 -> changed
-					rec('boundary', 900), // == stored -> STOP
-					rec('never', 1),
+					rec('boundary', 900), // == stored -> up-to-date, do NOT stop
+					rec('new-below', 1), // NEW, below the up-to-date one -> still caught
 				],
 			],
 		});
 		const result = await runAutoSyncTick(d);
-		expect(result.reachedUpToDate).toBe(true);
+		// The page produced candidates, so we did not reach the "nothing to
+		// import" frontier; the short page (4 < 10) is what ends paging.
+		expect(result.reachedUpToDate).toBe(false);
 		expect(result.pagesScanned).toBe(1);
-		expect(importCalls).toEqual([{ newIds: ['new1'], changedIds: ['changed'] }]);
-		expect(result.imported).toBe(1);
+		expect(importCalls).toEqual([
+			{ newIds: ['new1', 'new-below'], changedIds: ['changed'] },
+		]);
+		expect(result.imported).toBe(2);
 		expect(result.updated).toBe(1);
 	});
 
-	it('pages across multiple pages until the boundary', async () => {
-		const index = idx([['stop', 100]]);
-		const { deps: d, listSkips } = deps({
+	it('keeps paging past up-to-date recordings and stops on the first page with no candidates', async () => {
+		const index = idx([
+			['synced-a', 500],
+			['synced-b', 500],
+			['synced-c', 500],
+		]);
+		const { deps: d, listSkips, importCalls } = deps({
 			index,
 			pageSize: 2,
 			pages: [
-				[rec('a', 900), rec('b', 800)], // full page, keep going
-				[rec('c', 700), rec('stop', 100)], // boundary at 'stop'
-				[rec('should-not-load', 1)],
+				[rec('a', 900), rec('b', 800)], // page 1: both new -> keep going
+				[rec('c', 700), rec('synced-a', 500)], // page 2: new + up-to-date -> keep going
+				[rec('synced-b', 400), rec('synced-c', 300)], // page 3: all up-to-date -> STOP
+				[rec('should-not-load', 1)], // page 4: never loaded
 			],
 		});
 		const result = await runAutoSyncTick(d);
-		expect(result.reachedUpToDate).toBe(true);
-		expect(result.pagesScanned).toBe(2);
-		expect(listSkips).toEqual([0, 2]); // never asked for page 3
+		expect(result.reachedUpToDate).toBe(true); // page 3 yielded zero candidates
+		expect(result.pagesScanned).toBe(3);
+		expect(listSkips).toEqual([0, 2, 4]); // never asked for page 4
+		expect(importCalls[0].newIds).toEqual(['a', 'b', 'c']);
 	});
 
 	it('caps by maxPagesPerTick on a cold index (nothing up to date)', async () => {

--- a/__tests__/auto-sync.test.ts
+++ b/__tests__/auto-sync.test.ts
@@ -66,36 +66,69 @@ describe('classifyRecording', () => {
 		);
 	});
 
-	it('skips a recording still syncing from the device (wait_pull)', () => {
+	it('imports a wait_pull recording that already has content ready', () => {
+		// wait_pull tracks the device audio pull, not transcript/summary
+		// readiness: a transcribed recording must import even while wait_pull=1.
 		expect(
 			classifyRecording(rec({ id: 'a', versionMs: 999, waitPull: true }), idx([])),
+		).toBe('new');
+	});
+
+	it('skips a wait_pull recording only when it has no content yet', () => {
+		expect(
+			classifyRecording(
+				rec({
+					id: 'a',
+					versionMs: 999,
+					waitPull: true,
+					transcriptAvailable: false,
+					summaryAvailable: false,
+				}),
+				idx([]),
+			),
 		).toBe('skipped-wait-pull');
 	});
 });
 
 describe('selectAutoSyncCandidates', () => {
-	it('collects new and changed, and stops at the first up-to-date boundary', () => {
-		// edit-time-descending page: a changed-old recording sits ABOVE the
-		// boundary and must still be caught; everything after the boundary is
-		// skipped without classification.
+	it('scans the whole page so a new recording below an up-to-date one is still caught', () => {
+		// Bug B regression: after a backlog builds up (e.g. auto-sync was
+		// auth-paused), a NEW recording can sort BELOW an already-synced
+		// (up-to-date-boundary) recording in edit-time order. The scan must not
+		// stop at the boundary, or that new recording is stranded forever.
 		const index = idx([
 			['changed-old', { path: 'c', versionMs: 100 }],
 			['boundary', { path: 'b', versionMs: 500 }],
-			['below', { path: 'x', versionMs: 10 }],
+			['below-synced', { path: 'x', versionMs: 10 }],
 		]);
 		const page = [
 			rec({ id: 'brand-new', versionMs: 900 }),
 			rec({ id: 'changed-old', versionMs: 800 }),
-			rec({ id: 'boundary', versionMs: 500 }), // == stored -> boundary, STOP
-			rec({ id: 'below', versionMs: 5 }), // never examined
-			rec({ id: 'also-new', versionMs: 1 }), // never examined
+			rec({ id: 'boundary', versionMs: 500 }), // == stored -> up-to-date, do NOT stop
+			rec({ id: 'below-synced', versionMs: 5 }), // in index, up-to-date, skip
+			rec({ id: 'also-new', versionMs: 1 }), // NEW, below the boundary -> must be caught
 		];
 		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, index);
-		expect(reachedUpToDate).toBe(true);
+		expect(reachedUpToDate).toBe(false); // the page produced candidates
 		expect(candidates.map((c) => `${c.recording.id}:${c.kind}`)).toEqual([
 			'brand-new:new',
 			'changed-old:changed',
+			'also-new:new',
 		]);
+	});
+
+	it('flags reachedUpToDate only when the page yields no candidates', () => {
+		const index = idx([
+			['a', { path: 'a', versionMs: 500 }],
+			['b', { path: 'b', versionMs: 500 }],
+		]);
+		const page = [
+			rec({ id: 'a', versionMs: 500 }), // up-to-date
+			rec({ id: 'b', versionMs: 400 }), // up-to-date
+		];
+		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, index);
+		expect(candidates).toEqual([]);
+		expect(reachedUpToDate).toBe(true);
 	});
 
 	it('does not stop on a missing-marker note and never flags it changed', () => {
@@ -118,14 +151,26 @@ describe('selectAutoSyncCandidates', () => {
 		expect(candidates.map((c) => c.recording.id)).toEqual(['keep']);
 	});
 
-	it('skips wait_pull recordings but keeps scanning', () => {
+	it('skips a content-less wait_pull recording but keeps scanning', () => {
 		const page = [
-			rec({ id: 'pending', versionMs: 900, waitPull: true }),
+			rec({
+				id: 'pending',
+				versionMs: 900,
+				waitPull: true,
+				transcriptAvailable: false,
+				summaryAvailable: false,
+			}),
 			rec({ id: 'ready', versionMs: 800 }),
 		];
 		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, idx([]));
 		expect(reachedUpToDate).toBe(false);
 		expect(candidates.map((c) => c.recording.id)).toEqual(['ready']);
+	});
+
+	it('imports a wait_pull recording that has content (transcribed but audio still pulling)', () => {
+		const page = [rec({ id: 'pending-with-content', versionMs: 900, waitPull: true })];
+		const { candidates } = selectAutoSyncCandidates(page, idx([]));
+		expect(candidates.map((c) => c.recording.id)).toEqual(['pending-with-content']);
 	});
 });
 

--- a/__tests__/auto-sync.test.ts
+++ b/__tests__/auto-sync.test.ts
@@ -117,18 +117,56 @@ describe('selectAutoSyncCandidates', () => {
 		]);
 	});
 
-	it('flags reachedUpToDate only when the page yields no candidates', () => {
+	it('reaches the frontier only when the whole page is proven up-to-date', () => {
 		const index = idx([
 			['a', { path: 'a', versionMs: 500 }],
 			['b', { path: 'b', versionMs: 500 }],
 		]);
 		const page = [
-			rec({ id: 'a', versionMs: 500 }), // up-to-date
-			rec({ id: 'b', versionMs: 400 }), // up-to-date
+			rec({ id: 'a', versionMs: 500 }), // up-to-date-boundary
+			rec({ id: 'b', versionMs: 400 }), // up-to-date-boundary
 		];
 		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, index);
 		expect(candidates).toEqual([]);
 		expect(reachedUpToDate).toBe(true);
+	});
+
+	it('does NOT reach the frontier on a page of only legacy (no-marker) notes', () => {
+		// up-to-date-current rows cannot prove the frontier (migration rule): a
+		// ready recording can still sit below them on a later page.
+		const index = idx([
+			['legacy-a', { path: 'a' }], // no versionMs
+			['legacy-b', { path: 'b' }],
+		]);
+		const page = [
+			rec({ id: 'legacy-a', versionMs: 900 }),
+			rec({ id: 'legacy-b', versionMs: 800 }),
+		];
+		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, index);
+		expect(candidates).toEqual([]);
+		expect(reachedUpToDate).toBe(false);
+	});
+
+	it('does NOT reach the frontier on a page of only pending wait_pull notes', () => {
+		const page = [
+			rec({
+				id: 'p1',
+				versionMs: 900,
+				waitPull: true,
+				transcriptAvailable: false,
+				summaryAvailable: false,
+			}),
+			rec({
+				id: 'p2',
+				versionMs: 800,
+				waitPull: true,
+				transcriptAvailable: false,
+				summaryAvailable: false,
+			}),
+		];
+		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(page, idx([]));
+		expect(candidates).toEqual([]);
+		expect(reachedUpToDate).toBe(false);
 	});
 
 	it('does not stop on a missing-marker note and never flags it changed', () => {

--- a/auto-sync.ts
+++ b/auto-sync.ts
@@ -111,12 +111,16 @@ export interface AutoSyncCandidate {
 export interface SelectCandidatesResult {
 	readonly candidates: readonly AutoSyncCandidate[];
 	/**
-	 * True when this page produced NO importable candidates (nothing new or
-	 * changed after scanning the whole page). In edit-time-descending order a
-	 * page with nothing to import means we have reached the synced frontier, so
-	 * the scheduler stops paging. This replaces the old "first up-to-date
-	 * recording" break, which could strand a new recording that sorts below an
-	 * already-synced one.
+	 * True only when EVERY recording on the page is a proven-unchanged
+	 * `up-to-date-boundary` (in the vault, with a version marker, listed
+	 * `version_ms` <= stored). That is the real synced frontier, so the
+	 * scheduler stops paging. A page is deliberately NOT a frontier when it
+	 * still holds any candidate, any `up-to-date-current` (legacy note with no
+	 * marker, per the migration rule), or any `skipped-wait-pull` row: an
+	 * importable recording can sort below those on a later page, so paging must
+	 * continue. This replaces both the old "first up-to-date recording" break
+	 * (stranded new recordings below it) and the interim "zero candidates" stop
+	 * (stranded ready recordings below an all-legacy or all-wait_pull page).
 	 */
 	readonly reachedUpToDate: boolean;
 }
@@ -130,9 +134,9 @@ export interface SelectCandidatesResult {
  * recording: a `new` (never-imported) recording can sit below an
  * `up-to-date-boundary` one in edit-time order once a backlog accumulates (for
  * example after auto-sync was auth-paused and several recordings piled up), so
- * an early break would strand it. Instead, `reachedUpToDate` is set when the
- * page yields zero candidates, and the scheduler uses that (plus its page /
- * import caps) to decide when to stop paging.
+ * an early break would strand it. Paging stops only when the whole page is
+ * proven up-to-date (see `reachedUpToDate`), which the scheduler combines with
+ * its page / import caps.
  */
 export function selectAutoSyncCandidates(
 	page: readonly Recording[],
@@ -141,16 +145,25 @@ export function selectAutoSyncCandidates(
 	// Never import trash. filterVisibleRecordings preserves order.
 	const visible = filterVisibleRecordings(page, false);
 	const candidates: AutoSyncCandidate[] = [];
+	// The frontier is reached only if the page has at least one recording and
+	// every one of them is an `up-to-date-boundary`. Any candidate, legacy
+	// (`up-to-date-current`), or pending (`skipped-wait-pull`) row means an
+	// importable recording could still be below, so we must keep paging.
+	let sawRecording = false;
+	let allProvenUpToDate = true;
 	for (const recording of visible) {
+		sawRecording = true;
 		const classification = classifyRecording(recording, index);
 		if (classification === 'new' || classification === 'changed') {
 			candidates.push({ recording, kind: classification });
+			allProvenUpToDate = false;
+		} else if (classification !== 'up-to-date-boundary') {
+			// 'up-to-date-current' (legacy) or 'skipped-wait-pull' (pending):
+			// non-importable here, but NOT a frontier. Skip and keep scanning.
+			allProvenUpToDate = false;
 		}
-		// 'up-to-date-boundary', 'up-to-date-current', and 'skipped-wait-pull'
-		// are all non-importable: skip them but keep scanning the rest of the
-		// page so a new recording below them is not missed.
 	}
-	return { candidates, reachedUpToDate: candidates.length === 0 };
+	return { candidates, reachedUpToDate: sawRecording && allProvenUpToDate };
 }
 
 // -----------------------------------------------------------------------------

--- a/auto-sync.ts
+++ b/auto-sync.ts
@@ -27,9 +27,12 @@ import {
  *  - `changed`: in the vault with a stored marker, and the listed `version_ms`
  *    is strictly greater. Re-import (overwrite) it.
  *  - `up-to-date-boundary`: in the vault with a stored marker and listed
- *    `version_ms` <= stored. Proof it has not changed; because the list is
- *    edit-time-descending, everything BELOW it is also unchanged, so this is
- *    the stop signal.
+ *    `version_ms` <= stored. Proof this recording has not changed. It is NOT a
+ *    hard stop signal on its own: a NEW (never-imported) recording can sort
+ *    below it in edit-time order once a backlog accumulates (for example while
+ *    auto-sync was auth-paused), so paging must not terminate at the first one.
+ *    `selectAutoSyncCandidates` stops only after a whole page yields nothing to
+ *    import.
  *  - `up-to-date-current`: in the vault but no comparable marker (imported
  *    before this feature, or the list omitted `version_ms`). Migration rule:
  *    treat as current so enabling auto-sync never mass-overwrites an existing
@@ -49,7 +52,22 @@ export function classifyRecording(
 	recording: Recording,
 	index: ReadonlyMap<PlaudRecordingId, ImportedRecord>,
 ): AutoSyncClassification {
-	if (recording.waitPull === true) {
+	// `wait_pull` tracks the device's ORIGINAL-AUDIO pull (the list's
+	// `ori_ready`), NOT transcript/summary readiness. A recording is routinely
+	// fully transcribed and summarized (`transcriptAvailable` / `summaryAvailable`
+	// true) while `wait_pull` is still 1 for a long time; observed live at 30
+	// minutes to 24 hours after the transcript was ready. Skipping on `wait_pull`
+	// alone therefore withholds importable notes from auto-sync for that whole
+	// window, even though the content is complete (verified: the transcript/
+	// summary fetch succeeds on a `wait_pull === 1` recording). Only skip when
+	// there is genuinely no content yet; a transcribed recording imports now and
+	// its audio, if enabled, stays best-effort, matching the manual import path.
+	// If the recording later changes, `version_ms` advances and it re-syncs.
+	if (
+		recording.waitPull === true &&
+		!recording.transcriptAvailable &&
+		!recording.summaryAvailable
+	) {
 		return 'skipped-wait-pull';
 	}
 	const existing = index.get(recording.id);
@@ -93,8 +111,12 @@ export interface AutoSyncCandidate {
 export interface SelectCandidatesResult {
 	readonly candidates: readonly AutoSyncCandidate[];
 	/**
-	 * True when a definitively up-to-date recording was reached (the boundary).
-	 * The scheduler stops paging when this is set.
+	 * True when this page produced NO importable candidates (nothing new or
+	 * changed after scanning the whole page). In edit-time-descending order a
+	 * page with nothing to import means we have reached the synced frontier, so
+	 * the scheduler stops paging. This replaces the old "first up-to-date
+	 * recording" break, which could strand a new recording that sorts below an
+	 * already-synced one.
 	 */
 	readonly reachedUpToDate: boolean;
 }
@@ -102,9 +124,15 @@ export interface SelectCandidatesResult {
 /**
  * Classify one edit-time-descending page against the index and collect the
  * importable candidates. Trashed recordings are removed first (auto-sync never
- * imports trash regardless of the show-trash display setting). Iteration stops
- * at the first `up-to-date-boundary`: everything after it in the page is older
- * and unchanged.
+ * imports trash regardless of the show-trash display setting).
+ *
+ * The WHOLE page is scanned rather than stopping at the first already-synced
+ * recording: a `new` (never-imported) recording can sit below an
+ * `up-to-date-boundary` one in edit-time order once a backlog accumulates (for
+ * example after auto-sync was auth-paused and several recordings piled up), so
+ * an early break would strand it. Instead, `reachedUpToDate` is set when the
+ * page yields zero candidates, and the scheduler uses that (plus its page /
+ * import caps) to decide when to stop paging.
  */
 export function selectAutoSyncCandidates(
 	page: readonly Recording[],
@@ -113,19 +141,16 @@ export function selectAutoSyncCandidates(
 	// Never import trash. filterVisibleRecordings preserves order.
 	const visible = filterVisibleRecordings(page, false);
 	const candidates: AutoSyncCandidate[] = [];
-	let reachedUpToDate = false;
 	for (const recording of visible) {
 		const classification = classifyRecording(recording, index);
-		if (classification === 'up-to-date-boundary') {
-			reachedUpToDate = true;
-			break;
-		}
 		if (classification === 'new' || classification === 'changed') {
 			candidates.push({ recording, kind: classification });
 		}
-		// 'skipped-wait-pull' and 'up-to-date-current' fall through: skip, keep going.
+		// 'up-to-date-boundary', 'up-to-date-current', and 'skipped-wait-pull'
+		// are all non-importable: skip them but keep scanning the rest of the
+		// page so a new recording below them is not missed.
 	}
-	return { candidates, reachedUpToDate };
+	return { candidates, reachedUpToDate: candidates.length === 0 };
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Hotfix for two background auto-sync bugs in 0.18.0 that leave transcribed recordings un-imported. Found via a live debug-log session on a real account. Ships as 0.18.1, ahead of the folder-import feature.

## Bug 1: auto-sync skips transcribed recordings that are still `wait_pull=1`
`classifyRecording` skipped any recording with `wait_pull === 1`. But `wait_pull` tracks the device's **original-audio** pull (the list's `ori_ready`), **not** transcript/summary readiness. In live data, recordings are routinely fully transcribed and summarized (`is_trans` / `is_summary` true, transcript fetch succeeds) while `wait_pull` stays 1 for 30 minutes to 24 hours. So auto-sync withheld importable notes for that whole window, even though the content was complete. Manual import ignores `wait_pull`, which is why the same recordings imported fine by hand.

**Fix:** only skip on `wait_pull` when there is genuinely no content yet (no transcript and no summary). A transcribed recording imports immediately; its audio, if enabled, stays best-effort; a later change re-syncs via `version_ms`.

## Bug 2: the "stop at first up-to-date" scan strands backlogged recordings
`selectAutoSyncCandidates` stopped scanning at the first `up-to-date-boundary` recording, assuming everything below it in edit-time order was also synced. That assumption breaks when a backlog accumulates, for example after auto-sync was auth-paused on a token expiry: a **new** (never-imported) recording can sort **below** an already-synced one and is then never scanned, so it is never imported.

**Fix:** scan the whole page and stop paging only when a page yields **zero** new/changed candidates (the real synced frontier). A backlog now drains fully. Steady-state cost is unchanged: an all-synced first page still stops after one page.

## Evidence
Debug-log tick showed `newCount: 0, changedCount: 0, reachedUpToDate: true` while five newest recordings were transcribed-but-`wait_pull=1` (Bug 1), and a synced recording whose `version_ms` was the highest sat above four new, un-imported recordings that were never scanned (Bug 2).

## Scope
- `auto-sync.ts`: `classifyRecording` (Bug 1) and `selectAutoSyncCandidates` (Bug 2). Pure logic, no I/O.
- The `auto-sync-runner.ts` paging loop is unchanged; only the meaning of its stop flag changed (now "page had nothing to import").

## Testing
`npm run lint && npm run build && npm test` green (728 tests). New/updated coverage:
- `wait_pull` recording with content imports; without content is skipped.
- a new recording below an up-to-date one is caught (Bug 2 regression test).
- the runner keeps paging past up-to-date recordings and stops on the first zero-candidate page; an all-synced first page still stops after one page.

## Smoke test (maintainer)
1. With auto-sync on, record something new; once it shows transcribed in Plaud (even if still `wait_pull`), confirm it imports on the next check (do not wait for audio).
2. Let a few recordings accumulate while sync is paused (expire/withhold the token), then reconnect; confirm all of them import, not just the newest.
