### PR TITLE
Add {{title}} subfolder token and configurable forbidden-char replacement (issue #30 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`{{title}}` in the subfolder template.** The subfolder setting now supports the `{{title}}` token, so you can file each recording in its own folder named after it (a "folder note" layout that pairs well with plugins like Notebook Navigator): `{{YYYY}}/{{title}}` files a July recording titled Team sync under `2026/Team sync`. The title has any leading date removed, the same as in the note name, so the folder and note names line up. A slash or backslash in a title is flattened to your replacement character so it stays a single folder instead of creating an accidental nested level, and a recording whose title is only a date files under `_untitled` rather than dropping into the output root. Resolves the follow-up on issue #30.
+- **Configurable forbidden-character replacement.** A new setting chooses the character that stands in for a slash, colon, or other character a file name or folder cannot contain (for example one that appears in a recording title). It defaults to a dash and applies to both note names and folder names. Set it to `_` or any other single safe character; the setting refuses a value that would itself be an illegal character.
+
 ## [0.22.1] - 2026-07-06
 
 ### Fixed

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -184,6 +184,18 @@ describe('sanitizeFilename', () => {
 		// A '$' replacement must not be read as a replacement-string special.
 		expect(sanitizeFilename('A/B', '$')).toBe('A$B');
 	});
+
+	it('falls back to a dash when given an unsafe replacement (defense-in-depth)', () => {
+		// An exported function must not trust its caller: an unsafe replacement
+		// (a forbidden char, separator, dot/space, control code, empty, or
+		// multi-char) would reintroduce what the sanitizer removes, so it coerces
+		// to '-' rather than emitting the unsafe value.
+		expect(sanitizeFilename('A/B', '/')).toBe('A-B');
+		expect(sanitizeFilename('A/B', '\\')).toBe('A-B');
+		expect(sanitizeFilename('A:B', '.')).toBe('A-B');
+		expect(sanitizeFilename('A|B', '')).toBe('A-B');
+		expect(sanitizeFilename('A|B', '__')).toBe('A-B');
+	});
 });
 
 describe('isValidReplacementChar', () => {

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -19,6 +19,7 @@ import {
 	formatTranscriptSection,
 	groupTranscriptByChapters,
 	isValidNoteNameTemplate,
+	isValidReplacementChar,
 	migrateLegacyDateTemplate,
 	mergeTagSources,
 	buildNoteTags,
@@ -171,6 +172,46 @@ describe('sanitizeFilename', () => {
 		expect(sanitizeFilename('nul.md')).toBe('_nul.md');
 		// A name whose base is not a device stays unchanged.
 		expect(sanitizeFilename('console.log')).toBe('console.log');
+	});
+
+	it('uses a configured replacement character instead of a dash', () => {
+		expect(sanitizeFilename('Q2: Review', '_')).toBe('Q2_ Review');
+		expect(sanitizeFilename('A/B test', '_')).toBe('A_B test');
+		expect(sanitizeFilename('foo|bar<baz>', '~')).toBe('foo~bar~baz~');
+	});
+
+	it('inserts a replacement containing $ literally (no regex back-reference)', () => {
+		// A '$' replacement must not be read as a replacement-string special.
+		expect(sanitizeFilename('A/B', '$')).toBe('A$B');
+	});
+});
+
+describe('isValidReplacementChar', () => {
+	it.each([['-'], ['_'], ['~'], ['+'], ['a'], ['9'], ['$'], ['@']])(
+		'accepts the safe single character %p',
+		(char) => {
+			expect(isValidReplacementChar(char)).toBe(true);
+		},
+	);
+
+	it.each([
+		['empty', ''],
+		['two characters', '--'],
+		['slash', '/'],
+		['backslash', '\\'],
+		['colon', ':'],
+		['asterisk', '*'],
+		['question mark', '?'],
+		['angle bracket', '<'],
+		['pipe', '|'],
+		['double quote', '"'],
+		['open bracket', '['],
+		['close bracket', ']'],
+		['dot', '.'],
+		['space', ' '],
+		['control char', '\x00'],
+	])('rejects %s', (_label, value) => {
+		expect(isValidReplacementChar(value)).toBe(false);
 	});
 });
 
@@ -700,6 +741,70 @@ describe('resolveSubfolder', () => {
 		expect(resolveSubfolder('{{Q}}', new Date(2026, 3, 1))).toBe('2'); // Apr
 		expect(resolveSubfolder('{{Q}}', jun4)).toBe('2'); // Jun
 		expect(resolveSubfolder('{{Q}}', new Date(2026, 11, 31))).toBe('4'); // Dec
+	});
+
+	// {{title}} support (issue #30 follow-up) for folder-note layouts.
+	it('expands {{title}} to the recording title', () => {
+		expect(resolveSubfolder('{{title}}', jun4, 'Team sync')).toBe('Team sync');
+		expect(resolveSubfolder('{{YYYY}}/{{title}}', jun4, 'Team sync')).toBe(
+			'2026/Team sync',
+		);
+	});
+
+	it('strips a leading date from a {{title}} folder, matching the note name', () => {
+		expect(resolveSubfolder('{{title}}', jun4, '06-04 Team sync')).toBe('Team sync');
+		expect(resolveSubfolder('{{title}}', jun4, '2026-06-04 Team sync')).toBe(
+			'Team sync',
+		);
+	});
+
+	it('flattens a slash or backslash in a title so it stays one folder', () => {
+		// A slash in a title must NOT create an extra nesting level; it is flattened
+		// to the replacement char before the path split.
+		expect(resolveSubfolder('{{title}}', jun4, 'Q3/Q4 sync')).toBe('Q3-Q4 sync');
+		// normalizeFolderPath turns a stray backslash into '/', so it is flattened
+		// too, before that conversion.
+		expect(resolveSubfolder('{{title}}', jun4, 'a\\b')).toBe('a-b');
+		// A literal '/' the user types between tokens still nests.
+		expect(resolveSubfolder('{{YYYY}}/{{title}}', jun4, 'A/B')).toBe('2026/A-B');
+	});
+
+	it('uses the configured replacement char for a flattened title separator', () => {
+		expect(resolveSubfolder('{{title}}', jun4, 'Q3/Q4', '_')).toBe('Q3_Q4');
+	});
+
+	it('sanitizes other forbidden characters in a {{title}} folder per segment', () => {
+		// A colon in the title is not a path separator, so the per-segment folder
+		// sanitizer rewrites it (to the replacement char) after the split.
+		expect(resolveSubfolder('{{title}}', jun4, 'Q2: review')).toBe('Q2- review');
+	});
+
+	it('does not throw on a title that is unusable as a raw folder segment', () => {
+		// Unlike an authored template literal, a recording title is data: a reserved
+		// device name, a trailing dot/space, or an over-length title must sanitize
+		// (like a filename) rather than throw and abort the import.
+		expect(resolveSubfolder('{{title}}', jun4, 'CON')).toBe('_CON');
+		expect(resolveSubfolder('{{title}}', jun4, 'Team sync.')).toBe('Team sync');
+		expect(resolveSubfolder('{{title}}', jun4, 'Team sync ')).toBe('Team sync');
+		expect(resolveSubfolder('{{title}}', jun4, 'x'.repeat(201))).toBe(
+			'x'.repeat(200),
+		);
+	});
+
+	it('buckets an empty-title folder to _untitled instead of collapsing', () => {
+		// A title that reduces to empty (only a date, blank, or only punctuation
+		// that sanitizes away) would otherwise resolve to '' and drop the note into
+		// the output root, or produce a folder literally named 'Untitled'.
+		expect(resolveSubfolder('{{title}}', jun4, '2026-06-04')).toBe('_untitled');
+		expect(resolveSubfolder('{{title}}', jun4, '')).toBe('_untitled');
+		expect(resolveSubfolder('{{title}}', jun4, '   ')).toBe('_untitled');
+		expect(resolveSubfolder('{{title}}', jun4, '.')).toBe('_untitled');
+		expect(resolveSubfolder('{{title}}', jun4, '...')).toBe('_untitled');
+	});
+
+	it('does not bucket a template that still has a date level around an empty title', () => {
+		// Only a fully-empty result buckets; a surviving date segment keeps nesting.
+		expect(resolveSubfolder('{{YYYY}}/{{title}}', jun4, '')).toBe('2026');
 	});
 });
 

--- a/main.ts
+++ b/main.ts
@@ -3173,7 +3173,7 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				this.plugin.settings.forbiddenCharReplacement = next;
 			} else {
 				new Notice(
-					"Plaud importer: The replacement must be a single character and cannot be a slash, colon, square bracket, asterisk, question mark, angle bracket, pipe, double quote, dot, or space. Keeping the previous value.",
+					"Plaud importer: The replacement must be a single character and cannot be a slash, backslash, colon, square bracket, asterisk, question mark, angle bracket, pipe, double quote, dot, space, or control character. Keeping the previous value.",
 				);
 				return;
 			}

--- a/main.ts
+++ b/main.ts
@@ -35,6 +35,7 @@ import {
 	resolveSubfolder,
 	buildNoteName,
 	formatDatetime,
+	isValidReplacementChar,
 	TEMPLATE_PREVIEW_DATE,
 	TEMPLATE_PREVIEW_DATETIME,
 	TEMPLATE_PREVIEW_TITLE,
@@ -150,7 +151,7 @@ const DEFAULT_RIBBON_ICON = "audio-lines";
 // at createEl/setDesc) so the obsidianmd sentence-case lint, which inspects
 // literal arguments, leaves the token examples and proper nouns alone.
 const SUBFOLDER_TEMPLATE_INTRO =
-	"Optional. Files each imported note into a subfolder of the output folder, built from the recording's own date. Leave empty to keep every note in one folder. Text inside {{ }} is a date format written in Moment style (the same syntax core Daily Notes uses); text outside the braces is kept as-is, and a forward slash (/) starts a new nested folder level, so {{YYYY}}/{{MM}} makes a year folder holding month folders. Separators like dashes and spaces are fine inside the braces; keep your own words (plain letters) outside them, since letters inside are read as date tokens.";
+	"Optional. Files each imported note into a subfolder of the output folder, built from the recording's own date. Leave empty to keep every note in one folder. Text inside {{ }} is a date format written in Moment style (the same syntax core Daily Notes uses); text outside the braces is kept as-is, and a forward slash (/) starts a new nested folder level, so {{YYYY}}/{{MM}} makes a year folder holding month folders. Separators like dashes and spaces are fine inside the braces; keep your own words (plain letters) outside them, since letters inside are read as date tokens. You can also use {{title}}, the recording title (with a leading date removed, the same as in the note name), to build folder-note layouts like {{YYYY}}/{{title}}. A slash inside a title is turned into your forbidden-character replacement so the title stays a single folder.";
 
 // [token, what it expands to] pairs. Real Moment format tokens (case matters).
 // The same vocabulary works in the note-name field, so a user learns it once.
@@ -162,17 +163,20 @@ const SUBFOLDER_TEMPLATE_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["{{dddd}}", "weekday name, for example Monday"],
 	["{{WW}}", "ISO week number, 01 to 53"],
 	["{{Q}}", "quarter, 1 to 4"],
+	["{{title}}", "the recording title, with a leading numeric date removed (for folder-note layouts)"],
 ];
 
-// [template, resulting folder] pairs for a June 4 2026 recording. Covers
-// nesting, a custom separator, a day-first order, week foldering, and two tokens
-// inside one {{ }}. Outputs verified against Moment 2.29.
+// [template, resulting folder] pairs for a June 4 2026 recording titled Team
+// sync. Covers nesting, a custom separator, a day-first order, week foldering,
+// two tokens inside one {{ }}, and a folder-note title layout. Outputs verified
+// against Moment 2.29.
 const SUBFOLDER_TEMPLATE_EXAMPLES: ReadonlyArray<readonly [string, string]> = [
 	["{{YYYY-MM}}", "2026-06 (one folder)"],
 	["{{YYYY}}/{{MM}}", "2026/06 (a 2026 folder holding a 06 folder)"],
 	["{{DD}}-{{MM}}-{{YYYY}}", "04-06-2026 (day-first order)"],
 	["{{YYYY}}/W{{WW}}", "2026/W23 (by week)"],
 	["{{YYYY}}/{{MM MMMM}}", "2026/06 June (two tokens in one {{ }})"],
+	["{{YYYY}}/{{title}}", "2026/Team sync (a folder per recording)"],
 ];
 
 const SUBFOLDER_TEMPLATE_TOKENS_HEADING =
@@ -222,6 +226,12 @@ const NOTE_NAME_TEMPLATE_EXAMPLES_HEADING = "Examples:";
 const NOTE_NAME_TEMPLATE_FOOTNOTE =
 	"Applies to new imports; notes you already imported keep their current names.";
 
+// Description for the forbidden-character replacement setting. Held in a const so
+// the declarative (1.13+) and imperative (1.12) settings paths show identical
+// text and the sentence-case lint inspects one literal.
+const FORBIDDEN_CHAR_REPLACEMENT_DESC =
+	"Character that replaces a slash, colon, or other character a file name or folder cannot contain, for example one that appears in a recording title. Must be a single character; the default is a dash.";
+
 // [label, template] preset buttons. All dashes, so every preset is filename-safe.
 // ISO/US/EU cover the common date orders; putting the date after {{title}} (the
 // "date at the end" example in the reference) is left to the user to type.
@@ -234,8 +244,8 @@ const NOTE_NAME_TEMPLATE_PRESETS: ReadonlyArray<readonly [string, string]> = [
 // [label, inserted token] for the insert-token buttons above each template
 // field. Labels are friendly names; clicking inserts the exact Moment token at
 // the cursor so the common path is typo-proof (bare letters typed by hand would
-// be read as tokens). The note-name field adds Title; the subfolder field does
-// not (a title in a path segment is surprising and folders are date-only).
+// be read as tokens). Both the note-name and subfolder fields add Title; the
+// subfolder uses it for folder-note layouts, flattening any slash in the title.
 const DATE_INSERT_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["Year", "{{YYYY}}"],
 	["Month #", "{{MM}}"],
@@ -322,6 +332,11 @@ interface PlaudImporterSettings {
 	// stays YYYY-MM-DD for Dataview, so the user can add the recording time in any
 	// format (24h, 12h, ISO 8601) without disturbing existing date queries.
 	datetimeTemplate: string;
+	// Single character that replaces a forbidden filename/folder character (the
+	// Windows-forbidden set, control codes, and brackets in a note name), and the
+	// path separators inside a {{title}} folder token. Default "-". Validated to a
+	// safe single char before saving (see isValidReplacementChar).
+	forbiddenCharReplacement: string;
 	onDuplicate: "skip" | "overwrite" | "prompt";
 	showRibbonIcon: boolean;
 	ribbonIcon: string;
@@ -380,6 +395,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	subfolderTemplate: "",
 	noteNameTemplate: DEFAULT_NOTE_NAME_TEMPLATE,
 	datetimeTemplate: "",
+	forbiddenCharReplacement: "-",
 	onDuplicate: "prompt",
 	showRibbonIcon: true,
 	ribbonIcon: DEFAULT_RIBBON_ICON,
@@ -724,6 +740,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			subfolderTemplate: this.settings.subfolderTemplate,
 			noteNameTemplate: this.settings.noteNameTemplate,
 			datetimeTemplate: this.settings.datetimeTemplate,
+			forbiddenCharReplacement: this.settings.forbiddenCharReplacement,
 			onDuplicate: this.settings.onDuplicate,
 			includeTranscript: this.settings.includeTranscript,
 			includeSummary: this.settings.defaultIncludeSummary,
@@ -810,8 +827,12 @@ export default class PlaudImporterPlugin extends Plugin {
 		new RenameRecordingModal(this.app, file.basename, (rawName) => {
 			// sanitizeFilename never returns empty (it falls back to "Untitled"),
 			// and the modal already rejects an empty entry, so there is no
-			// unusable-name case to handle here.
-			const sanitized = sanitizeFilename(rawName);
+			// unusable-name case to handle here. Uses the configured replacement
+			// character so a manual rename matches how imports sanitize names.
+			const sanitized = sanitizeFilename(
+				rawName,
+				this.settings.forbiddenCharReplacement,
+			);
 			// Obsidian represents the vault root as either "" or "/" depending on
 			// the call site; treat both as no-dir so a root note does not produce
 			// a leading-slash path like "/New name.md".
@@ -1560,6 +1581,17 @@ export default class PlaudImporterPlugin extends Plugin {
 		) {
 			this.settings.outputFolder = "Plaud";
 		}
+		// Repair a hand-edited or malformed replacement character back to the
+		// default dash, so every consumer (imports and the rename command) gets a
+		// safe single character. The settings UI validates on entry, but data.json
+		// could carry anything; an unsafe value (e.g. "/") would otherwise let
+		// sanitizing produce a path separator. NoteWriter also guards defensively.
+		if (
+			typeof this.settings.forbiddenCharReplacement !== "string" ||
+			!isValidReplacementChar(this.settings.forbiddenCharReplacement)
+		) {
+			this.settings.forbiddenCharReplacement = "-";
+		}
 		// v1 (issue #30): the date-template engine moved from bespoke lowercase
 		// tokens to real Moment. Rewrite the two stored templates once, output-
 		// preserving (see migrateLegacyDateTemplate), so an existing install's
@@ -2010,6 +2042,13 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				DATETIME_TEMPLATE_INTRO,
 			),
 		);
+		this.addTextRow(
+			containerEl,
+			"Forbidden character replacement",
+			FORBIDDEN_CHAR_REPLACEMENT_DESC,
+			"forbiddenCharReplacement",
+			"-",
+		);
 		this.addDropdownRow(
 			containerEl,
 			"Duplicate handling",
@@ -2454,7 +2493,10 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 		// the button/field closures, which only run on later user interaction.
 		let field: TextComponent | null = null;
 		let updatePreview: (template: string) => void = () => {};
-		for (const [label, token] of DATE_INSERT_TOKENS) {
+		// Date tokens plus Title: the subfolder now supports {{title}} for
+		// folder-note layouts (issue #30 follow-up), so it gets the same button set
+		// as the note-name field.
+		for (const [label, token] of [...DATE_INSERT_TOKENS, TITLE_INSERT_TOKEN]) {
 			setting.addButton((button) => {
 				button
 					.setButtonText(label)
@@ -2489,7 +2531,15 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				return "Preview: no subfolder (every note in the output folder)";
 			}
 			try {
-				return `Preview folder: ${resolveSubfolder(template, TEMPLATE_PREVIEW_DATE)}`;
+				// Pass the sample title so a {{title}} template previews with a real
+				// folder name, and the configured replacement char so the preview
+				// matches what an import would actually write.
+				return `Preview folder: ${resolveSubfolder(
+					template,
+					TEMPLATE_PREVIEW_DATE,
+					TEMPLATE_PREVIEW_TITLE,
+					this.plugin.settings.forbiddenCharReplacement,
+				)}`;
 			} catch (err) {
 				return `Preview (not usable): ${
 					err instanceof Error ? err.message : String(err)
@@ -2868,6 +2918,15 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 							this.renderDatetimeTemplateControl(setting),
 					},
 					{
+						name: "Forbidden character replacement",
+						desc: FORBIDDEN_CHAR_REPLACEMENT_DESC,
+						control: {
+							type: "text",
+							key: "forbiddenCharReplacement",
+							placeholder: "-",
+						},
+					},
+					{
 						name: "Duplicate handling",
 						desc: "What to do when a note for the recording already exists in the output folder.",
 						control: {
@@ -3096,9 +3155,26 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				// persisted. No Notice here: this field persists per keystroke, so a
 				// Notice would spam while ".." is mid-typed; the live preview already
 				// shows "(not usable)", and the previous good value stays saved.
-				resolveSubfolder(next, TEMPLATE_PREVIEW_DATE);
+				resolveSubfolder(next, TEMPLATE_PREVIEW_DATE, TEMPLATE_PREVIEW_TITLE);
 				this.plugin.settings.subfolderTemplate = next;
 			} catch {
+				return;
+			}
+		} else if (key === "forbiddenCharReplacement") {
+			// Coerce to a single safe character. Cleared field falls back to the
+			// default dash; an unsafe entry (a forbidden char, a separator, a dot or
+			// space, or more than one character) is refused with a Notice and the
+			// previous value is kept, so sanitizing can never reintroduce a
+			// forbidden character.
+			const next = typeof value === "string" ? value.trim() : "";
+			if (next === "") {
+				this.plugin.settings.forbiddenCharReplacement = "-";
+			} else if (isValidReplacementChar(next)) {
+				this.plugin.settings.forbiddenCharReplacement = next;
+			} else {
+				new Notice(
+					"Plaud importer: The replacement must be a single character and cannot be a slash, colon, square bracket, asterisk, question mark, angle bracket, pipe, double quote, dot, or space. Keeping the previous value.",
+				);
 				return;
 			}
 		} else if (key === "noteNameTemplate") {

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -140,6 +140,14 @@ export interface NoteWriterOptions {
 	 */
 	readonly datetimeTemplate?: string;
 	/**
+	 * Character that replaces a forbidden filename/folder character (the Windows
+	 * set plus control codes; brackets too in a note name). Defaults to '-'.
+	 * Applied to both the note name and each resolved subfolder segment, and to
+	 * the path separators inside an injected `{{title}}`. The settings layer
+	 * validates it is itself a safe single character before it is stored.
+	 */
+	readonly forbiddenCharReplacement?: string;
+	/**
 	 * Optional vault-wide lookup from a `plaud-id` to the path of an existing
 	 * note for that recording, anywhere under the output folder. Lets the
 	 * writer find a prior import that lives in a DIFFERENT subfolder (for
@@ -269,11 +277,32 @@ function isReservedDeviceName(name: string): boolean {
 const MAX_PATH_COMPONENT_LENGTH = 200;
 
 /**
+ * Whether a string is usable as the forbidden-character replacement. It must be
+ * a single character that does not itself reintroduce the problem the sanitizer
+ * fixes: not a forbidden filename/folder character, not a path separator, not a
+ * bracket (stripped from note names for wikilink safety), not a dot or space
+ * (Windows drops a trailing dot/space, recreating the very collision the
+ * sanitizer prevents), and not a control code. Empty fails. Shared by the
+ * settings validation and NoteWriter construction so both apply one rule.
+ */
+export function isValidReplacementChar(value: string): boolean {
+	if (value.length !== 1) {
+		return false;
+	}
+	// eslint-disable-next-line no-control-regex -- reject control codes as a replacement
+	return !/[<>:"/\\|?*[\]. \x00-\x1f]/.test(value);
+}
+
+/**
  * Sanitize a Plaud recording title into a filename that is legal on Windows,
  * macOS, and Linux and doesn't collide with Obsidian's wikilink parser.
  * Never throws, always returns a non-empty string.
  */
-export function sanitizeFilename(title: string): string {
+export function sanitizeFilename(
+	title: string,
+	replacement: string = '-',
+	emptyFallback: string = 'Untitled',
+): string {
 	// Strip leading/trailing whitespace first so subsequent length checks
 	// don't operate on padded input.
 	let out = title.trim();
@@ -285,11 +314,13 @@ export function sanitizeFilename(title: string): string {
 
 	// Now replace the Windows-forbidden chars, square brackets (wikilink
 	// collision), and any remaining non-whitespace control characters with
-	// dashes. Whitespace control chars like \t and \n were already handled
-	// by the step above, so what's left is things like NUL (\x00) and the
-	// other non-whitespace control codes.
+	// the configured replacement (default '-'). Whitespace control chars like
+	// \t and \n were already handled by the step above, so what's left is
+	// things like NUL (\x00) and the other non-whitespace control codes. A
+	// function replacer is used so a replacement containing `$` is inserted
+	// literally, not treated as a regex back-reference.
 	// eslint-disable-next-line no-control-regex -- intentional: this class strips NUL and other non-whitespace control codes from the filename
-	out = out.replace(/[<>:"/\\|?*\x00-\x08\x0b\x0c\x0e-\x1f[\]]/g, '-');
+	out = out.replace(/[<>:"/\\|?*\x00-\x08\x0b\x0c\x0e-\x1f[\]]/g, () => replacement);
 
 	// Strip trailing dots and spaces — Windows silently drops them from
 	// filenames, which causes "File.md" and "File .md" to collide.
@@ -312,9 +343,11 @@ export function sanitizeFilename(title: string): string {
 	}
 
 	// Empty-after-sanitization fallback. This can happen for titles that are
-	// entirely punctuation or whitespace.
+	// entirely punctuation or whitespace. Defaults to 'Untitled' (a note must have
+	// a name); the subfolder path passes '' so an empty title falls through to the
+	// _untitled bucket instead of a folder literally named 'Untitled'.
 	if (out.length === 0) {
-		out = 'Untitled';
+		out = emptyFallback;
 	}
 
 	return out;
@@ -455,9 +488,10 @@ function formatDateYmd(d: Date): string {
  *
  * Moment formats in LOCAL time, the same calendar basis as formatDateYmd, so a
  * note name, its subfolder, and the `date:` frontmatter never disagree about
- * which day a recording belongs to. When `title` is provided (the note-name
- * path) a `{{title}}` token is replaced with it BEFORE the Moment call; the
- * subfolder path passes no title, so `{{title}}` is not special there.
+ * which day a recording belongs to. When `title` is provided a `{{title}}` token
+ * is replaced with it BEFORE the Moment call. Both the note-name and the subfolder
+ * paths pass a title (the subfolder flattens its path separators first); a caller
+ * that passes no title gets no `{{title}}` substitution.
  *
  * The formatter is pinned to the English locale. Obsidian's `moment` otherwise
  * follows the app's display language, which would make `{{MMMM}}`/`{{dddd}}`
@@ -508,9 +542,11 @@ export function formatDatetime(template: string, date: Date): string {
  * intentionally excluded: the caller splits on it, so a segment never contains
  * one.
  */
-function sanitizeFolderSegment(segment: string): string {
+function sanitizeFolderSegment(segment: string, replacement: string = '-'): string {
+	// A function replacer inserts the replacement literally even when it contains
+	// a `$` (which would otherwise be read as a regex back-reference).
 	// eslint-disable-next-line no-control-regex -- intentional: strip ASCII control codes a folder segment cannot hold
-	return segment.replace(/[<>:"\\|?*\x00-\x1f]/g, '-');
+	return segment.replace(/[<>:"\\|?*\x00-\x1f]/g, () => replacement);
 }
 
 /**
@@ -574,7 +610,12 @@ function assertUsableFolderSegment(segment: string): string {
  *    rejected (assertUsableFolderSegment throws), rather than silently rewritten,
  *    so the settings guard refuses the template instead of relocating a folder.
  */
-export function resolveSubfolder(template: string, date: Date): string {
+export function resolveSubfolder(
+	template: string,
+	date: Date,
+	title?: string,
+	replacement: string = '-',
+): string {
 	if (template.trim() === '') {
 		return '';
 	}
@@ -582,12 +623,39 @@ export function resolveSubfolder(template: string, date: Date): string {
 	if (!dateValid && /\{\{[^}]*\}\}/.test(template)) {
 		return '_undated';
 	}
-	return normalizeFolderPath(expandDateTemplate(template, date))
+	// {{title}} support (issue #30 follow-up): strip a leading date from the title
+	// (parity with the note name, which also uses titleWithoutLeadingDate), then
+	// sanitize it into a single legal folder segment with the configured
+	// replacement. sanitizeFilename flattens path separators (so a title slash
+	// cannot add a folder level), rewrites other forbidden characters, prefixes a
+	// reserved device name, strips a trailing dot/space, and clamps the length, so
+	// an arbitrary recording title can never make assertUsableFolderSegment throw
+	// and abort the import; only authored template literals should be refused. An
+	// empty result (a title that was only a date) is kept empty so the _untitled
+	// bucket below fires, not sanitizeFilename's 'Untitled' fallback.
+	let safeTitle: string | undefined;
+	if (title !== undefined) {
+		// emptyFallback '' so a title that reduces to nothing (only a date, or only
+		// punctuation like '.') yields an empty segment for the _untitled bucket
+		// below, instead of sanitizeFilename's 'Untitled' fallback.
+		safeTitle = sanitizeFilename(titleWithoutLeadingDate(title), replacement, '');
+	}
+	const resolved = normalizeFolderPath(expandDateTemplate(template, date, safeTitle))
 		.split('/')
 		// Drop empty/whitespace-only segments so nesting stays as authored.
 		.filter((segment) => segment.trim() !== '')
-		.map((segment) => assertUsableFolderSegment(sanitizeFolderSegment(segment)))
+		.map((segment) =>
+			assertUsableFolderSegment(sanitizeFolderSegment(segment, replacement)),
+		)
 		.join('/');
+	// Empty-title bucket: a template that is only {{title}} (or otherwise renders
+	// entirely empty because the title stripped to nothing) would collapse to no
+	// subfolder, silently dropping the note into the output root. Bucket it,
+	// mirroring _undated, so the nesting the user asked for stays intentional.
+	if (resolved === '' && /\{\{\s*title\s*}}/.test(template)) {
+		return '_untitled';
+	}
+	return resolved;
 }
 
 /**
@@ -1960,6 +2028,7 @@ export class NoteWriter {
 	private readonly subfolderTemplate: string;
 	private readonly noteNameTemplate: string;
 	private readonly datetimeTemplate: string;
+	private readonly forbiddenCharReplacement: string;
 	private readonly existingPathForPlaudId?: (plaudId: string) => string | null;
 	private readonly migrateExistingNote?: (
 		oldNotePath: string,
@@ -1997,6 +2066,14 @@ export class NoteWriter {
 				? requestedTemplate
 				: DEFAULT_NOTE_NAME_TEMPLATE;
 		this.datetimeTemplate = options.datetimeTemplate ?? '';
+		// Defense-in-depth: the settings layer validates this, but a headless caller
+		// or hand-edited data.json could pass anything, so fall back to '-' for an
+		// unusable value rather than sanitizing with a forbidden character.
+		this.forbiddenCharReplacement = isValidReplacementChar(
+			options.forbiddenCharReplacement ?? '',
+		)
+			? (options.forbiddenCharReplacement as string)
+			: '-';
 		this.existingPathForPlaudId = options.existingPathForPlaudId;
 		this.migrateExistingNote = options.migrateExistingNote;
 		this.onDuplicate = options.onDuplicate;
@@ -2016,7 +2093,12 @@ export class NoteWriter {
 	 * writePlaceholderNote so both land a recording at the exact same path.
 	 */
 	private async resolveTargetPath(recording: Recording): Promise<string> {
-		const subfolder = resolveSubfolder(this.subfolderTemplate, recording.createdAt);
+		const subfolder = resolveSubfolder(
+			this.subfolderTemplate,
+			recording.createdAt,
+			recording.title,
+			this.forbiddenCharReplacement,
+		);
 		const destinationFolder = joinFolderPath(this.outputFolder, subfolder);
 		await this.ensureFolder(destinationFolder);
 		const expandedTitle = buildNoteName(
@@ -2024,7 +2106,7 @@ export class NoteWriter {
 			recording.createdAt,
 			this.noteNameTemplate,
 		);
-		const filename = `${sanitizeFilename(expandedTitle)}.md`;
+		const filename = `${sanitizeFilename(expandedTitle, this.forbiddenCharReplacement)}.md`;
 		return destinationFolder === '' ? filename : `${destinationFolder}/${filename}`;
 	}
 

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -303,6 +303,13 @@ export function sanitizeFilename(
 	replacement: string = '-',
 	emptyFallback: string = 'Untitled',
 ): string {
+	// Defense-in-depth: this function is exported and also sanitizes an injected
+	// {{title}} before resolveSubfolder splits on '/', so it must not trust an
+	// unsafe replacement. A forbidden char, separator, dot/space, or control code
+	// would reintroduce exactly what the sanitizer removes; fall back to '-'.
+	// Production callers already pass a settings-validated char (this guards any
+	// other caller). Applied to sanitizeFolderSegment too.
+	const repl = isValidReplacementChar(replacement) ? replacement : '-';
 	// Strip leading/trailing whitespace first so subsequent length checks
 	// don't operate on padded input.
 	let out = title.trim();
@@ -320,7 +327,7 @@ export function sanitizeFilename(
 	// function replacer is used so a replacement containing `$` is inserted
 	// literally, not treated as a regex back-reference.
 	// eslint-disable-next-line no-control-regex -- intentional: this class strips NUL and other non-whitespace control codes from the filename
-	out = out.replace(/[<>:"/\\|?*\x00-\x08\x0b\x0c\x0e-\x1f[\]]/g, () => replacement);
+	out = out.replace(/[<>:"/\\|?*\x00-\x08\x0b\x0c\x0e-\x1f[\]]/g, () => repl);
 
 	// Strip trailing dots and spaces — Windows silently drops them from
 	// filenames, which causes "File.md" and "File .md" to collide.
@@ -543,10 +550,13 @@ export function formatDatetime(template: string, date: Date): string {
  * one.
  */
 function sanitizeFolderSegment(segment: string, replacement: string = '-'): string {
+	// Defense-in-depth, matching sanitizeFilename: never trust an unsafe
+	// replacement, which would reintroduce a forbidden character; fall back to '-'.
+	const repl = isValidReplacementChar(replacement) ? replacement : '-';
 	// A function replacer inserts the replacement literally even when it contains
 	// a `$` (which would otherwise be read as a regex back-reference).
 	// eslint-disable-next-line no-control-regex -- intentional: strip ASCII control codes a folder segment cannot hold
-	return segment.replace(/[<>:"\\|?*\x00-\x1f]/g, () => replacement);
+	return segment.replace(/[<>:"\\|?*\x00-\x1f]/g, () => repl);
 }
 
 /**


### PR DESCRIPTION
## Summary

Release B: two coupled changes for folder-note layouts and safer name sanitization.

- **`{{title}}` in the subfolder template.** File each recording in its own folder named after it (`{{YYYY}}/{{title}}`). The title has its leading date stripped (parity with the note name) and is sanitized into a single legal folder segment: path separators are flattened, forbidden characters replaced, reserved device names prefixed, trailing dot/space stripped, and length clamped, so an arbitrary recording title can never abort folder resolution. A title that reduces to empty files under `_untitled` instead of collapsing into the output root. Resolves the follow-up on issue #30.
- **Configurable forbidden-character replacement.** A new setting (default `-`) chooses the stand-in for a character a file name or folder cannot hold, applied to both note names and folders. Validated to a safe single char via `isValidReplacementChar`, enforced in the settings UI, coerced on load (a hand-edited `data.json` cannot feed an unsafe char to the rename command or imports), and guarded again in the `NoteWriter` constructor.

Under the hood: `sanitizeFilename` and `sanitizeFolderSegment` take a `replacement` param (function replacer, so a `$` is literal) plus an `emptyFallback` param; `resolveSubfolder` takes an optional title and replacement.

## Testing

- `npm run build` (tsc) clean
- `npm run lint` clean (eslint + obsidianmd + check-submission)
- `npm test`: 874 passing, including new `{{title}}` subfolder cases (leading-date strip, slash/backslash flatten, custom char, `_untitled` bucket, reserved/trailing-dot/over-length titles), `isValidReplacementChar`, and configurable-char `sanitizeFilename` cases
- Codex pre-commit review: clean after fixes for title-segment assertion aborts, the rename-path validation gap, and preview/import char desync

## Not yet validated

Hands-on: a `{{title}}` subfolder import with a title containing a `/` and a leading date, and a custom replacement char, in a live vault.

## Review

CodeRabbit review requested (Copilot auto-reviews at the repo level).