### PR TITLE
Add {{plaud-folder}} subfolder token (issue #16 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`{{plaud-folder}}` in the subfolder template.** The subfolder setting now supports a `{{plaud-folder}}` token that expands to the recording's Plaud folder name, so `{{plaud-folder}}/{{YYYY}}` mirrors your Plaud folders into the vault tree (nice with a folder browser like Notebook Navigator). Plaud folders are flat, so a slash in a folder name is flattened to your replacement character rather than creating a nested level, and a recording with no Plaud folder files under `_unfiled`. A recording in more than one Plaud folder uses the first. Follows up on the `plaud-folder` frontmatter field from 0.19.0 (issue #16).
+
 ## [0.23.0] - 2026-07-06
 
 ### Added

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -818,6 +818,43 @@ describe('resolveSubfolder', () => {
 		// Only a fully-empty result buckets; a surviving date segment keeps nesting.
 		expect(resolveSubfolder('{{YYYY}}/{{title}}', jun4, '')).toBe('2026');
 	});
+
+	// {{plaud-folder}} support (issue #16 follow-up): the 5th arg is the folder.
+	it('expands {{plaud-folder}} to the Plaud folder name', () => {
+		expect(resolveSubfolder('{{plaud-folder}}', jun4, undefined, '-', 'Meetings')).toBe(
+			'Meetings',
+		);
+		expect(
+			resolveSubfolder('{{plaud-folder}}/{{YYYY}}', jun4, undefined, '-', 'Meetings'),
+		).toBe('Meetings/2026');
+	});
+
+	it('flattens a slash in a folder name and sanitizes forbidden characters', () => {
+		// Plaud folders are flat, so a '/' in a name is literal text, flattened to
+		// the replacement rather than treated as a nesting level.
+		expect(resolveSubfolder('{{plaud-folder}}', jun4, undefined, '-', 'Q3/Q4')).toBe(
+			'Q3-Q4',
+		);
+		expect(resolveSubfolder('{{plaud-folder}}', jun4, undefined, '_', 'A:B')).toBe(
+			'A_B',
+		);
+	});
+
+	it('buckets an unfiled recording (empty folder) to _unfiled', () => {
+		expect(resolveSubfolder('{{plaud-folder}}', jun4, undefined, '-', '')).toBe(
+			'_unfiled',
+		);
+		// A surviving date level keeps nesting instead of bucketing.
+		expect(
+			resolveSubfolder('{{YYYY}}/{{plaud-folder}}', jun4, undefined, '-', ''),
+		).toBe('2026');
+	});
+
+	it('combines {{plaud-folder}} and {{title}} in one template', () => {
+		expect(
+			resolveSubfolder('{{plaud-folder}}/{{title}}', jun4, 'Team sync', '-', 'Meetings'),
+		).toBe('Meetings/Team sync');
+	});
 });
 
 // migrateLegacyDateTemplate -------------------------------------------------
@@ -2239,6 +2276,56 @@ describe('NoteWriter', () => {
 			expect(outcome.status).toBe('skipped');
 			expect(outcome.path).toBe(OLD);
 			expect(migrateCalls).toEqual([]);
+		});
+	});
+
+	describe('{{plaud-folder}} unfiled placeholder migrates to the real folder', () => {
+		it('files a stub under _unfiled, then moves it to the Plaud folder on the real import', async () => {
+			const vault = makeFakeVault();
+			vault.folders.add('Plaud');
+			const migrateCalls: Array<[string, string]> = [];
+			const unfiledPath = 'Plaud/_unfiled/2026-04-14 Morning standup.md';
+			const filedPath = 'Plaud/Meetings/2026-04-14 Morning standup.md';
+			const writer = new NoteWriter(vault, {
+				outputFolder: 'Plaud',
+				subfolderTemplate: '{{plaud-folder}}',
+				onDuplicate: 'overwrite',
+				// Vault-wide plaud-id lookup, as the plugin injects: return wherever
+				// the note for this recording currently lives.
+				existingPathForPlaudId: (id) =>
+					id === 'abc123'
+						? [...vault.files.keys()].find((p) =>
+								p.endsWith('Morning standup.md'),
+							) ?? null
+						: null,
+				migrateExistingNote: async (oldPath, newPath) => {
+					migrateCalls.push([oldPath, newPath]);
+					const c = vault.files.get(oldPath) ?? '';
+					vault.files.delete(oldPath);
+					vault.files.set(newPath, c);
+				},
+			});
+
+			// 1. Transcript/summary not ready: a placeholder is written. The error
+			// path resolves no folder names, so it lands in _unfiled.
+			const stub = await writer.writePlaceholderNote(makeRecording(), 'no content yet');
+			expect(stub.status).toBe('created');
+			expect(stub.path).toBe(unfiledPath);
+
+			// 2. The real import arrives with the resolved Plaud folder. The target is
+			// now the Meetings folder; the writer finds the _unfiled stub by plaud-id
+			// and migrates it before overwriting, so the note is not duplicated.
+			const outcome = await writer.writeNote(
+				makeRecording(),
+				makeTranscript(),
+				makeSummary(),
+				undefined,
+				{ folders: ['Meetings'] },
+			);
+			expect(migrateCalls).toEqual([[unfiledPath, filedPath]]);
+			expect(outcome.path).toBe(filedPath);
+			expect(vault.files.has(filedPath)).toBe(true);
+			expect(vault.files.has(unfiledPath)).toBe(false);
 		});
 	});
 

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -840,14 +840,18 @@ describe('resolveSubfolder', () => {
 		);
 	});
 
-	it('buckets an unfiled recording (empty folder) to _unfiled', () => {
+	it('expands an unfiled recording (empty folder) to a literal _unfiled segment', () => {
 		expect(resolveSubfolder('{{plaud-folder}}', jun4, undefined, '-', '')).toBe(
 			'_unfiled',
 		);
-		// A surviving date level keeps nesting instead of bucketing.
+		// _unfiled expands inline wherever the token sits, so unfiled recordings are
+		// visibly grouped instead of mixing into the sibling date level.
 		expect(
 			resolveSubfolder('{{YYYY}}/{{plaud-folder}}', jun4, undefined, '-', ''),
-		).toBe('2026');
+		).toBe('2026/_unfiled');
+		expect(
+			resolveSubfolder('{{plaud-folder}}/{{YYYY}}', jun4, undefined, '-', ''),
+		).toBe('_unfiled/2026');
 	});
 
 	it('combines {{plaud-folder}} and {{title}} in one template', () => {
@@ -2326,6 +2330,29 @@ describe('NoteWriter', () => {
 			expect(outcome.path).toBe(filedPath);
 			expect(vault.files.has(filedPath)).toBe(true);
 			expect(vault.files.has(unfiledPath)).toBe(false);
+		});
+
+		it('uses only the first folder when a recording is in multiple Plaud folders', async () => {
+			const vault = makeFakeVault();
+			vault.folders.add('Plaud');
+			const writer = new NoteWriter(vault, {
+				outputFolder: 'Plaud',
+				subfolderTemplate: '{{plaud-folder}}',
+				onDuplicate: 'skip',
+			});
+
+			const outcome = await writer.writeNote(
+				makeRecording(),
+				makeTranscript(),
+				makeSummary(),
+				undefined,
+				{ folders: ['A', 'B'] },
+			);
+
+			// The first folder wins; the second is ignored (Plaud recordings are
+			// normally single-folder).
+			expect(outcome.path).toBe('Plaud/A/2026-04-14 Morning standup.md');
+			expect(vault.files.has('Plaud/A/2026-04-14 Morning standup.md')).toBe(true);
 		});
 	});
 

--- a/main.ts
+++ b/main.ts
@@ -155,7 +155,9 @@ const SUBFOLDER_TEMPLATE_INTRO =
 	"Optional. Files each imported note into a subfolder of the output folder, built from the recording's own date. Leave empty to keep every note in one folder. Text inside {{ }} is a date format written in Moment style (the same syntax core Daily Notes uses); text outside the braces is kept as-is, and a forward slash (/) starts a new nested folder level, so {{YYYY}}/{{MM}} makes a year folder holding month folders. Separators like dashes and spaces are fine inside the braces; keep your own words (plain letters) outside them, since letters inside are read as date tokens. You can also use {{title}}, the recording title (with a leading date removed, the same as in the note name), to build folder-note layouts like {{YYYY}}/{{title}}. A slash inside a title is turned into your forbidden-character replacement so the title stays a single folder. {{plaud-folder}} is the recording's Plaud folder name, so {{plaud-folder}}/{{YYYY}} mirrors your Plaud folders into the vault; a recording with no Plaud folder files under _unfiled.";
 
 // [token, what it expands to] pairs. Real Moment format tokens (case matters).
-// The same vocabulary works in the note-name field, so a user learns it once.
+// The date and {{title}} tokens also work in the note-name field, so a user
+// learns them once; {{plaud-folder}} is subfolder-only (a folder name in a
+// per-note file name is surprising).
 const SUBFOLDER_TEMPLATE_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["{{YYYY}}", "year, for example 2026"],
 	["{{MM}}", "month, 01 to 12"],

--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,7 @@ import {
 	TEMPLATE_PREVIEW_DATE,
 	TEMPLATE_PREVIEW_DATETIME,
 	TEMPLATE_PREVIEW_TITLE,
+	TEMPLATE_PREVIEW_FOLDER,
 	sanitizeFilename,
 	type RenameFileFn,
 	type TagMode,
@@ -151,7 +152,7 @@ const DEFAULT_RIBBON_ICON = "audio-lines";
 // at createEl/setDesc) so the obsidianmd sentence-case lint, which inspects
 // literal arguments, leaves the token examples and proper nouns alone.
 const SUBFOLDER_TEMPLATE_INTRO =
-	"Optional. Files each imported note into a subfolder of the output folder, built from the recording's own date. Leave empty to keep every note in one folder. Text inside {{ }} is a date format written in Moment style (the same syntax core Daily Notes uses); text outside the braces is kept as-is, and a forward slash (/) starts a new nested folder level, so {{YYYY}}/{{MM}} makes a year folder holding month folders. Separators like dashes and spaces are fine inside the braces; keep your own words (plain letters) outside them, since letters inside are read as date tokens. You can also use {{title}}, the recording title (with a leading date removed, the same as in the note name), to build folder-note layouts like {{YYYY}}/{{title}}. A slash inside a title is turned into your forbidden-character replacement so the title stays a single folder.";
+	"Optional. Files each imported note into a subfolder of the output folder, built from the recording's own date. Leave empty to keep every note in one folder. Text inside {{ }} is a date format written in Moment style (the same syntax core Daily Notes uses); text outside the braces is kept as-is, and a forward slash (/) starts a new nested folder level, so {{YYYY}}/{{MM}} makes a year folder holding month folders. Separators like dashes and spaces are fine inside the braces; keep your own words (plain letters) outside them, since letters inside are read as date tokens. You can also use {{title}}, the recording title (with a leading date removed, the same as in the note name), to build folder-note layouts like {{YYYY}}/{{title}}. A slash inside a title is turned into your forbidden-character replacement so the title stays a single folder. {{plaud-folder}} is the recording's Plaud folder name, so {{plaud-folder}}/{{YYYY}} mirrors your Plaud folders into the vault; a recording with no Plaud folder files under _unfiled.";
 
 // [token, what it expands to] pairs. Real Moment format tokens (case matters).
 // The same vocabulary works in the note-name field, so a user learns it once.
@@ -164,6 +165,7 @@ const SUBFOLDER_TEMPLATE_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["{{WW}}", "ISO week number, 01 to 53"],
 	["{{Q}}", "quarter, 1 to 4"],
 	["{{title}}", "the recording title, with a leading numeric date removed (for folder-note layouts)"],
+	["{{plaud-folder}}", "the recording's Plaud folder name (or _unfiled when it has none)"],
 ];
 
 // [template, resulting folder] pairs for a June 4 2026 recording titled Team
@@ -177,6 +179,7 @@ const SUBFOLDER_TEMPLATE_EXAMPLES: ReadonlyArray<readonly [string, string]> = [
 	["{{YYYY}}/W{{WW}}", "2026/W23 (by week)"],
 	["{{YYYY}}/{{MM MMMM}}", "2026/06 June (two tokens in one {{ }})"],
 	["{{YYYY}}/{{title}}", "2026/Team sync (a folder per recording)"],
+	["{{plaud-folder}}/{{YYYY}}", "Meetings/2026 (mirror the Plaud folder)"],
 ];
 
 const SUBFOLDER_TEMPLATE_TOKENS_HEADING =
@@ -264,6 +267,10 @@ const DATE_INSERT_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	["Offset", "{{Z}}"],
 ];
 const TITLE_INSERT_TOKEN: readonly [string, string] = ["Title", "{{title}}"];
+// Subfolder-only: the recording's Plaud folder name, for mirroring Plaud folders
+// into the vault tree. Not offered on the note-name field (a folder name in a
+// per-note file name is surprising).
+const FOLDER_INSERT_TOKEN: readonly [string, string] = ["Folder", "{{plaud-folder}}"];
 
 // Datetime-template documentation for the `datetime:` frontmatter field (issue
 // #32). Mirrors the subfolder field's Moment-only shape (no {{title}}, no
@@ -2493,10 +2500,15 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 		// the button/field closures, which only run on later user interaction.
 		let field: TextComponent | null = null;
 		let updatePreview: (template: string) => void = () => {};
-		// Date tokens plus Title: the subfolder now supports {{title}} for
-		// folder-note layouts (issue #30 follow-up), so it gets the same button set
-		// as the note-name field.
-		for (const [label, token] of [...DATE_INSERT_TOKENS, TITLE_INSERT_TOKEN]) {
+		// Date tokens plus Title and Folder: the subfolder supports {{title}} for
+		// folder-note layouts (issue #30 follow-up) and {{plaud-folder}} for
+		// mirroring Plaud folders (issue #16 follow-up), so it gets the date button
+		// set plus both.
+		for (const [label, token] of [
+			...DATE_INSERT_TOKENS,
+			TITLE_INSERT_TOKEN,
+			FOLDER_INSERT_TOKEN,
+		]) {
 			setting.addButton((button) => {
 				button
 					.setButtonText(label)
@@ -2531,14 +2543,15 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				return "Preview: no subfolder (every note in the output folder)";
 			}
 			try {
-				// Pass the sample title so a {{title}} template previews with a real
-				// folder name, and the configured replacement char so the preview
-				// matches what an import would actually write.
+				// Pass the sample title and folder so {{title}} and {{plaud-folder}}
+				// templates preview with real names, and the configured replacement
+				// char so the preview matches what an import would actually write.
 				return `Preview folder: ${resolveSubfolder(
 					template,
 					TEMPLATE_PREVIEW_DATE,
 					TEMPLATE_PREVIEW_TITLE,
 					this.plugin.settings.forbiddenCharReplacement,
+					TEMPLATE_PREVIEW_FOLDER,
 				)}`;
 			} catch (err) {
 				return `Preview (not usable): ${
@@ -3155,7 +3168,13 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				// persisted. No Notice here: this field persists per keystroke, so a
 				// Notice would spam while ".." is mid-typed; the live preview already
 				// shows "(not usable)", and the previous good value stays saved.
-				resolveSubfolder(next, TEMPLATE_PREVIEW_DATE, TEMPLATE_PREVIEW_TITLE);
+				resolveSubfolder(
+					next,
+					TEMPLATE_PREVIEW_DATE,
+					TEMPLATE_PREVIEW_TITLE,
+					this.plugin.settings.forbiddenCharReplacement,
+					TEMPLATE_PREVIEW_FOLDER,
+				);
 				this.plugin.settings.subfolderTemplate = next;
 			} catch {
 				return;

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -662,11 +662,15 @@ export function resolveSubfolder(
 	// {{plaud-folder}} support (issue #16 follow-up): the recording's Plaud folder
 	// name, sanitized into one legal segment the same way as {{title}}. Plaud
 	// folders are flat (plaud-client.ts: no parent_id), so a '/' in a folder name
-	// is literal text and is flattened, not treated as nesting. Empty (an unfiled
-	// recording) yields '' so the _unfiled bucket below fires.
+	// is literal text and is flattened, not treated as nesting. An unfiled
+	// recording (empty folder) expands to the literal _unfiled segment, so the
+	// token ALWAYS produces a visible bucket wherever it sits — {{plaud-folder}}
+	// alone -> _unfiled, {{plaud-folder}}/{{YYYY}} -> _unfiled/2026 — instead of
+	// dropping the empty segment and mixing unfiled recordings into the sibling
+	// levels. Mirrors the _undated bucket for a missing date.
 	let safeFolder: string | undefined;
 	if (folder !== undefined) {
-		safeFolder = sanitizeFilename(folder, replacement, '');
+		safeFolder = sanitizeFilename(folder, replacement, '') || '_unfiled';
 	}
 	const resolved = normalizeFolderPath(
 		expandDateTemplate(template, date, safeTitle, safeFolder),
@@ -678,18 +682,12 @@ export function resolveSubfolder(
 			assertUsableFolderSegment(sanitizeFolderSegment(segment, replacement)),
 		)
 		.join('/');
-	// Empty-value buckets: a template that renders entirely empty because its only
-	// dynamic token (a folder or title that reduced to nothing) was empty would
-	// collapse to no subfolder, silently dropping the note into the output root.
-	// Bucket it, mirroring _undated, so the nesting the user asked for stays
-	// intentional. plaud-folder is checked first as the primary grouping.
-	if (resolved === '') {
-		if (/\{\{\s*plaud-folder\s*}}/.test(template)) {
-			return '_unfiled';
-		}
-		if (/\{\{\s*title\s*}}/.test(template)) {
-			return '_untitled';
-		}
+	// Empty-title bucket: a {{title}}-only template whose title reduced to nothing
+	// would collapse to no subfolder, silently dropping the note into the output
+	// root. Bucket it, mirroring _undated. (The folder token handles its own empty
+	// case inline above, so it needs no bucket here.)
+	if (resolved === '' && /\{\{\s*title\s*}}/.test(template)) {
+		return '_untitled';
 	}
 	return resolved;
 }
@@ -2128,7 +2126,13 @@ export class NoteWriter {
 	/**
 	 * Resolve the per-recording destination path (folder + sanitized filename),
 	 * creating the destination folder if needed. Shared by writeNote and
-	 * writePlaceholderNote so both land a recording at the exact same path.
+	 * writePlaceholderNote. Both land a recording at the same path for a given set
+	 * of inputs; the one input that can differ between them is the Plaud folder
+	 * names, which writeNote passes and the placeholder path (an error path that
+	 * has not resolved them) does not — so a {{plaud-folder}} template can file a
+	 * placeholder under _unfiled and the later real note under its folder. The
+	 * cross-folder dedup (existingPathForPlaudId + migrateExistingNote) reconciles
+	 * that by migrating the stub to the real path on the successful import.
 	 */
 	private async resolveTargetPath(
 		recording: Recording,

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -507,7 +507,12 @@ function formatDateYmd(d: Date): string {
  * output-preserving even for a user on a non-English Obsidian UI, and keeps
  * names stable and filename-safe regardless of language.
  */
-function expandDateTemplate(template: string, date: Date, title?: string): string {
+function expandDateTemplate(
+	template: string,
+	date: Date,
+	title?: string,
+	folder?: string,
+): string {
 	// Obsidian re-exports `moment`, and in the marketplace's stricter type-checking
 	// environment that re-export resolves as the `error`/`any` type, which trips
 	// @typescript-eslint/no-unsafe-* on every call in this chain. Pin the factory
@@ -520,6 +525,9 @@ function expandDateTemplate(template: string, date: Date, title?: string): strin
 		const inner = raw.trim();
 		if (title !== undefined && inner === 'title') {
 			return title;
+		}
+		if (folder !== undefined && inner === 'plaud-folder') {
+			return folder;
 		}
 		return m.format(inner);
 	});
@@ -625,6 +633,7 @@ export function resolveSubfolder(
 	date: Date,
 	title?: string,
 	replacement: string = '-',
+	folder?: string,
 ): string {
 	if (template.trim() === '') {
 		return '';
@@ -650,7 +659,18 @@ export function resolveSubfolder(
 		// below, instead of sanitizeFilename's 'Untitled' fallback.
 		safeTitle = sanitizeFilename(titleWithoutLeadingDate(title), replacement, '');
 	}
-	const resolved = normalizeFolderPath(expandDateTemplate(template, date, safeTitle))
+	// {{plaud-folder}} support (issue #16 follow-up): the recording's Plaud folder
+	// name, sanitized into one legal segment the same way as {{title}}. Plaud
+	// folders are flat (plaud-client.ts: no parent_id), so a '/' in a folder name
+	// is literal text and is flattened, not treated as nesting. Empty (an unfiled
+	// recording) yields '' so the _unfiled bucket below fires.
+	let safeFolder: string | undefined;
+	if (folder !== undefined) {
+		safeFolder = sanitizeFilename(folder, replacement, '');
+	}
+	const resolved = normalizeFolderPath(
+		expandDateTemplate(template, date, safeTitle, safeFolder),
+	)
 		.split('/')
 		// Drop empty/whitespace-only segments so nesting stays as authored.
 		.filter((segment) => segment.trim() !== '')
@@ -658,12 +678,18 @@ export function resolveSubfolder(
 			assertUsableFolderSegment(sanitizeFolderSegment(segment, replacement)),
 		)
 		.join('/');
-	// Empty-title bucket: a template that is only {{title}} (or otherwise renders
-	// entirely empty because the title stripped to nothing) would collapse to no
-	// subfolder, silently dropping the note into the output root. Bucket it,
-	// mirroring _undated, so the nesting the user asked for stays intentional.
-	if (resolved === '' && /\{\{\s*title\s*}}/.test(template)) {
-		return '_untitled';
+	// Empty-value buckets: a template that renders entirely empty because its only
+	// dynamic token (a folder or title that reduced to nothing) was empty would
+	// collapse to no subfolder, silently dropping the note into the output root.
+	// Bucket it, mirroring _undated, so the nesting the user asked for stays
+	// intentional. plaud-folder is checked first as the primary grouping.
+	if (resolved === '') {
+		if (/\{\{\s*plaud-folder\s*}}/.test(template)) {
+			return '_unfiled';
+		}
+		if (/\{\{\s*title\s*}}/.test(template)) {
+			return '_untitled';
+		}
 	}
 	return resolved;
 }
@@ -878,6 +904,8 @@ export const TEMPLATE_PREVIEW_DATE = new Date(2026, 6, 5); // 2026-07-05 local (
 // meaningful time (2026-07-05 14:30:00), not 00:00:00.
 export const TEMPLATE_PREVIEW_DATETIME = new Date(2026, 6, 5, 14, 30, 0);
 export const TEMPLATE_PREVIEW_TITLE = 'Team sync';
+// Sample Plaud folder name for the subfolder preview's {{plaud-folder}} token.
+export const TEMPLATE_PREVIEW_FOLDER = 'Meetings';
 
 /**
  * Build a note name from a recording title and date, using a `{{...}}` template.
@@ -2102,12 +2130,24 @@ export class NoteWriter {
 	 * creating the destination folder if needed. Shared by writeNote and
 	 * writePlaceholderNote so both land a recording at the exact same path.
 	 */
-	private async resolveTargetPath(recording: Recording): Promise<string> {
+	private async resolveTargetPath(
+		recording: Recording,
+		folders?: readonly string[],
+	): Promise<string> {
+		// A recording is normally in a single Plaud folder; use the first resolved
+		// name for the {{plaud-folder}} token, or '' when unfiled (the token then
+		// buckets to _unfiled). Always pass a string so {{plaud-folder}} resolves
+		// instead of being handed to Moment as a format. The placeholder path passes
+		// no folders (they are not resolved on the error path); cross-folder dedup
+		// (existingPathForPlaudId) migrates such a stub to the real folder on the
+		// later successful import.
+		const folderName = folders && folders.length > 0 ? folders[0] : '';
 		const subfolder = resolveSubfolder(
 			this.subfolderTemplate,
 			recording.createdAt,
 			recording.title,
 			this.forbiddenCharReplacement,
+			folderName,
 		);
 		const destinationFolder = joinFolderPath(this.outputFolder, subfolder);
 		await this.ensureFolder(destinationFolder);
@@ -2265,10 +2305,12 @@ export class NoteWriter {
 			);
 		}
 
-		// Resolve the per-recording destination path. The subfolder template
-		// keys off the recording date, so the resolved path is a pure function
-		// of the recording's own metadata and stays stable across re-imports.
-		const targetPath = await this.resolveTargetPath(recording);
+		// Resolve the per-recording destination path. The subfolder template keys
+		// off the recording's own metadata (date, title, and now its Plaud folder),
+		// so the resolved path stays stable across re-imports. The folder names come
+		// from formatOptions so a {{plaud-folder}} template files the note under its
+		// Plaud folder.
+		const targetPath = await this.resolveTargetPath(recording, formatOptions?.folders);
 		const effectiveFormatOptions: FormatMarkdownOptions = {
 			...this.defaultFormatOptions,
 			...formatOptions,


### PR DESCRIPTION
## Summary

Release C: adds a `{{plaud-folder}}` token to the subfolder template, expanding to the recording's Plaud folder name, so users can mirror their Plaud folder structure into the vault (`{{plaud-folder}}/{{YYYY}}` → `Meetings/2026`). Follows up on the `plaud-folder:` frontmatter field from 0.19.0 (issue #16).

- The folder name is sanitized into one legal segment the same way as `{{title}}`. Plaud folders are flat, so a `/` in a name is flattened to the replacement char, not treated as nesting.
- An unfiled recording files under `_unfiled` (mirrors the `_undated`/`_untitled` buckets).
- A recording in more than one Plaud folder uses the first.
- The resolved folder names (already on `formatOptions.folders`) are threaded into `resolveTargetPath`. The placeholder path resolves no folders → `_unfiled`; cross-folder dedup (`existingPathForPlaudId` + `migrateExistingNote`) migrates such a stub to the real folder on the later successful import.
- Settings: `{{plaud-folder}}` added to the subfolder token docs/examples/intro, a Folder insert button (subfolder-only), and the preview + save-guard render a sample folder.

## Testing

- `npm run build` (tsc) clean; `npm run lint` clean (eslint + obsidianmd + check-submission)
- `npm test`: 880 passing, including `{{plaud-folder}}` expansion, slash-flatten, forbidden-char sanitize, `_unfiled` bucketing, `{{plaud-folder}}`+`{{title}}` combined, and an integration test for the `_unfiled` placeholder → real-folder migration
- Codex pre-commit review: clean

## Not yet validated

Hands-on: a `{{plaud-folder}}` subfolder import in a live vault with a filed recording, an unfiled one, and a multi-folder one.

## Review

CodeRabbit review requested (Copilot auto-reviews at the repo level).