### PR TITLE
Fix Cassette tape ribbon icon id (issue #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- The "Cassette tape" ribbon icon option now shows an icon instead of disappearing. It referenced a Lucide icon id (`tape`) that does not exist; the correct id is `cassette-tape`. Selecting it left the ribbon with no icon. Resolves issue #34.
+
 ## [0.22.0] - 2026-07-06
 
 ### Added

--- a/main.ts
+++ b/main.ts
@@ -136,7 +136,7 @@ const RIBBON_ICON_CHOICES: ReadonlyArray<{ id: string; label: string }> = [
 	{ id: "file-audio-2", label: "Audio file" },
 	{ id: "podcast", label: "Podcast" },
 	{ id: "radio", label: "Radio" },
-	{ id: "tape", label: "Cassette tape" },
+	{ id: "cassette-tape", label: "Cassette tape" },
 	{ id: "volume-2", label: "Speaker" },
 	{ id: "notebook-pen", label: "Notebook" },
 	{ id: "captions", label: "Captions" },


### PR DESCRIPTION
## Summary

The "Cassette tape" ribbon icon option used the Lucide id `tape`, which does not exist in Lucide. `setIcon` with an unknown id renders nothing, so selecting that option left the ribbon with no icon. Corrected to `cassette-tape`.

Resolves #34.

## Verification

Verified every id in `RIBBON_ICON_CHOICES` against the Lucide registry over the network (lucide-static, following redirects):

| id | result |
|---|---|
| `tape` | 404 — does not exist |
| `cassette-tape` | 200 — exists (the fix) |
| audio-lines, mic, mic-vocal, headphones, file-audio-2, podcast, radio, volume-2, notebook-pen, captions, users-round | 200 — all exist |

Only `tape` was wrong.

Caveat: this checks Lucide's current release; Obsidian pins its own Lucide version. For the reporter's Obsidian 1.12.7 these are safe, and the icon picker's live preview renders each option, so a bad id shows as a blank preview. The definitive check is Obsidian itself.

Note: this list is a hand-curated set of external identifiers with no automated validation — a jest test can't verify icon ids without Obsidian's runtime `getIconIds()`. That gap is why the wrong id shipped originally (commit 62cc2af, 2026-04-21). Flagging it; a CI check that validates the list against Lucide would prevent recurrence.

## Testing

- `npm run build` (tsc) clean
- `npm run lint` clean
- `npm test`: 841 passing (no behavior change to tested code; this is a one-line data fix)

## Review

CodeRabbit review requested.