### PR TITLE
Add configurable datetime frontmatter property (issue #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Datetime frontmatter property.** A new setting adds a `datetime:` property to each imported note, formatted with the same `{{ }}` Moment tokens as the folder and note-name fields. It is empty by default (no property is written); set a template to turn it on. The existing `date:` property stays `YYYY-MM-DD` so Dataview queries and daily-note links keep working, and this separate field records the time in whatever format you want: 24-hour (`{{YYYY-MM-DD HH:mm}}`), 12-hour (`{{YYYY-MM-DD h:mm A}}`), or ISO 8601 with the UTC offset (`{{YYYY-MM-DDTHH:mm:ssZ}}`). The value is your computer's local time; include `{{Z}}` to record the offset so the instant stays unambiguous across devices and time zones. A live preview shows the result as you type. Resolves issue #32.
+- **Time tokens on every template field.** The insert-token buttons now include Hour, Minute, Second, AM/PM, and Offset, so you can compose a time in the subfolder and note-name templates too, not just the new datetime field.
+
 ## [0.21.1] - 2026-07-05
 
 ### Fixed

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -3560,6 +3560,30 @@ describe('formatPlaceholderMarkdown', () => {
 		expect(md).toContain('line one line two');
 		expect(md).not.toContain('line one\nline two');
 	});
+
+	// datetime property (issue #32): the placeholder path mirrors formatFrontmatter,
+	// so it must emit datetime under the same conditions to stay in sync.
+	it('omits the datetime line when no datetime template is given', () => {
+		expect(formatPlaceholderMarkdown(makeRecording(), 'reason')).not.toMatch(
+			/^datetime:/m,
+		);
+		expect(
+			formatPlaceholderMarkdown(makeRecording(), 'reason', DEFAULT_NOTE_NAME_TEMPLATE, ''),
+		).not.toMatch(/^datetime:/m);
+	});
+
+	it('emits the datetime line, quoted, when a datetime template is given', () => {
+		const md = formatPlaceholderMarkdown(
+			makeRecording(),
+			'reason',
+			DEFAULT_NOTE_NAME_TEMPLATE,
+			'{{YYYY-MM-DD HH:mm}}',
+		);
+		const lines = md.split('\n');
+		const dateIdx = lines.findIndex((l) => l.startsWith('date:'));
+		expect(lines[dateIdx]).toBe('date: 2026-04-14');
+		expect(lines[dateIdx + 1]).toBe('datetime: "2026-04-14 09:30"');
+	});
 });
 
 // NoteWriter.writePlaceholderNote --------------------------------------------

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -1002,6 +1002,71 @@ describe('formatFrontmatter', () => {
 		).not.toMatch(/plaud-folder:/);
 	});
 
+	// datetime property (issue #32). The recording is 2026-04-14 09:30 local.
+	it('omits the datetime line when the template is absent or empty', () => {
+		expect(formatFrontmatter(makeRecording(), [])).not.toMatch(/^datetime:/m);
+		expect(
+			formatFrontmatter(makeRecording(), [], null, undefined, undefined, ''),
+		).not.toMatch(/^datetime:/m);
+		expect(
+			formatFrontmatter(makeRecording(), [], null, undefined, undefined, '   '),
+		).not.toMatch(/^datetime:/m);
+	});
+
+	it('emits a 24-hour datetime, quoted for the colon', () => {
+		const fm = formatFrontmatter(
+			makeRecording(),
+			[],
+			null,
+			undefined,
+			undefined,
+			'{{YYYY-MM-DD HH:mm}}',
+		);
+		expect(fm).toContain('datetime: "2026-04-14 09:30"');
+	});
+
+	it('emits a 12-hour datetime with AM/PM', () => {
+		const fm = formatFrontmatter(
+			makeRecording(),
+			[],
+			null,
+			undefined,
+			undefined,
+			'{{h:mm A}}',
+		);
+		expect(fm).toContain('datetime: "9:30 AM"');
+	});
+
+	it('emits an ISO datetime carrying the local UTC offset', () => {
+		const fm = formatFrontmatter(
+			makeRecording(),
+			[],
+			null,
+			undefined,
+			undefined,
+			'{{YYYY-MM-DDTHH:mm:ssZ}}',
+		);
+		// The offset depends on the machine time zone, so assert the shape, not a
+		// fixed offset. The wall-clock stays 09:30:00 because the sample date was
+		// built from local components and Moment formats in local time.
+		expect(fm).toMatch(/^datetime: "2026-04-14T09:30:00[+-]\d\d:\d\d"$/m);
+	});
+
+	it('keeps date as YYYY-MM-DD and places datetime right after it', () => {
+		const fm = formatFrontmatter(
+			makeRecording(),
+			[],
+			null,
+			undefined,
+			undefined,
+			'{{YYYY-MM-DD HH:mm}}',
+		);
+		const lines = fm.split('\n');
+		const dateIdx = lines.findIndex((l) => l.startsWith('date:'));
+		expect(lines[dateIdx]).toBe('date: 2026-04-14');
+		expect(lines[dateIdx + 1]).toBe('datetime: "2026-04-14 09:30"');
+	});
+
 	it('clamps negative/infinite durations in the duration-seconds line', () => {
 		const fm = formatFrontmatter(
 			makeRecording({ durationSeconds: -10 }),

--- a/main.ts
+++ b/main.ts
@@ -34,7 +34,9 @@ import {
 	renameRecordingNote,
 	resolveSubfolder,
 	buildNoteName,
+	formatDatetime,
 	TEMPLATE_PREVIEW_DATE,
+	TEMPLATE_PREVIEW_DATETIME,
 	TEMPLATE_PREVIEW_TITLE,
 	sanitizeFilename,
 	type RenameFileFn,
@@ -242,8 +244,49 @@ const DATE_INSERT_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["Weekday", "{{dddd}}"],
 	["Quarter", "{{Q}}"],
 	["Week", "{{WW}}"],
+	// Time tokens (issue #32). Available in every template field so a user can
+	// compose a time however they like; most useful in the datetime frontmatter
+	// field. Offset ({{Z}}) records the UTC offset so an ISO value is unambiguous.
+	["Hour", "{{HH}}"],
+	["Minute", "{{mm}}"],
+	["Second", "{{ss}}"],
+	["AM/PM", "{{A}}"],
+	["Offset", "{{Z}}"],
 ];
 const TITLE_INSERT_TOKEN: readonly [string, string] = ["Title", "{{title}}"];
+
+// Datetime-template documentation for the `datetime:` frontmatter field (issue
+// #32). Mirrors the subfolder field's Moment-only shape (no {{title}}, no
+// presets) but leads with the time tokens, which are the reason this field
+// exists. Held in consts, like the other template strings, so the sentence-case
+// lint inspects the literal arguments and leaves the token examples untouched.
+const DATETIME_TEMPLATE_INTRO =
+	"Adds a datetime property to each note's frontmatter, formatted with the same {{ }} Moment tokens as the other fields. Leave it empty to write no datetime property. The date property stays YYYY-MM-DD for Dataview; this separate field lets you record the recording time in any format. The value is your computer's local time, so include {{Z}} to capture the UTC offset if you want the instant to stay unambiguous across devices and time zones.";
+
+const DATETIME_TEMPLATE_TOKENS: ReadonlyArray<readonly [string, string]> = [
+	["{{YYYY}}-{{MM}}-{{DD}}", "the date, for example 2026-07-05"],
+	["{{HH}}", "hour, 00 to 23"],
+	["{{mm}}", "minute, 00 to 59"],
+	["{{ss}}", "second, 00 to 59"],
+	["{{h}}", "hour, 1 to 12"],
+	["{{A}}", "AM or PM"],
+	["{{Z}}", "UTC offset, for example +02:00"],
+];
+
+// [template, resulting value] pairs for the sample datetime 2026-07-05 14:30:00.
+// The ISO example's offset depends on the user's own time zone; the live preview
+// shows their real value, so the doc labels it rather than committing to one.
+const DATETIME_TEMPLATE_EXAMPLES: ReadonlyArray<readonly [string, string]> = [
+	["{{YYYY-MM-DD HH:mm}}", "2026-07-05 14:30 (24-hour)"],
+	["{{YYYY-MM-DD h:mm A}}", "2026-07-05 2:30 PM (12-hour)"],
+	["{{YYYY-MM-DDTHH:mm:ssZ}}", "2026-07-05T14:30:00+00:00 (ISO 8601, with your UTC offset)"],
+];
+
+const DATETIME_TEMPLATE_TOKENS_HEADING =
+	"Tokens (case matters; combine them with separators inside the braces):";
+const DATETIME_TEMPLATE_EXAMPLES_HEADING = "Examples:";
+const DATETIME_TEMPLATE_FOOTNOTE =
+	"Applies to new imports; notes you already imported keep their current frontmatter.";
 
 /**
  * Coerce a stored ribbon icon ID to a known-good value. Protects against
@@ -274,6 +317,11 @@ interface PlaudImporterSettings {
 	// subfolderTemplate, plus {{title}}). Default "{{YYYY}}-{{MM}}-{{DD}} {{title}}"
 	// reproduces the historical naming. Validated filename-safe before it is saved.
 	noteNameTemplate: string;
+	// {{...}} Moment template for a `datetime:` frontmatter property (issue #32).
+	// Empty (the default) emits no property. Separate from the `date:` field, which
+	// stays YYYY-MM-DD for Dataview, so the user can add the recording time in any
+	// format (24h, 12h, ISO 8601) without disturbing existing date queries.
+	datetimeTemplate: string;
 	onDuplicate: "skip" | "overwrite" | "prompt";
 	showRibbonIcon: boolean;
 	ribbonIcon: string;
@@ -331,6 +379,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	outputFolder: "Plaud",
 	subfolderTemplate: "",
 	noteNameTemplate: DEFAULT_NOTE_NAME_TEMPLATE,
+	datetimeTemplate: "",
 	onDuplicate: "prompt",
 	showRibbonIcon: true,
 	ribbonIcon: DEFAULT_RIBBON_ICON,
@@ -674,6 +723,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			outputFolder: this.settings.outputFolder,
 			subfolderTemplate: this.settings.subfolderTemplate,
 			noteNameTemplate: this.settings.noteNameTemplate,
+			datetimeTemplate: this.settings.datetimeTemplate,
 			onDuplicate: this.settings.onDuplicate,
 			includeTranscript: this.settings.includeTranscript,
 			includeSummary: this.settings.defaultIncludeSummary,
@@ -1953,6 +2003,13 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				NOTE_NAME_TEMPLATE_INTRO,
 			),
 		);
+		this.renderDatetimeTemplateControl(
+			this.makeSetting(
+				containerEl,
+				"Datetime property",
+				DATETIME_TEMPLATE_INTRO,
+			),
+		);
 		this.addDropdownRow(
 			containerEl,
 			"Duplicate handling",
@@ -2442,6 +2499,69 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 		updatePreview(this.readSettingString("subfolderTemplate"));
 	}
 
+	// Renders the datetime template row for the `datetime:` frontmatter property
+	// (issue #32). Mirrors the subfolder row (Moment-only, per-keystroke persist,
+	// no presets); the shared insert-token buttons now include the time tokens.
+	// Empty is a valid value (writes no property), so unlike the note-name field
+	// there is no blur-commit or invalid-template Notice — Moment never errors and
+	// the preview is the only feedback needed.
+	private renderDatetimeTemplateControl(setting: Setting): void {
+		setting.settingEl.addClass("plaud-importer-stacked-row");
+		const docEl = setting.descEl.createDiv();
+		docEl.createDiv({ text: DATETIME_TEMPLATE_TOKENS_HEADING });
+		const tokenList = docEl.createEl("ul");
+		for (const [token, meaning] of DATETIME_TEMPLATE_TOKENS) {
+			const item = tokenList.createEl("li");
+			item.createEl("code", { text: token });
+			item.createSpan({ text: ` ${meaning}` });
+		}
+		docEl.createDiv({ text: DATETIME_TEMPLATE_EXAMPLES_HEADING });
+		const exampleList = docEl.createEl("ul");
+		for (const [template, result] of DATETIME_TEMPLATE_EXAMPLES) {
+			const item = exampleList.createEl("li");
+			item.createEl("code", { text: template });
+			item.createSpan({ text: ` → ${result}` });
+		}
+		docEl.createDiv({ text: DATETIME_TEMPLATE_FOOTNOTE });
+
+		let field: TextComponent | null = null;
+		let updatePreview: (template: string) => void = () => {};
+		for (const [label, token] of DATE_INSERT_TOKENS) {
+			setting.addButton((button) => {
+				button
+					.setButtonText(label)
+					.setTooltip(`Insert ${token}`)
+					.onClick(async () => {
+						if (field === null) return;
+						this.insertTokenAtCursor(field, token);
+						const value = field.getValue();
+						await this.applyControlChange("datetimeTemplate", value);
+						updatePreview(value);
+					});
+				button.buttonEl.addEventListener("mousedown", (event) =>
+					event.preventDefault(),
+				);
+			});
+		}
+		setting.addText((text) => {
+			field = text;
+			text
+				.setPlaceholder("{{YYYY-MM-DD HH:mm}}")
+				.setValue(this.readSettingString("datetimeTemplate"))
+				.onChange(async (value) => {
+					await this.applyControlChange("datetimeTemplate", value);
+					updatePreview(value);
+				});
+		});
+		updatePreview = this.attachTemplatePreview(setting, (template) => {
+			if (template.trim() === "") {
+				return "Preview: no datetime property";
+			}
+			return `Preview datetime: ${formatDatetime(template, TEMPLATE_PREVIEW_DATETIME)}`;
+		});
+		updatePreview(this.readSettingString("datetimeTemplate"));
+	}
+
 	// Renders the note-name template row: the token reference and examples (lists,
 	// so they read clearly) into the description, then a text control bound to
 	// noteNameTemplate, then ISO/US/EU preset buttons that fill the field and
@@ -2739,6 +2859,15 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 							this.renderNoteNameTemplateControl(setting),
 					},
 					{
+						name: "Datetime property",
+						desc: DATETIME_TEMPLATE_INTRO,
+						// Rendered imperatively for the token + examples lists, like
+						// the two template rows above.
+						searchable: false,
+						render: (setting: Setting) =>
+							this.renderDatetimeTemplateControl(setting),
+					},
+					{
 						name: "Duplicate handling",
 						desc: "What to do when a note for the recording already exists in the output folder.",
 						control: {
@@ -2995,6 +3124,13 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				);
 				return;
 			}
+		} else if (key === "datetimeTemplate") {
+			// Any {{ }} Moment template is accepted, empty included (which writes no
+			// datetime property). Moment never throws on an unknown token, and there
+			// is no path or filename safety concern here, so there is nothing to
+			// reject and the live preview is the only feedback. Persisted as typed.
+			this.plugin.settings.datetimeTemplate =
+				typeof value === "string" ? value : "";
 		} else if (key === "transcriptHeaderLevel") {
 			const level = Number(value);
 			if (level >= 1 && level <= 6) {

--- a/main.ts
+++ b/main.ts
@@ -279,7 +279,7 @@ const DATETIME_TEMPLATE_TOKENS: ReadonlyArray<readonly [string, string]> = [
 const DATETIME_TEMPLATE_EXAMPLES: ReadonlyArray<readonly [string, string]> = [
 	["{{YYYY-MM-DD HH:mm}}", "2026-07-05 14:30 (24-hour)"],
 	["{{YYYY-MM-DD h:mm A}}", "2026-07-05 2:30 PM (12-hour)"],
-	["{{YYYY-MM-DDTHH:mm:ssZ}}", "2026-07-05T14:30:00+00:00 (ISO 8601, with your UTC offset)"],
+	["{{YYYY-MM-DDTHH:mm:ssZ}}", "2026-07-05T14:30:00±hh:mm, your local UTC offset (ISO 8601)"],
 ];
 
 const DATETIME_TEMPLATE_TOKENS_HEADING =

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -133,6 +133,13 @@ export interface NoteWriterOptions {
 	 */
 	readonly noteNameTemplate?: string;
 	/**
+	 * Optional `{{...}}` Moment template for a `datetime:` frontmatter property
+	 * (issue #32). Empty or omitted writes no property. Separate from the fixed
+	 * `date:` field (which stays `YYYY-MM-DD` for Dataview) so the recording time
+	 * can be recorded in any format without disturbing date queries.
+	 */
+	readonly datetimeTemplate?: string;
+	/**
 	 * Optional vault-wide lookup from a `plaud-id` to the path of an existing
 	 * note for that recording, anywhere under the output folder. Lets the
 	 * writer find a prior import that lives in a DIFFERENT subfolder (for
@@ -478,6 +485,17 @@ function expandDateTemplate(template: string, date: Date, title?: string): strin
 }
 
 /**
+ * Render a `datetime:` frontmatter value from a `{{...}}` Moment template (issue
+ * #32). A thin exported wrapper over the shared template engine so the
+ * frontmatter builder and the settings live preview format identically. An empty
+ * template yields an empty string; the caller decides whether to emit a line.
+ * Local time, the same basis as the `date:` field.
+ */
+export function formatDatetime(template: string, date: Date): string {
+	return expandDateTemplate(template, date);
+}
+
+/**
  * Rewrite only the characters a folder name cannot hold on Windows/macOS/Linux,
  * each to a dash: the Windows-forbidden punctuation and any ASCII control
  * character (0x00-0x1F, which sanitizeFilename also strips). Deliberately
@@ -778,6 +796,9 @@ export function migrateLegacyDateTemplate(template: string): string {
  * (and the tests assert against) the same sample.
  */
 export const TEMPLATE_PREVIEW_DATE = new Date(2026, 6, 5); // 2026-07-05 local (Sunday)
+// A sample with a non-midnight local time so the datetime-field preview shows a
+// meaningful time (2026-07-05 14:30:00), not 00:00:00.
+export const TEMPLATE_PREVIEW_DATETIME = new Date(2026, 6, 5, 14, 30, 0);
 export const TEMPLATE_PREVIEW_TITLE = 'Team sync';
 
 /**
@@ -1050,6 +1071,7 @@ export function formatFrontmatter(
 	summary?: Summary | null,
 	keywords?: readonly string[],
 	folders?: readonly string[],
+	datetimeTemplate?: string,
 ): string {
 	const duration = Number.isFinite(recording.durationSeconds)
 		? Math.max(0, Math.floor(recording.durationSeconds))
@@ -1064,6 +1086,14 @@ export function formatFrontmatter(
 	// parsers.
 	lines.push(`plaud-url: ${yamlScalar(formatPlaudWebUrl(recording.id))}`);
 	lines.push(`date: ${formatDateYmd(recording.createdAt)}`);
+	// Optional datetime property (issue #32): a user-formatted timestamp, emitted
+	// only when a template is configured. yamlScalar quotes it so a `:` in the time
+	// is not read as a YAML mapping. Local time, the same basis as `date:`.
+	if (datetimeTemplate && datetimeTemplate.trim() !== '') {
+		lines.push(
+			`datetime: ${yamlScalar(formatDatetime(datetimeTemplate, recording.createdAt))}`,
+		);
+	}
 	lines.push(`duration-seconds: ${duration}`);
 	// Human-readable duration alongside the raw seconds so users can read
 	// it at a glance without the note also pretending to support Dataview
@@ -1645,6 +1675,11 @@ export interface FormatMarkdownOptions {
 	 * reproduces `YYYY-MM-DD <title>`.
 	 */
 	readonly noteNameTemplate?: string;
+	/**
+	 * `{{...}}` Moment template for the `datetime:` frontmatter property (issue
+	 * #32). Empty or omitted writes no property. See `formatDatetime`.
+	 */
+	readonly datetimeTemplate?: string;
 }
 
 export function formatMarkdown(
@@ -1669,7 +1704,14 @@ export function formatMarkdown(
 		? formatTranscriptSection(transcript, groups, headerLevel)
 		: '';
 	const parts: string[] = [
-		formatFrontmatter(recording, speakers, summary, options.keywords, options.folders),
+		formatFrontmatter(
+			recording,
+			speakers,
+			summary,
+			options.keywords,
+			options.folders,
+			options.datetimeTemplate,
+		),
 		'',
 		`# ${expandedTitle}`,
 		'',
@@ -1725,6 +1767,7 @@ export function formatPlaceholderMarkdown(
 	recording: Recording,
 	reason: string,
 	template: string = DEFAULT_NOTE_NAME_TEMPLATE,
+	datetimeTemplate: string = '',
 ): string {
 	const url = formatPlaudWebUrl(recording.id);
 	const expandedTitle = buildNoteName(
@@ -1738,6 +1781,13 @@ export function formatPlaceholderMarkdown(
 		`plaud-id: ${yamlScalar(recording.id)}`,
 		`plaud-url: ${yamlScalar(url)}`,
 		`date: ${formatDateYmd(recording.createdAt)}`,
+		// Match the real note's frontmatter (issue #32): emit datetime only when a
+		// template is configured, so a Dataview query sees the same shape on stubs.
+		...(datetimeTemplate.trim() !== ''
+			? [
+					`datetime: ${yamlScalar(formatDatetime(datetimeTemplate, recording.createdAt))}`,
+				]
+			: []),
 		'source: plaud',
 		// Marker that distinguishes this stub from a real note. extractPlaud-
 		// PlaceholderFlag keys on it so a later real import always replaces it.
@@ -1909,6 +1959,7 @@ export class NoteWriter {
 	private readonly outputFolder: string;
 	private readonly subfolderTemplate: string;
 	private readonly noteNameTemplate: string;
+	private readonly datetimeTemplate: string;
 	private readonly existingPathForPlaudId?: (plaudId: string) => string | null;
 	private readonly migrateExistingNote?: (
 		oldNotePath: string,
@@ -1945,6 +1996,7 @@ export class NoteWriter {
 			requestedTemplate && isValidNoteNameTemplate(requestedTemplate)
 				? requestedTemplate
 				: DEFAULT_NOTE_NAME_TEMPLATE;
+		this.datetimeTemplate = options.datetimeTemplate ?? '';
 		this.existingPathForPlaudId = options.existingPathForPlaudId;
 		this.migrateExistingNote = options.migrateExistingNote;
 		this.onDuplicate = options.onDuplicate;
@@ -1954,6 +2006,7 @@ export class NoteWriter {
 			includeSummary: options.includeSummary,
 			transcriptHeaderLevel: options.transcriptHeaderLevel,
 			noteNameTemplate: this.noteNameTemplate,
+			datetimeTemplate: this.datetimeTemplate,
 		};
 	}
 
@@ -2050,6 +2103,7 @@ export class NoteWriter {
 			recording,
 			reason,
 			this.noteNameTemplate,
+			this.datetimeTemplate,
 		);
 		const { existing, notePath } = this.findExistingNote(recording, targetPath);
 		if (existing === null) {


### PR DESCRIPTION
## Summary

Release A of the frontmatter-datetime / title-in-path work. Adds a user-configurable `datetime:` frontmatter property to imported notes (issue #32) and surfaces time tokens across the template fields.

- New `datetimeTemplate` setting drives a `datetime:` property via the same `{{ }}` Moment engine as the folder and note-name fields. Empty by default (writes no property); a non-empty template turns it on, mirroring the subfolder field's on/off model.
- `date:` stays frozen at `YYYY-MM-DD` for Dataview stability. `datetime:` is a separate additive property, so the time can be recorded in any format: 24h (`{{YYYY-MM-DD HH:mm}}`), 12h (`{{h:mm A}}`), or ISO 8601 with the UTC offset (`{{YYYY-MM-DDTHH:mm:ssZ}}`). Value is machine-local time, the same basis as `date:`.
- Time tokens (Hour, Minute, Second, AM/PM, Offset) added to the shared insert-token buttons, so they work in the subfolder and note-name templates too.
- New `formatDatetime` export is shared by the frontmatter builder and the settings live preview so both format identically. The `datetime:` line is also emitted in the placeholder-note path so stubs match real notes.

## Testing

- `npm run build` (tsc) clean
- `npm run lint` clean (eslint + obsidianmd ruleset + check-submission pre-filter)
- `npm test`: 839 passing, including new `formatFrontmatter` datetime cases (24h, 12h, ISO-with-offset shape, date/datetime ordering, off-when-empty)
- Codex pre-commit review: no findings

## Not yet validated

The real gate for this feature is a Dataview query parsing the emitted `datetime:` value in a live vault. That is a hands-on step, not covered by the unit tests.

## Review

CodeRabbit only on this PR (Copilot not requested), per the cost-management decision.