### PR TITLE
Add silent Plaud session refresh (issue #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Added
 
+- **Your Plaud session now stays connected on its own.** Plaud's access token expires about every 24 hours, which used to pause background auto-sync roughly once a day until you reconnected. The plugin now renews the session quietly in the background before the token expires, so auto-sync and imports keep working without a daily reconnect. It is on by default and can be turned off under Settings, Automatic sync, "Keep the session alive automatically". A new **Refresh session now** command renews immediately and reports whether it worked, so you can confirm the whole path in seconds. Renewal is fail-safe: your stored token is only ever replaced after a renewal succeeds, so a failed renewal (or turning the feature off) simply falls back to the one-click reconnect prompt (issue #5).
 - **One-click reconnect when your Plaud session expires.** When background auto-sync pauses because your session expired (or no token is configured), the pause notice now carries a **Reconnect** link that opens sign-in and resumes auto-sync the moment a token is captured, instead of sending you to settings. The **Backfill version markers** command does the same: if it fails because the session expired, it offers **Reconnect and retry** rather than a dead-end error. Signing in this way sets the token in the not-configured case too.
 
 ### Changed

--- a/__tests__/plaud-refresh-net.test.ts
+++ b/__tests__/plaud-refresh-net.test.ts
@@ -1,0 +1,224 @@
+import { readJwtPayloadClaim } from '../plaud-refresh';
+import {
+	extractWorkspaceId,
+	normalizeTrustedOrigin,
+	parseWorkspaceTokenResponse,
+	performNetRefresh,
+	readRegionRedirect,
+	type SessionPost,
+} from '../plaud-refresh-net';
+
+// Build a minimal unsigned JWT with the given payload claims. The helpers only
+// read unverified payload claims, so an unsigned token with a dummy signature is
+// a faithful fixture.
+function makeJwt(payload: Record<string, unknown>): string {
+	const b64url = (obj: unknown): string =>
+		Buffer.from(JSON.stringify(obj))
+			.toString('base64')
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');
+	return `${b64url({ alg: 'HS256', typ: 'WT' })}.${b64url(payload)}.sig`;
+}
+
+const WID = 'ws_clF1vOqcHS';
+const STORED_WT = makeJwt({ wid: WID, client_id: 'web', sub: 'x' });
+const FRESH_WT = makeJwt({ wid: WID, sub: 'x', exp: 9_999_999_999 });
+
+describe('readJwtPayloadClaim', () => {
+	it('reads a string payload claim', () => {
+		expect(readJwtPayloadClaim(STORED_WT, 'wid')).toBe(WID);
+		expect(readJwtPayloadClaim(STORED_WT, 'client_id')).toBe('web');
+		expect(readJwtPayloadClaim(`bearer ${STORED_WT}`, 'wid')).toBe(WID);
+	});
+	it('returns null for an absent claim, a non-string claim, or a non-JWT', () => {
+		expect(readJwtPayloadClaim(STORED_WT, 'nope')).toBeNull();
+		expect(readJwtPayloadClaim(makeJwt({ wid: 5 }), 'wid')).toBeNull();
+		expect(readJwtPayloadClaim('not-a-token', 'wid')).toBeNull();
+	});
+});
+
+describe('extractWorkspaceId', () => {
+	it('returns the wid claim when it looks like a workspace id', () => {
+		expect(extractWorkspaceId(STORED_WT)).toBe(WID);
+	});
+	it('returns null when wid is missing or not a ws_ id', () => {
+		expect(extractWorkspaceId(makeJwt({ sub: 'x' }))).toBeNull();
+		expect(extractWorkspaceId(makeJwt({ wid: 'mem_x' }))).toBeNull();
+		expect(extractWorkspaceId('not-a-token')).toBeNull();
+	});
+});
+
+describe('normalizeTrustedOrigin', () => {
+	it('returns the origin (no path) for a trusted plaud https host', () => {
+		expect(normalizeTrustedOrigin('https://api.plaud.ai/x?y=1')).toBe(
+			'https://api.plaud.ai',
+		);
+		expect(normalizeTrustedOrigin('https://api-euc1.plaud.ai')).toBe(
+			'https://api-euc1.plaud.ai',
+		);
+	});
+	it('rejects non-https, non-plaud, or malformed urls', () => {
+		expect(normalizeTrustedOrigin('http://api.plaud.ai')).toBeNull();
+		expect(normalizeTrustedOrigin('https://evil.com')).toBeNull();
+		expect(normalizeTrustedOrigin('https://plaud.ai.evil.com')).toBeNull();
+		expect(normalizeTrustedOrigin('not a url')).toBeNull();
+	});
+});
+
+describe('readRegionRedirect', () => {
+	it('returns the origin for a -302 pointing at a trusted plaud host', () => {
+		expect(
+			readRegionRedirect({
+				status: -302,
+				data: { domains: { api: 'https://api-euc1.plaud.ai/x?y=1' } },
+			}),
+		).toBe('https://api-euc1.plaud.ai');
+	});
+	it('returns null for non-redirect status, non-plaud host, or non-https', () => {
+		expect(readRegionRedirect({ status: 0 })).toBeNull();
+		expect(
+			readRegionRedirect({ status: -302, data: { domains: { api: 'https://evil.com' } } }),
+		).toBeNull();
+		expect(
+			readRegionRedirect({ status: -302, data: { domains: { api: 'http://api.plaud.ai' } } }),
+		).toBeNull();
+		expect(readRegionRedirect({ status: -302, data: { domains: {} } })).toBeNull();
+	});
+});
+
+describe('parseWorkspaceTokenResponse', () => {
+	it('extracts the workspace token and rotated refresh token', () => {
+		expect(
+			parseWorkspaceTokenResponse({
+				status: 0,
+				data: { workspace_token: 'eyJ.wt.sig', refresh_token: 'urt-value' },
+			}),
+		).toEqual({ token: 'eyJ.wt.sig', refreshToken: 'urt-value' });
+	});
+	it('treats an absent refresh token as null', () => {
+		expect(
+			parseWorkspaceTokenResponse({ status: 0, data: { workspace_token: 'eyJ.wt.sig' } }),
+		).toEqual({ token: 'eyJ.wt.sig', refreshToken: null });
+	});
+	it('returns null on non-success status or a missing token', () => {
+		expect(
+			parseWorkspaceTokenResponse({ status: -1, data: { workspace_token: 'eyJ.wt.sig' } }),
+		).toBeNull();
+		expect(parseWorkspaceTokenResponse({ status: 0, data: {} })).toBeNull();
+		expect(parseWorkspaceTokenResponse({ status: 0, data: { workspace_token: '' } })).toBeNull();
+	});
+});
+
+describe('performNetRefresh', () => {
+	const okRefresh = JSON.stringify({ status: 0, data: {} });
+	const okMint = JSON.stringify({
+		status: 0,
+		data: { workspace_token: FRESH_WT, refresh_token: 'new-urt' },
+	});
+
+	function recordingPost(
+		responses: Array<{ status: number; text: string }>,
+	): { post: SessionPost; calls: Array<{ url: string; body: string }> } {
+		const calls: Array<{ url: string; body: string }> = [];
+		let i = 0;
+		const post: SessionPost = (url, body) => {
+			calls.push({ url, body });
+			return Promise.resolve(responses[i++]);
+		};
+		return { post, calls };
+	}
+
+	it('runs refresh then mint and returns the fresh WT', async () => {
+		const { post, calls } = recordingPost([
+			{ status: 200, text: okRefresh },
+			{ status: 200, text: okMint },
+		]);
+		const result = await performNetRefresh({
+			currentToken: STORED_WT,
+			baseUrl: 'https://api.plaud.ai',
+			post,
+		});
+		expect(result).toEqual({ token: FRESH_WT, refreshToken: 'new-urt', apiBaseUrl: null });
+		expect(calls[0]).toEqual({
+			url: 'https://api.plaud.ai/auth/refresh-user-token',
+			body: '{}',
+		});
+		expect(calls[1]).toEqual({
+			url: `https://api.plaud.ai/user-app/auth/workspace/token/${WID}`,
+			body: '{}',
+		});
+	});
+
+	it('follows a region redirect once and mints against the new host', async () => {
+		const redirect = JSON.stringify({
+			status: -302,
+			data: { domains: { api: 'https://api-euc1.plaud.ai' } },
+		});
+		const { post, calls } = recordingPost([
+			{ status: 200, text: redirect },
+			{ status: 200, text: okRefresh },
+			{ status: 200, text: okMint },
+		]);
+		const result = await performNetRefresh({
+			currentToken: STORED_WT,
+			baseUrl: 'https://api.plaud.ai',
+			post,
+		});
+		expect(result?.apiBaseUrl).toBe('https://api-euc1.plaud.ai');
+		expect(calls[2].url).toBe(
+			`https://api-euc1.plaud.ai/user-app/auth/workspace/token/${WID}`,
+		);
+	});
+
+	it('returns null (no call) when the stored token has no wid', async () => {
+		const { post, calls } = recordingPost([]);
+		const result = await performNetRefresh({
+			currentToken: makeJwt({ sub: 'x' }),
+			baseUrl: 'https://api.plaud.ai',
+			post,
+		});
+		expect(result).toBeNull();
+		expect(calls).toHaveLength(0);
+	});
+
+	it('returns null (no call) when the stored base host is not a trusted plaud host', async () => {
+		const { post, calls } = recordingPost([]);
+		const result = await performNetRefresh({
+			currentToken: STORED_WT,
+			baseUrl: 'https://evil.com',
+			post,
+		});
+		expect(result).toBeNull();
+		expect(calls).toHaveLength(0);
+	});
+
+	it('returns null when refresh is not JSON, fails, or the mint fails', async () => {
+		const bad = { currentToken: STORED_WT, baseUrl: 'https://api.plaud.ai' };
+		await expect(
+			performNetRefresh({ ...bad, post: recordingPost([{ status: 200, text: 'nope' }]).post }),
+		).resolves.toBeNull();
+		await expect(
+			performNetRefresh({
+				...bad,
+				post: recordingPost([{ status: 200, text: JSON.stringify({ status: -1 }) }]).post,
+			}),
+		).resolves.toBeNull();
+		await expect(
+			performNetRefresh({
+				...bad,
+				post: recordingPost([
+					{ status: 200, text: okRefresh },
+					{ status: 200, text: JSON.stringify({ status: -1 }) },
+				]).post,
+			}),
+		).resolves.toBeNull();
+	});
+
+	it('returns null (never throws) when the transport throws', async () => {
+		const post: SessionPost = () => Promise.reject(new Error('network down'));
+		await expect(
+			performNetRefresh({ currentToken: STORED_WT, baseUrl: 'https://api.plaud.ai', post }),
+		).resolves.toBeNull();
+	});
+});

--- a/__tests__/plaud-refresh.test.ts
+++ b/__tests__/plaud-refresh.test.ts
@@ -1,0 +1,234 @@
+import {
+	decodeJwtExpMs,
+	isFreshAccessToken,
+	jwtTyp,
+	parseRefreshResponse,
+	refreshPlaudSession,
+	type RefreshTransport,
+} from '../plaud-refresh';
+
+// Build a minimal unsigned JWT with the given header `typ` and payload `exp`
+// (seconds). The refresh module only reads unverified claims (typ, exp), so an
+// unsigned token with a dummy signature segment is a faithful fixture.
+function makeJwt(typ: string, expSeconds: number | null): string {
+	const b64url = (obj: unknown): string =>
+		Buffer.from(JSON.stringify(obj))
+			.toString('base64')
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');
+	const header = b64url({ alg: 'HS256', typ });
+	const payload = b64url(expSeconds === null ? { sub: 'x' } : { sub: 'x', exp: expSeconds });
+	return `${header}.${payload}.sig`;
+}
+
+const NOW = 1_780_000_000_000; // fixed clock in ms
+const FUTURE_EXP_S = Math.floor(NOW / 1000) + 24 * 3600; // +24h
+const PAST_EXP_S = Math.floor(NOW / 1000) - 60; // 1 min ago
+
+const FRESH_WT = makeJwt('WT', FUTURE_EXP_S);
+const EXPIRED_WT = makeJwt('WT', PAST_EXP_S);
+const FRESH_WRT = makeJwt('WRT', FUTURE_EXP_S);
+
+describe('jwtTyp / decodeJwtExpMs', () => {
+	it('reads the header typ', () => {
+		expect(jwtTyp(FRESH_WT)).toBe('WT');
+		expect(jwtTyp(FRESH_WRT)).toBe('WRT');
+		expect(jwtTyp(`bearer ${FRESH_WT}`)).toBe('WT');
+	});
+
+	it('returns null for a non-JWT', () => {
+		expect(jwtTyp('not-a-token')).toBeNull();
+		expect(decodeJwtExpMs('not-a-token')).toBeNull();
+	});
+
+	it('reads exp as milliseconds', () => {
+		expect(decodeJwtExpMs(FRESH_WT)).toBe(FUTURE_EXP_S * 1000);
+	});
+
+	it('returns null when exp is absent', () => {
+		expect(decodeJwtExpMs(makeJwt('WT', null))).toBeNull();
+	});
+});
+
+describe('isFreshAccessToken', () => {
+	it('accepts a WT with a future exp', () => {
+		expect(isFreshAccessToken(FRESH_WT, NOW)).toBe(true);
+	});
+	it('rejects an expired WT', () => {
+		expect(isFreshAccessToken(EXPIRED_WT, NOW)).toBe(false);
+	});
+	it('rejects a WRT (wrong typ) even if unexpired', () => {
+		expect(isFreshAccessToken(FRESH_WRT, NOW)).toBe(false);
+	});
+});
+
+describe('parseRefreshResponse', () => {
+	it('returns success with tokens for status 0 and a fresh WT', () => {
+		const parsed = parseRefreshResponse(
+			{ status: 0, access_token: FRESH_WT, refresh_token: FRESH_WRT },
+			NOW,
+		);
+		expect(parsed).toEqual({
+			kind: 'success',
+			accessToken: FRESH_WT,
+			refreshToken: FRESH_WRT,
+		});
+	});
+
+	it('treats a missing refresh_token as null (not a failure)', () => {
+		const parsed = parseRefreshResponse({ status: 0, access_token: FRESH_WT }, NOW);
+		expect(parsed).toEqual({ kind: 'success', accessToken: FRESH_WT, refreshToken: null });
+	});
+
+	it('fails (fail-safe) when status 0 returns an expired WT', () => {
+		const parsed = parseRefreshResponse({ status: 0, access_token: EXPIRED_WT }, NOW);
+		expect(parsed.kind).toBe('failure');
+	});
+
+	it('fails when status 0 returns a non-WT token', () => {
+		const parsed = parseRefreshResponse({ status: 0, access_token: FRESH_WRT }, NOW);
+		expect(parsed.kind).toBe('failure');
+	});
+
+	it('fails when access_token is missing', () => {
+		expect(parseRefreshResponse({ status: 0 }, NOW).kind).toBe('failure');
+	});
+
+	it('fails on a non-zero status with a message', () => {
+		const parsed = parseRefreshResponse({ status: -1, msg: 'token invalid or expired' }, NOW);
+		expect(parsed.kind).toBe('failure');
+	});
+
+	it('detects a region switch to a trusted plaud host', () => {
+		const parsed = parseRefreshResponse(
+			{ status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } },
+			NOW,
+		);
+		expect(parsed).toEqual({ kind: 'switch', apiBaseUrl: 'https://api-euc1.plaud.ai' });
+	});
+
+	it('does not treat an untrusted host as a switch', () => {
+		const parsed = parseRefreshResponse(
+			{ status: 100, data: { domains: { api: 'https://evil.example' } } },
+			NOW,
+		);
+		expect(parsed.kind).toBe('failure');
+	});
+
+	it('rejects an embedded-credential host', () => {
+		const parsed = parseRefreshResponse(
+			{ status: 100, data: { domains: { api: 'https://api.plaud.ai@evil.example' } } },
+			NOW,
+		);
+		expect(parsed.kind).toBe('failure');
+	});
+
+	it('fails on a non-object body', () => {
+		expect(parseRefreshResponse(null, NOW).kind).toBe('failure');
+		expect(parseRefreshResponse('nope', NOW).kind).toBe('failure');
+	});
+});
+
+// A transport double recording the requests it received.
+function transport(
+	responses: Array<{ status: number; json: unknown; text?: string }>,
+	cookieHeader: string | null = 'urt=cookievalue',
+): RefreshTransport & { calls: Array<{ url: string; headers: Record<string, string>; body: string }> } {
+	const calls: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
+	let i = 0;
+	return {
+		calls,
+		post: async (req) => {
+			calls.push({ url: req.url, headers: { ...req.headers }, body: req.body });
+			const r = responses[Math.min(i, responses.length - 1)];
+			i += 1;
+			return { status: r.status, json: r.json, text: r.text ?? '' };
+		},
+		readCookieHeader: async () => cookieHeader,
+	};
+}
+
+describe('refreshPlaudSession', () => {
+	const base = { apiBaseUrl: 'https://api.plaud.ai', now: () => NOW };
+
+	it('posts empty body to the refresh endpoint with cookie and bearer', async () => {
+		const t = transport([
+			{ status: 200, json: { status: 0, access_token: FRESH_WT, refresh_token: FRESH_WRT } },
+		]);
+		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
+		expect(result).toEqual({
+			ok: true,
+			accessToken: FRESH_WT,
+			refreshToken: FRESH_WRT,
+			apiBaseUrl: 'https://api.plaud.ai',
+		});
+		expect(t.calls[0].url).toBe('https://api.plaud.ai/auth/refresh-user-token');
+		expect(t.calls[0].body).toBe('{}');
+		expect(t.calls[0].headers.Cookie).toBe('urt=cookievalue');
+		expect(t.calls[0].headers.Authorization).toBe(`Bearer ${FRESH_WRT}`);
+	});
+
+	it('omits the Authorization header when no refresh token is stored', async () => {
+		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
+		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
+		expect(result.ok).toBe(true);
+		expect(t.calls[0].headers.Authorization).toBeUndefined();
+	});
+
+	it('strips a bearer prefix from the stored refresh token', async () => {
+		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
+		await refreshPlaudSession({ ...base, refreshToken: `bearer ${FRESH_WRT}`, transport: t });
+		expect(t.calls[0].headers.Authorization).toBe(`Bearer ${FRESH_WRT}`);
+	});
+
+	it('follows a single region switch and retries against the new host', async () => {
+		const t = transport([
+			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } } },
+			{ status: 200, json: { status: 0, access_token: FRESH_WT } },
+		]);
+		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.apiBaseUrl).toBe('https://api-euc1.plaud.ai');
+		}
+		expect(t.calls).toHaveLength(2);
+		expect(t.calls[1].url).toBe('https://api-euc1.plaud.ai/auth/refresh-user-token');
+	});
+
+	it('does not loop on a second region switch', async () => {
+		const t = transport([
+			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } } },
+			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-usw2.plaud.ai' } } } },
+		]);
+		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
+		expect(result.ok).toBe(false);
+		expect(t.calls).toHaveLength(2);
+	});
+
+	it('fails on a 401 without switching or throwing', async () => {
+		const t = transport([{ status: 401, json: { status: -1, msg: 'unauthorized' } }]);
+		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
+		expect(result.ok).toBe(false);
+	});
+
+	it('maps a transport rejection to a failure, never throwing', async () => {
+		const t: RefreshTransport = {
+			post: async () => {
+				throw new Error('offline');
+			},
+			readCookieHeader: async () => null,
+		};
+		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
+		expect(result).toEqual({ ok: false, reason: 'transport error: offline' });
+	});
+
+	it('sends no Cookie header when the partition has no cookies', async () => {
+		const t = transport(
+			[{ status: 200, json: { status: 0, access_token: FRESH_WT } }],
+			null,
+		);
+		await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
+		expect(t.calls[0].headers.Cookie).toBeUndefined();
+	});
+});

--- a/__tests__/plaud-refresh.test.ts
+++ b/__tests__/plaud-refresh.test.ts
@@ -1,15 +1,8 @@
-import {
-	decodeJwtExpMs,
-	isFreshAccessToken,
-	jwtTyp,
-	parseRefreshResponse,
-	refreshPlaudSession,
-	type RefreshTransport,
-} from '../plaud-refresh';
+import { decodeJwtExpMs, isFreshAccessToken, jwtTyp } from '../plaud-refresh';
 
 // Build a minimal unsigned JWT with the given header `typ` and payload `exp`
-// (seconds). The refresh module only reads unverified claims (typ, exp), so an
-// unsigned token with a dummy signature segment is a faithful fixture.
+// (seconds). The helpers only read unverified claims (typ, exp), so an unsigned
+// token with a dummy signature segment is a faithful fixture.
 function makeJwt(typ: string, expSeconds: number | null): string {
 	const b64url = (obj: unknown): string =>
 		Buffer.from(JSON.stringify(obj))
@@ -28,11 +21,13 @@ const PAST_EXP_S = Math.floor(NOW / 1000) - 60; // 1 min ago
 
 const FRESH_WT = makeJwt('WT', FUTURE_EXP_S);
 const EXPIRED_WT = makeJwt('WT', PAST_EXP_S);
+const FRESH_UT = makeJwt('UT', FUTURE_EXP_S); // the user token the refresh endpoint returns
 const FRESH_WRT = makeJwt('WRT', FUTURE_EXP_S);
 
 describe('jwtTyp / decodeJwtExpMs', () => {
 	it('reads the header typ', () => {
 		expect(jwtTyp(FRESH_WT)).toBe('WT');
+		expect(jwtTyp(FRESH_UT)).toBe('UT');
 		expect(jwtTyp(FRESH_WRT)).toBe('WRT');
 		expect(jwtTyp(`bearer ${FRESH_WT}`)).toBe('WT');
 	});
@@ -58,197 +53,10 @@ describe('isFreshAccessToken', () => {
 	it('rejects an expired WT', () => {
 		expect(isFreshAccessToken(EXPIRED_WT, NOW)).toBe(false);
 	});
-	it('rejects a WRT (wrong typ) even if unexpired', () => {
+	it('rejects a UT (the refresh-endpoint token type) even if unexpired', () => {
+		expect(isFreshAccessToken(FRESH_UT, NOW)).toBe(false);
+	});
+	it('rejects a WRT even if unexpired', () => {
 		expect(isFreshAccessToken(FRESH_WRT, NOW)).toBe(false);
-	});
-});
-
-describe('parseRefreshResponse', () => {
-	it('returns success with tokens for status 0 and a fresh WT', () => {
-		const parsed = parseRefreshResponse(
-			{ status: 0, access_token: FRESH_WT, refresh_token: FRESH_WRT },
-			NOW,
-		);
-		expect(parsed).toEqual({
-			kind: 'success',
-			accessToken: FRESH_WT,
-			refreshToken: FRESH_WRT,
-		});
-	});
-
-	it('treats a missing refresh_token as null (not a failure)', () => {
-		const parsed = parseRefreshResponse({ status: 0, access_token: FRESH_WT }, NOW);
-		expect(parsed).toEqual({ kind: 'success', accessToken: FRESH_WT, refreshToken: null });
-	});
-
-	it('fails (fail-safe) when status 0 returns an expired WT', () => {
-		const parsed = parseRefreshResponse({ status: 0, access_token: EXPIRED_WT }, NOW);
-		expect(parsed.kind).toBe('failure');
-	});
-
-	it('fails when status 0 returns a non-WT token', () => {
-		const parsed = parseRefreshResponse({ status: 0, access_token: FRESH_WRT }, NOW);
-		expect(parsed.kind).toBe('failure');
-	});
-
-	it('fails when access_token is missing', () => {
-		expect(parseRefreshResponse({ status: 0 }, NOW).kind).toBe('failure');
-	});
-
-	it('fails on a non-zero status with a message', () => {
-		const parsed = parseRefreshResponse({ status: -1, msg: 'token invalid or expired' }, NOW);
-		expect(parsed.kind).toBe('failure');
-	});
-
-	it('detects a region switch to a trusted plaud host', () => {
-		const parsed = parseRefreshResponse(
-			{ status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } },
-			NOW,
-		);
-		expect(parsed).toEqual({ kind: 'switch', apiBaseUrl: 'https://api-euc1.plaud.ai' });
-	});
-
-	it('does not treat an untrusted host as a switch', () => {
-		const parsed = parseRefreshResponse(
-			{ status: 100, data: { domains: { api: 'https://evil.example' } } },
-			NOW,
-		);
-		expect(parsed.kind).toBe('failure');
-	});
-
-	it('normalizes a switch host with a trailing dot and mixed case', () => {
-		const parsed = parseRefreshResponse(
-			{ status: 100, data: { domains: { api: 'https://API-EUC1.Plaud.AI.' } } },
-			NOW,
-		);
-		expect(parsed).toEqual({ kind: 'switch', apiBaseUrl: 'https://api-euc1.plaud.ai' });
-	});
-
-	it('rejects an embedded-credential host', () => {
-		const parsed = parseRefreshResponse(
-			{ status: 100, data: { domains: { api: 'https://api.plaud.ai@evil.example' } } },
-			NOW,
-		);
-		expect(parsed.kind).toBe('failure');
-	});
-
-	it('fails on a non-object body', () => {
-		expect(parseRefreshResponse(null, NOW).kind).toBe('failure');
-		expect(parseRefreshResponse('nope', NOW).kind).toBe('failure');
-	});
-});
-
-// A transport double recording the requests it received.
-function transport(
-	responses: Array<{ status: number; json: unknown; text?: string }>,
-	cookieHeader: string | null = 'urt=cookievalue',
-): RefreshTransport & { calls: Array<{ url: string; headers: Record<string, string>; body: string }> } {
-	const calls: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
-	let i = 0;
-	return {
-		calls,
-		post: async (req) => {
-			calls.push({ url: req.url, headers: { ...req.headers }, body: req.body });
-			const r = responses[Math.min(i, responses.length - 1)];
-			i += 1;
-			return { status: r.status, json: r.json, text: r.text ?? '' };
-		},
-		readCookieHeader: async () => cookieHeader,
-	};
-}
-
-describe('refreshPlaudSession', () => {
-	const base = { apiBaseUrl: 'https://api.plaud.ai', now: () => NOW };
-
-	it('posts empty body to the refresh endpoint with cookie and bearer', async () => {
-		const t = transport([
-			{ status: 200, json: { status: 0, access_token: FRESH_WT, refresh_token: FRESH_WRT } },
-		]);
-		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
-		expect(result).toEqual({
-			ok: true,
-			accessToken: FRESH_WT,
-			refreshToken: FRESH_WRT,
-			apiBaseUrl: 'https://api.plaud.ai',
-		});
-		expect(t.calls[0].url).toBe('https://api.plaud.ai/auth/refresh-user-token');
-		expect(t.calls[0].body).toBe('{}');
-		expect(t.calls[0].headers.Cookie).toBe('urt=cookievalue');
-		expect(t.calls[0].headers.Authorization).toBe(`Bearer ${FRESH_WRT}`);
-	});
-
-	it('omits the Authorization header when no refresh token is stored', async () => {
-		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
-		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
-		expect(result.ok).toBe(true);
-		expect(t.calls[0].headers.Authorization).toBeUndefined();
-	});
-
-	it('strips a bearer prefix from the stored refresh token', async () => {
-		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
-		await refreshPlaudSession({ ...base, refreshToken: `bearer ${FRESH_WRT}`, transport: t });
-		expect(t.calls[0].headers.Authorization).toBe(`Bearer ${FRESH_WRT}`);
-	});
-
-	it('follows a single region switch and retries against the new host', async () => {
-		const t = transport([
-			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } } },
-			{ status: 200, json: { status: 0, access_token: FRESH_WT } },
-		]);
-		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.apiBaseUrl).toBe('https://api-euc1.plaud.ai');
-		}
-		expect(t.calls).toHaveLength(2);
-		expect(t.calls[1].url).toBe('https://api-euc1.plaud.ai/auth/refresh-user-token');
-	});
-
-	it('does not loop on a second region switch', async () => {
-		const t = transport([
-			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-euc1.plaud.ai' } } } },
-			{ status: 200, json: { status: 100, data: { domains: { api: 'https://api-usw2.plaud.ai' } } } },
-		]);
-		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
-		expect(result.ok).toBe(false);
-		expect(t.calls).toHaveLength(2);
-	});
-
-	it('fails on a 401 without switching or throwing', async () => {
-		const t = transport([{ status: 401, json: { status: -1, msg: 'unauthorized' } }]);
-		const result = await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
-		expect(result.ok).toBe(false);
-	});
-
-	it('maps a transport rejection to a failure, never throwing', async () => {
-		const t: RefreshTransport = {
-			post: async () => {
-				throw new Error('offline');
-			},
-			readCookieHeader: async () => null,
-		};
-		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
-		expect(result).toEqual({ ok: false, reason: 'transport error: offline' });
-	});
-
-	it('fails closed on an untrusted api base url without sending credentials', async () => {
-		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
-		const result = await refreshPlaudSession({
-			apiBaseUrl: 'https://evil.example',
-			now: () => NOW,
-			refreshToken: FRESH_WRT,
-			transport: t,
-		});
-		expect(result.ok).toBe(false);
-		expect(t.calls).toHaveLength(0);
-	});
-
-	it('sends no Cookie header when the partition has no cookies', async () => {
-		const t = transport(
-			[{ status: 200, json: { status: 0, access_token: FRESH_WT } }],
-			null,
-		);
-		await refreshPlaudSession({ ...base, refreshToken: FRESH_WRT, transport: t });
-		expect(t.calls[0].headers.Cookie).toBeUndefined();
 	});
 });

--- a/__tests__/plaud-refresh.test.ts
+++ b/__tests__/plaud-refresh.test.ts
@@ -116,6 +116,14 @@ describe('parseRefreshResponse', () => {
 		expect(parsed.kind).toBe('failure');
 	});
 
+	it('normalizes a switch host with a trailing dot and mixed case', () => {
+		const parsed = parseRefreshResponse(
+			{ status: 100, data: { domains: { api: 'https://API-EUC1.Plaud.AI.' } } },
+			NOW,
+		);
+		expect(parsed).toEqual({ kind: 'switch', apiBaseUrl: 'https://api-euc1.plaud.ai' });
+	});
+
 	it('rejects an embedded-credential host', () => {
 		const parsed = parseRefreshResponse(
 			{ status: 100, data: { domains: { api: 'https://api.plaud.ai@evil.example' } } },
@@ -221,6 +229,18 @@ describe('refreshPlaudSession', () => {
 		};
 		const result = await refreshPlaudSession({ ...base, refreshToken: null, transport: t });
 		expect(result).toEqual({ ok: false, reason: 'transport error: offline' });
+	});
+
+	it('fails closed on an untrusted api base url without sending credentials', async () => {
+		const t = transport([{ status: 200, json: { status: 0, access_token: FRESH_WT } }]);
+		const result = await refreshPlaudSession({
+			apiBaseUrl: 'https://evil.example',
+			now: () => NOW,
+			refreshToken: FRESH_WRT,
+			transport: t,
+		});
+		expect(result.ok).toBe(false);
+		expect(t.calls).toHaveLength(0);
 	});
 
 	it('sends no Cookie header when the partition has no cookies', async () => {

--- a/main.ts
+++ b/main.ts
@@ -25,7 +25,13 @@ import {
 	clearPlaudLoginSession,
 	isAccessToken,
 	openPlaudLogin,
+	readPlaudSessionCookieHeader,
 } from "./plaud-login";
+import {
+	decodeJwtExpMs,
+	refreshPlaudSession,
+	type RefreshTransport,
+} from "./plaud-refresh";
 import {
 	NoteWriter,
 	DEFAULT_NOTE_NAME_TEMPLATE,
@@ -71,6 +77,31 @@ import {
 // Stable SecretStorage id for a token captured by the in-app sign-in flow.
 // Re-running sign-in overwrites it, mirroring "replace my token".
 const CAPTURED_SECRET_ID = "plaud-importer-token";
+
+// Stable SecretStorage id for the rotating refresh token (typ WRT) captured at
+// sign-in and rotated on each silent refresh. A credential, so it lives in
+// SecretStorage, never data.json. Lowercase-alphanumeric-with-dashes so
+// setSecret accepts it.
+const CAPTURED_REFRESH_SECRET_ID = "plaud-importer-refresh-token";
+
+// Silent-refresh scheduling. Refresh this long before the access token's `exp`
+// so a slow round-trip still lands before expiry.
+const REFRESH_LEAD_MS = 5 * 60 * 1000;
+// Never schedule a refresh sooner than this, so a past-due or about-to-expire
+// token triggers one prompt refresh rather than a tight loop.
+const REFRESH_MIN_DELAY_MS = 30 * 1000;
+// When the stored token is opaque (no decodable `exp`), poll at this cadence as
+// a fallback so a session can still be kept alive.
+const REFRESH_OPAQUE_FALLBACK_MS = 60 * 60 * 1000;
+// Backoff after a failed refresh, indexed by (failure streak - 1) and clamped to
+// the last entry. Keeps a dead 30-day refresh token from hammering the endpoint
+// (Plaud counts refreshes per hour) while still retrying periodically.
+const REFRESH_RETRY_BACKOFF_MS = [
+	5 * 60 * 1000,
+	15 * 60 * 1000,
+	30 * 60 * 1000,
+	60 * 60 * 1000,
+];
 
 // Plaud web app, opened in the system browser for the browser-based sign-in
 // flow (where Google/Apple SSO work, unlike an embedded webview).
@@ -238,6 +269,12 @@ const NOTE_NAME_TEMPLATE_FOOTNOTE =
 const FORBIDDEN_CHAR_REPLACEMENT_DESC =
 	"Character that replaces a slash, colon, or other character a file name or folder cannot contain, for example one that appears in a recording title. Must be a single character; the default is a dash.";
 
+// Description for the silent-refresh toggle (Release B). Held in a const so the
+// declarative (1.13+) and imperative (1.12) settings paths show identical text
+// and the sentence-case lint inspects one literal.
+const KEEP_SESSION_ALIVE_DESC =
+	"On by default. Renews your Plaud session in the background before its access token expires (about every 24 hours), so automatic sync and manual imports keep working without a daily reconnect. It only ever replaces the stored token after a renewal succeeds, so turning this off, or a failed renewal, simply falls back to the reconnect prompt. Use the 'Refresh session now' command to renew immediately, which also confirms the whole path works.";
+
 // [label, template] preset buttons. All dashes, so every preset is filename-safe.
 // ISO/US/EU cover the common date orders; putting the date after {{title}} (the
 // "date at the end" example in the reference) is left to the user to type.
@@ -391,6 +428,12 @@ interface PlaudImporterSettings {
 	autoSyncEnabled: boolean;
 	// Minutes between auto-sync ticks. Coerced to [15, 1440]; default 60.
 	autoSyncIntervalMinutes: number;
+	// Silent session refresh (Release B). When on, the plugin renews the Plaud
+	// session in the background before the ~24h access token expires, so
+	// auto-sync and imports keep working without a daily reconnect. ON by default
+	// because it is fail-safe: the stored token is only ever replaced after a
+	// refresh succeeds; a failure falls back to the reconnect prompt.
+	keepSessionAlive: boolean;
 	// Schema version for one-time settings migrations. Absent (pre-0.21.0) reads
 	// as 0. Version 1 rewrote the subfolder/note-name date templates from the old
 	// bespoke lowercase tokens to real Moment tokens (issue #30). Bumped only when
@@ -432,6 +475,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	autoUpdatePlaudTitle: false,
 	autoSyncEnabled: false,
 	autoSyncIntervalMinutes: 60,
+	keepSessionAlive: true,
 	settingsVersion: 1,
 };
 
@@ -512,6 +556,15 @@ export default class PlaudImporterPlugin extends Plugin {
 	private autoSyncIntervalId: number | undefined;
 	private autoSyncFirstRunTimeoutId: number | undefined;
 	private autoSyncState: AutoSyncState = INITIAL_AUTO_SYNC_STATE;
+	// Silent session refresh (Release B). The proactive timer fires ~5 min before
+	// the access token expires; onunload and reconcileTokenRefresh clear it.
+	private refreshTimeoutId: number | undefined;
+	// Re-entrancy guard so a scheduled, reactive, and manual refresh can never
+	// overlap and clobber each other's token write.
+	private refreshInFlight = false;
+	// Consecutive proactive-refresh failures, used only to back off the retry
+	// cadence. Reset to 0 on any success or a fresh interactive sign-in.
+	private refreshFailureStreak = 0;
 	// Single-flight coordination between the manual modal and background ticks.
 	// Two independent flags rather than one shared boolean, so the modal's
 	// open/close never clobbers a tick's in-flight state and vice versa. An
@@ -567,6 +620,18 @@ export default class PlaudImporterPlugin extends Plugin {
 			name: "Backfill version markers for auto-sync",
 			callback: () => {
 				void this.backfillVersionMarkers();
+			},
+		});
+
+		// Force one silent session refresh immediately and report the result. The
+		// validation gate for Release B: it works regardless of whether the current
+		// token is fresh, so the whole refresh path can be proven in seconds instead
+		// of waiting ~24h for a natural expiry. Also a user-facing fallback.
+		this.addCommand({
+			id: "refresh-session-now",
+			name: "Refresh session now",
+			callback: () => {
+				void this.refreshSessionCommand();
 			},
 		});
 
@@ -683,6 +748,11 @@ export default class PlaudImporterPlugin extends Plugin {
 			// The client exists now, so a scheduled tick can run. Starts the
 			// timer only when auto-sync is enabled; deferred first run is inside.
 			this.reconcileAutoSync();
+			// Schedule the silent session refresh from the stored token's expiry.
+			// Independent of auto-sync: keeping the session alive also serves
+			// manual imports. A past-due token refreshes promptly (delay clamps to
+			// the minimum), so reopening Obsidian after the token expired recovers.
+			this.reconcileTokenRefresh();
 		});
 	}
 
@@ -701,6 +771,12 @@ export default class PlaudImporterPlugin extends Plugin {
 		if (this.autoSyncFirstRunTimeoutId !== undefined) {
 			window.clearTimeout(this.autoSyncFirstRunTimeoutId);
 			this.autoSyncFirstRunTimeoutId = undefined;
+		}
+		// Clear the silent-refresh timer. An in-flight refresh checks `disposed`
+		// after its await before writing, so no token is persisted post-unload.
+		if (this.refreshTimeoutId !== undefined) {
+			window.clearTimeout(this.refreshTimeoutId);
+			this.refreshTimeoutId = undefined;
 		}
 		// Hide any sticky action notice (e.g. an auth-pause "Reconnect") so its
 		// click handler cannot open sign-in or save settings after unload.
@@ -1303,6 +1379,26 @@ export default class PlaudImporterPlugin extends Plugin {
 		} catch (err) {
 			const classification = classifyError(err);
 			const outcome = tickOutcomeForCategory(classification.category);
+			// Reactive silent refresh: an expired/rejected token may be recoverable
+			// without user action. Try one refresh before pausing. Only for
+			// token-rejected (an expired session), not not-configured (nothing to
+			// refresh from). A success clears the failure and schedules a soon retry.
+			if (
+				outcome === "auth" &&
+				classification.category === "token-rejected" &&
+				this.settings.keepSessionAlive &&
+				!this.disposed
+			) {
+				const refreshed = await this.tryRefreshSession("reactive");
+				if (refreshed && !this.disposed) {
+					this.refreshFailureStreak = 0;
+					this.autoSyncState = nextAutoSyncState(this.autoSyncState, "ok");
+					this.reconcileTokenRefresh();
+					this.scheduleFollowUpTick();
+					this.logAutoSync("tick auth failure recovered via silent refresh");
+					return;
+				}
+			}
 			this.autoSyncState = nextAutoSyncState(this.autoSyncState, outcome);
 			if (outcome === "auth") {
 				// The auth outcome covers both a rejected/expired token and a
@@ -1366,11 +1462,17 @@ export default class PlaudImporterPlugin extends Plugin {
 		if (!this.autoSyncState.paused) return;
 		this.autoSyncState = nextAutoSyncState(this.autoSyncState, "ok");
 		this.logAutoSync("auto-sync resumed after re-auth");
+		this.scheduleFollowUpTick();
+	}
+
+	/**
+	 * Schedule one soon-ish auto-sync tick (~1s), reusing the first-run timeout
+	 * slot so reconcileAutoSync() and onunload() clear it. No-op when auto-sync is
+	 * disabled. Shared by the re-auth resume and the reactive-refresh recovery so
+	 * an untracked setTimeout can never fire after disable/reschedule/unload.
+	 */
+	private scheduleFollowUpTick(): void {
 		if (!this.settings.autoSyncEnabled) return;
-		// Track this deferred tick in the same slot as the scheduled first run so
-		// reconcileAutoSync() and onunload() clear it. An untracked setTimeout
-		// could otherwise fire after auto-sync is disabled/rescheduled or during
-		// unload and run an unexpected tick.
 		if (this.autoSyncFirstRunTimeoutId !== undefined) {
 			window.clearTimeout(this.autoSyncFirstRunTimeoutId);
 		}
@@ -1378,6 +1480,204 @@ export default class PlaudImporterPlugin extends Plugin {
 			this.autoSyncFirstRunTimeoutId = undefined;
 			void this.runAutoSyncTickSafe();
 		}, 1000);
+	}
+
+	// ---- Silent session refresh (Release B) -----------------------------
+
+	/**
+	 * The Obsidian-backed transport the refresh module needs: a `requestUrl` POST
+	 * (avoids CORS/cert issues on Electron) plus a read of the Plaud partition's
+	 * cookies. Built per call so it always reads the current region.
+	 */
+	private buildRefreshTransport(): RefreshTransport {
+		return {
+			post: async ({ url, headers, body }) => {
+				const response = await requestUrl({
+					url,
+					method: "POST",
+					headers: { ...headers },
+					body,
+					throw: false,
+				});
+				return {
+					status: response.status,
+					json: safeJson(response),
+					text: response.text ?? "",
+				};
+			},
+			readCookieHeader: (url) => readPlaudSessionCookieHeader(url),
+		};
+	}
+
+	/** The currently-active access token (trimmed), or null when none is stored. */
+	private currentAccessToken(): string | null {
+		if (this.settings.secretId.length === 0) return null;
+		const token = this.app.secretStorage.getSecret(this.settings.secretId);
+		return token !== null && token.trim().length > 0 ? token.trim() : null;
+	}
+
+	/**
+	 * Attempt one silent session refresh. FAIL-SAFE: the stored token is replaced
+	 * only when the endpoint returns a fresh WT (validated in plaud-refresh, and
+	 * re-checked here as defense in depth). Any failure leaves every stored value
+	 * untouched and returns false, so the caller falls through to today's
+	 * behavior. Never throws; never logs a token value. `reason` only tags the
+	 * debug log. Serialized by `refreshInFlight` so refreshes never overlap.
+	 */
+	private async tryRefreshSession(
+		reason: "scheduled" | "reactive" | "manual",
+	): Promise<boolean> {
+		if (this.disposed || this.refreshInFlight) {
+			return false;
+		}
+		this.refreshInFlight = true;
+		try {
+			const storedRefreshToken = this.app.secretStorage.getSecret(
+				CAPTURED_REFRESH_SECRET_ID,
+			);
+			const result = await refreshPlaudSession({
+				apiBaseUrl: this.settings.apiBaseUrl,
+				refreshToken: storedRefreshToken,
+				transport: this.buildRefreshTransport(),
+				debugLogger: this.debugLogger,
+			});
+			// The refresh awaits the network; do not persist onto a torn-down plugin.
+			if (this.disposed) {
+				return false;
+			}
+			if (!result.ok) {
+				this.logAutoSync(`session refresh (${reason}) failed`, {
+					reason: result.reason,
+				});
+				return false;
+			}
+			// Defense in depth: the module already guarantees a fresh WT, but never
+			// overwrite a working token with something that is not even an access
+			// token if that guarantee ever regresses.
+			if (!isAccessToken(result.accessToken)) {
+				this.logAutoSync(
+					`session refresh (${reason}) returned a non-WT token; keeping existing`,
+				);
+				return false;
+			}
+			// Update the active secret in place (keeps a user's chosen secret slot),
+			// falling back to the captured-token slot when none is linked yet.
+			const targetSecretId =
+				this.settings.secretId.length > 0
+					? this.settings.secretId
+					: CAPTURED_SECRET_ID;
+			this.app.secretStorage.setSecret(targetSecretId, result.accessToken);
+			this.settings.secretId = targetSecretId;
+			if (result.refreshToken !== null && result.refreshToken.length > 0) {
+				// The refresh token rotates on each use; store the new one, stripped
+				// of any bearer prefix, for the next refresh.
+				this.app.secretStorage.setSecret(
+					CAPTURED_REFRESH_SECRET_ID,
+					result.refreshToken.replace(/^bearer\s+/i, ""),
+				);
+			}
+			if (result.apiBaseUrl.length > 0) {
+				this.settings.apiBaseUrl = result.apiBaseUrl;
+			}
+			await this.saveSettings();
+			this.logAutoSync(`session refreshed (${reason})`);
+			return true;
+		} catch (err) {
+			// A refresh bug must log, not throw into the timer or the auto-sync tick.
+			console.error("Plaud importer: silent session refresh failed", err);
+			return false;
+		} finally {
+			this.refreshInFlight = false;
+		}
+	}
+
+	/**
+	 * Start, stop, or reschedule the proactive session-refresh timer to match
+	 * settings and the stored token's expiry. Idempotent: clears the existing
+	 * timer first. No-op (and cleared) when the feature is off or no token is
+	 * stored. Called from onLayoutReady, the toggle, and after any token change.
+	 */
+	reconcileTokenRefresh(): void {
+		if (this.refreshTimeoutId !== undefined) {
+			window.clearTimeout(this.refreshTimeoutId);
+			this.refreshTimeoutId = undefined;
+		}
+		if (this.disposed || !this.settings.keepSessionAlive) return;
+		const token = this.currentAccessToken();
+		// Nothing to refresh proactively until a token exists; a fresh sign-in
+		// calls this again to (re)schedule.
+		if (token === null) return;
+		let delay: number;
+		if (this.refreshFailureStreak > 0) {
+			const index = Math.min(
+				this.refreshFailureStreak - 1,
+				REFRESH_RETRY_BACKOFF_MS.length - 1,
+			);
+			delay = REFRESH_RETRY_BACKOFF_MS[index];
+		} else {
+			const expMs = decodeJwtExpMs(token);
+			delay =
+				expMs === null
+					? REFRESH_OPAQUE_FALLBACK_MS
+					: Math.max(REFRESH_MIN_DELAY_MS, expMs - REFRESH_LEAD_MS - Date.now());
+		}
+		this.refreshTimeoutId = window.setTimeout(() => {
+			this.refreshTimeoutId = undefined;
+			void this.runScheduledRefresh();
+		}, delay);
+		this.logAutoSync("session refresh scheduled", {
+			delayMs: delay,
+			failureStreak: this.refreshFailureStreak,
+		});
+	}
+
+	/**
+	 * The proactive-timer callback: refresh, resume any auth-paused sync on
+	 * success, then reschedule (from the new token's expiry on success, or a
+	 * backoff on failure). Guarded so it never runs after unload or a disable.
+	 */
+	private async runScheduledRefresh(): Promise<void> {
+		if (this.disposed || !this.settings.keepSessionAlive) return;
+		const ok = await this.tryRefreshSession("scheduled");
+		if (this.disposed) return;
+		if (ok) {
+			this.refreshFailureStreak = 0;
+			this.resumeAutoSyncIfPaused();
+		} else {
+			this.refreshFailureStreak = Math.min(
+				this.refreshFailureStreak + 1,
+				REFRESH_RETRY_BACKOFF_MS.length,
+			);
+		}
+		this.reconcileTokenRefresh();
+	}
+
+	/**
+	 * Manual "Refresh session now" command. Forces one refresh and reports the
+	 * outcome. On success, resumes any paused sync and reschedules from the new
+	 * expiry. On failure, tells the user to sign in again if imports fail — the
+	 * stored token is never cleared by a failed refresh.
+	 */
+	private async refreshSessionCommand(): Promise<void> {
+		if (!this.client) {
+			new Notice("Plaud importer: still starting up. Try again in a moment.");
+			return;
+		}
+		new Notice("Plaud importer: refreshing your session…");
+		const ok = await this.tryRefreshSession("manual");
+		if (this.disposed) return;
+		if (ok) {
+			this.refreshFailureStreak = 0;
+			this.resumeAutoSyncIfPaused();
+			this.reconcileTokenRefresh();
+			new Notice(
+				"Plaud importer: session refreshed. Background sync and imports can keep running.",
+			);
+		} else {
+			new Notice(
+				"Plaud importer: could not refresh the session automatically. If imports start failing, sign in again from settings.",
+			);
+		}
 	}
 
 	/**
@@ -1767,8 +2067,13 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 		// Wipe the stored token value(s). Obsidian's SecretStorage exposes no
 		// delete call (only set/get/list), so the secret entry itself cannot be
-		// removed; blanking the value is the most thorough removal available.
-		for (const id of new Set([this.settings.secretId, CAPTURED_SECRET_ID])) {
+		// removed; blanking the value is the most thorough removal available. The
+		// refresh token is blanked too so a cleared session cannot silently refresh.
+		for (const id of new Set([
+			this.settings.secretId,
+			CAPTURED_SECRET_ID,
+			CAPTURED_REFRESH_SECRET_ID,
+		])) {
 			if (id.length > 0) {
 				try {
 					this.app.secretStorage.setSecret(id, "");
@@ -1779,6 +2084,9 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 		this.settings.secretId = "";
 		await this.saveSettings();
+		// No token remains, so cancel any pending proactive refresh.
+		this.refreshFailureStreak = 0;
+		this.reconcileTokenRefresh();
 		return { sessionCleared };
 	}
 
@@ -1814,10 +2122,22 @@ export default class PlaudImporterPlugin extends Plugin {
 			}
 			this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, result.token);
 			this.settings.secretId = CAPTURED_SECRET_ID;
+			// Keep the paired refresh token (typ WRT) for the silent-refresh path.
+			// It flies during login; store it stripped of any bearer prefix.
+			if (result.refreshToken !== null && result.refreshToken.trim().length > 0) {
+				this.app.secretStorage.setSecret(
+					CAPTURED_REFRESH_SECRET_ID,
+					result.refreshToken.trim().replace(/^bearer\s+/i, ""),
+				);
+			}
 			if (result.apiBaseUrl !== null) {
 				this.settings.apiBaseUrl = result.apiBaseUrl;
 			}
 			await this.saveSettings();
+			// A fresh sign-in clears any prior refresh-failure backoff and
+			// reschedules the proactive refresh from the new token's expiry.
+			this.refreshFailureStreak = 0;
+			this.reconcileTokenRefresh();
 			return true;
 		} finally {
 			this.reauthInFlight = false;
@@ -1911,6 +2231,12 @@ export default class PlaudImporterPlugin extends Plugin {
 		this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, token);
 		this.settings.secretId = CAPTURED_SECRET_ID;
 		await this.saveSettings();
+		// A newly pasted token clears any refresh backoff and reschedules the
+		// proactive refresh from its expiry. This paste path carries no refresh
+		// token (only the WT), so the silent refresh relies on the partition
+		// cookies until the next in-app sign-in captures a WRT.
+		this.refreshFailureStreak = 0;
+		this.reconcileTokenRefresh();
 		return true;
 	}
 
@@ -2342,6 +2668,12 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				"480": "Every 8 hours",
 				"1440": "Once a day",
 			},
+		);
+		this.addToggleRow(
+			containerEl,
+			"Keep the session alive automatically",
+			KEEP_SESSION_ALIVE_DESC,
+			"keepSessionAlive",
 		);
 
 		new Setting(containerEl).setName("Transcript rendering").setHeading();
@@ -3234,6 +3566,11 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 							},
 						},
 					},
+					{
+						name: "Keep the session alive automatically",
+						desc: KEEP_SESSION_ALIVE_DESC,
+						control: { type: "toggle", key: "keepSessionAlive" },
+					},
 				],
 			},
 			{
@@ -3402,6 +3739,11 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 			if (key === "autoSyncEnabled" && this.plugin.settings.autoSyncEnabled) {
 				this.plugin.resumeAutoSyncIfPaused();
 			}
+		} else if (key === "keepSessionAlive") {
+			// Start or stop the proactive refresh timer to match the toggle. When
+			// turned on with a token already past its refresh point, this schedules
+			// a prompt refresh (the delay clamps to the minimum).
+			this.plugin.reconcileTokenRefresh();
 		} else if (key === "debug") {
 			// Update the live logger's enabled flag in place so the change takes
 			// effect on the next API call without reinstantiating the client.

--- a/main.ts
+++ b/main.ts
@@ -25,13 +25,9 @@ import {
 	clearPlaudLoginSession,
 	isAccessToken,
 	openPlaudLogin,
-	readPlaudSessionCookieHeader,
 } from "./plaud-login";
-import {
-	decodeJwtExpMs,
-	refreshPlaudSession,
-	type RefreshTransport,
-} from "./plaud-refresh";
+import { decodeJwtExpMs, isFreshAccessToken } from "./plaud-refresh";
+import { buildPartitionPost, performNetRefresh } from "./plaud-refresh-net";
 import {
 	NoteWriter,
 	DEFAULT_NOTE_NAME_TEMPLATE,
@@ -1485,31 +1481,6 @@ export default class PlaudImporterPlugin extends Plugin {
 	// ---- Silent session refresh (Release B) -----------------------------
 
 	/**
-	 * The Obsidian-backed transport the refresh module needs: a `requestUrl` POST
-	 * (avoids CORS/cert issues on Electron) plus a read of the Plaud partition's
-	 * cookies. Built per call so it always reads the current region.
-	 */
-	private buildRefreshTransport(): RefreshTransport {
-		return {
-			post: async ({ url, headers, body }) => {
-				const response = await requestUrl({
-					url,
-					method: "POST",
-					headers: { ...headers },
-					body,
-					throw: false,
-				});
-				return {
-					status: response.status,
-					json: safeJson(response),
-					text: response.text ?? "",
-				};
-			},
-			readCookieHeader: (url) => readPlaudSessionCookieHeader(url),
-		};
-	}
-
-	/**
 	 * Blank any stored refresh token. Called whenever the access token is
 	 * replaced WITHOUT a matching fresh refresh token, so a later silent refresh
 	 * cannot use a previous session's WRT to authenticate as, and overwrite the
@@ -1531,78 +1502,159 @@ export default class PlaudImporterPlugin extends Plugin {
 	}
 
 	/**
-	 * Attempt one silent session refresh. FAIL-SAFE: the stored token is replaced
-	 * only when the endpoint returns a fresh WT (validated in plaud-refresh, and
-	 * re-checked here as defense in depth). Any failure leaves every stored value
-	 * untouched and returns false, so the caller falls through to today's
-	 * behavior. Never throws; never logs a token value. `reason` only tags the
-	 * debug log. Serialized by `refreshInFlight` so refreshes never overlap.
+	 * Attempt one silent session refresh by re-capturing a fresh workspace token
+	 * from a HIDDEN sign-in window on the persistent Plaud partition. The web app
+	 * auto-authenticates from the stored session and mints a fresh WT on load,
+	 * which the same capture used at login grabs — no user interaction, no need to
+	 * replicate Plaud's UT->WT token derivation (the direct refresh endpoint only
+	 * returns a UT, not the WT the data API needs).
+	 *
+	 * FAIL-SAFE: the stored token is replaced only when a fresh WT (typ WT, future
+	 * exp) is captured. A timeout, a closed window, or an unusable token leaves
+	 * every stored value untouched and returns false, so the caller falls back to
+	 * today's behavior. Never throws.
+	 *
+	 * Serialized against BOTH a concurrent silent refresh (`refreshInFlight`) and
+	 * a visible interactive sign-in (`reauthInFlight`): two windows on the same
+	 * partition would clobber each other's capture.
 	 */
 	private async tryRefreshSession(
 		reason: "scheduled" | "reactive" | "manual",
 	): Promise<boolean> {
-		if (this.disposed || this.refreshInFlight) {
+		if (this.disposed || this.refreshInFlight || this.reauthInFlight) {
 			return false;
 		}
 		this.refreshInFlight = true;
+		// Also hold the interactive-sign-in gate: a manual "Sign in" opening a
+		// second window on this partition mid-refresh would clobber the capture.
+		this.reauthInFlight = true;
 		try {
-			const storedRefreshToken = this.app.secretStorage.getSecret(
-				CAPTURED_REFRESH_SECRET_ID,
-			);
-			const result = await refreshPlaudSession({
-				apiBaseUrl: this.settings.apiBaseUrl,
-				refreshToken: storedRefreshToken,
-				transport: this.buildRefreshTransport(),
-				debugLogger: this.debugLogger,
-			});
-			// The refresh awaits the network; do not persist onto a torn-down plugin.
+			// Primary: the direct, windowless refresh over the partition cookies
+			// (POST /auth/refresh-user-token then the workspace/token mint). Returns
+			// false when the session.fetch surface is unavailable or any step fails,
+			// so we fall through to the headless window below.
+			if (await this.tryNetRefresh(reason)) {
+				return true;
+			}
 			if (this.disposed) {
 				return false;
 			}
-			if (!result.ok) {
-				this.logAutoSync(`session refresh (${reason}) failed`, {
-					reason: result.reason,
-				});
+			// Fallback: re-capture a fresh WT from a HIDDEN sign-in window, letting
+			// the web app mint it on load. Slower and heavier, but needs no knowledge
+			// of the credential and covers the case where the partition did not
+			// retain the httpOnly cookies the direct path relies on.
+			const result = await openPlaudLogin(this.app, {
+				debugLogger: this.debugLogger,
+				headless: true,
+			});
+			// The capture awaits a full app load; do not persist onto a torn-down
+			// plugin, and treat a timeout / closed window (null) as a benign failure.
+			if (this.disposed || result === null) {
+				if (result === null) {
+					this.logAutoSync(
+						`session refresh (${reason}) captured no token (timed out or session needs interaction)`,
+					);
+				}
 				return false;
 			}
-			// Defense in depth: the module already guarantees a fresh WT, but never
-			// overwrite a working token with something that is not even an access
-			// token if that guarantee ever regresses.
-			if (!isAccessToken(result.accessToken)) {
-				this.logAutoSync(
-					`session refresh (${reason}) returned a non-WT token; keeping existing`,
-				);
-				return false;
-			}
-			// Update the active secret in place (keeps a user's chosen secret slot),
-			// falling back to the captured-token slot when none is linked yet.
-			const targetSecretId =
-				this.settings.secretId.length > 0
-					? this.settings.secretId
-					: CAPTURED_SECRET_ID;
-			this.app.secretStorage.setSecret(targetSecretId, result.accessToken);
-			this.settings.secretId = targetSecretId;
-			if (result.refreshToken !== null && result.refreshToken.length > 0) {
-				// The refresh token rotates on each use; store the new one, stripped
-				// of any bearer prefix, for the next refresh.
-				this.app.secretStorage.setSecret(
-					CAPTURED_REFRESH_SECRET_ID,
-					result.refreshToken.replace(/^bearer\s+/i, ""),
-				);
-			}
-			if (result.apiBaseUrl.length > 0) {
-				this.settings.apiBaseUrl = result.apiBaseUrl;
-			}
-			await this.saveSettings();
-			this.logAutoSync(`session refreshed (${reason})`);
-			return true;
+			return await this.applyRefreshedToken(
+				result.token,
+				result.refreshToken,
+				result.apiBaseUrl,
+				reason,
+				"window",
+			);
 		} catch (err) {
 			// A refresh bug must log, not throw into the timer or the auto-sync tick.
 			console.error("Plaud importer: silent session refresh failed", err);
 			return false;
 		} finally {
 			this.refreshInFlight = false;
+			this.reauthInFlight = false;
 		}
+	}
+
+	/**
+	 * Primary refresh: the direct, windowless path. Reads `wid`/`client_id` off
+	 * the stored token, runs the two-step refresh over the partition cookie jar,
+	 * and hands the candidate WT to the shared fail-safe. Returns false (never
+	 * throws) when the session.fetch surface is missing, no token is stored, or
+	 * any step fails, so `tryRefreshSession` falls back to the headless window.
+	 */
+	private async tryNetRefresh(
+		reason: "scheduled" | "reactive" | "manual",
+	): Promise<boolean> {
+		const post = buildPartitionPost();
+		if (post === null) {
+			// No session.fetch on this runtime; the window path is the only option.
+			return false;
+		}
+		const token = this.currentAccessToken();
+		if (token === null) {
+			return false;
+		}
+		const result = await performNetRefresh({
+			currentToken: token,
+			baseUrl: this.settings.apiBaseUrl,
+			post,
+		});
+		if (this.disposed || result === null) {
+			return false;
+		}
+		return this.applyRefreshedToken(
+			result.token,
+			result.refreshToken,
+			result.apiBaseUrl,
+			reason,
+			"direct",
+		);
+	}
+
+	/**
+	 * Shared fail-safe for both refresh paths. Replaces the stored secrets ONLY
+	 * when the candidate decodes as a fresh workspace token (typ WT, future exp);
+	 * a non-WT or already-expired value is rejected and nothing is written, so a
+	 * failed refresh can never make things worse than the current stored token.
+	 */
+	private async applyRefreshedToken(
+		candidate: string,
+		refreshToken: string | null,
+		apiBaseUrl: string | null,
+		reason: "scheduled" | "reactive" | "manual",
+		via: "direct" | "window",
+	): Promise<boolean> {
+		if (
+			!isAccessToken(candidate) ||
+			!isFreshAccessToken(candidate, Date.now())
+		) {
+			this.logAutoSync(
+				`session refresh (${reason}, ${via}) produced a token that is not a fresh WT; keeping existing`,
+			);
+			return false;
+		}
+		const token = candidate.trim().replace(/^bearer\s+/i, "");
+		// Update the active secret in place (keeps a user's chosen secret slot),
+		// falling back to the captured-token slot when none is linked yet.
+		const targetSecretId =
+			this.settings.secretId.length > 0
+				? this.settings.secretId
+				: CAPTURED_SECRET_ID;
+		this.app.secretStorage.setSecret(targetSecretId, token);
+		this.settings.secretId = targetSecretId;
+		// Keep the paired refresh token if this refresh produced one; otherwise
+		// leave the stored one so a future attempt can still use it.
+		if (refreshToken !== null && refreshToken.trim().length > 0) {
+			this.app.secretStorage.setSecret(
+				CAPTURED_REFRESH_SECRET_ID,
+				refreshToken.trim().replace(/^bearer\s+/i, ""),
+			);
+		}
+		if (apiBaseUrl !== null) {
+			this.settings.apiBaseUrl = apiBaseUrl;
+		}
+		await this.saveSettings();
+		this.logAutoSync(`session refreshed (${reason}, ${via})`);
+		return true;
 	}
 
 	/**

--- a/main.ts
+++ b/main.ts
@@ -1509,6 +1509,20 @@ export default class PlaudImporterPlugin extends Plugin {
 		};
 	}
 
+	/**
+	 * Blank any stored refresh token. Called whenever the access token is
+	 * replaced WITHOUT a matching fresh refresh token, so a later silent refresh
+	 * cannot use a previous session's WRT to authenticate as, and overwrite the
+	 * new token with, the wrong account.
+	 */
+	private clearStoredRefreshToken(): void {
+		try {
+			this.app.secretStorage.setSecret(CAPTURED_REFRESH_SECRET_ID, "");
+		} catch (err) {
+			console.error("Plaud importer: failed to blank refresh token", err);
+		}
+	}
+
 	/** The currently-active access token (trimmed), or null when none is stored. */
 	private currentAccessToken(): string | null {
 		if (this.settings.secretId.length === 0) return null;
@@ -2123,12 +2137,16 @@ export default class PlaudImporterPlugin extends Plugin {
 			this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, result.token);
 			this.settings.secretId = CAPTURED_SECRET_ID;
 			// Keep the paired refresh token (typ WRT) for the silent-refresh path.
-			// It flies during login; store it stripped of any bearer prefix.
+			// It flies during login; store it stripped of any bearer prefix. When
+			// this sign-in did not capture a WRT, blank any stale one so a silent
+			// refresh cannot resurrect the previous session with a mismatched token.
 			if (result.refreshToken !== null && result.refreshToken.trim().length > 0) {
 				this.app.secretStorage.setSecret(
 					CAPTURED_REFRESH_SECRET_ID,
 					result.refreshToken.trim().replace(/^bearer\s+/i, ""),
 				);
+			} else {
+				this.clearStoredRefreshToken();
 			}
 			if (result.apiBaseUrl !== null) {
 				this.settings.apiBaseUrl = result.apiBaseUrl;
@@ -2230,11 +2248,15 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 		this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, token);
 		this.settings.secretId = CAPTURED_SECRET_ID;
+		// A pasted/deep-linked token carries no refresh token (only the WT), so
+		// blank any stale WRT from a previous session; a silent refresh must not
+		// resurrect that session and overwrite this token with the wrong account's.
+		// The refresh then relies on the partition cookies until the next in-app
+		// sign-in captures a fresh WRT.
+		this.clearStoredRefreshToken();
 		await this.saveSettings();
 		// A newly pasted token clears any refresh backoff and reschedules the
-		// proactive refresh from its expiry. This paste path carries no refresh
-		// token (only the WT), so the silent refresh relies on the partition
-		// cookies until the next in-app sign-in captures a WRT.
+		// proactive refresh from its expiry.
 		this.refreshFailureStreak = 0;
 		this.reconcileTokenRefresh();
 		return true;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
+		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-refresh.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/plaud-refresh.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-refresh.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/plaud-refresh.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
+		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-refresh.ts plaud-refresh-net.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/plaud-refresh.test.ts __tests__/plaud-refresh-net.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/plaud-login.ts
+++ b/plaud-login.ts
@@ -50,6 +50,11 @@ const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
 // with `status: -3901 "token type does not match parse mode"`. Only accept the
 // access token. Verified against a live web.plaud.ai session on 2026-06-18.
 const ACCESS_TOKEN_TYP = 'WT';
+// The paired REFRESH token type. The web app sends the WRT in an Authorization
+// header during login before the WT; we now keep it (in addition to the WT) so
+// the silent-refresh path can send it as a bearer if that is the credential the
+// refresh endpoint wants. See plaud-refresh.ts.
+const REFRESH_TOKEN_TYP = 'WRT';
 
 // Reads the JWT header `typ` from a (possibly bearer-prefixed) token, or null
 // when the value is not a decodable JWT.
@@ -73,6 +78,10 @@ function jwtTyp(value: string): string | null {
 
 export function isAccessToken(value: string): boolean {
 	return jwtTyp(value) === ACCESS_TOKEN_TYP;
+}
+
+export function isRefreshToken(value: string): boolean {
+	return jwtTyp(value) === REFRESH_TOKEN_TYP;
 }
 
 // Injected as a fallback when the session-level capture is unavailable.
@@ -139,6 +148,12 @@ export interface PlaudLoginResult {
 	readonly token: string;
 	/** Regional API origin if discoverable, else null. */
 	readonly apiBaseUrl: string | null;
+	/**
+	 * The paired refresh token (typ WRT) if it flew by during login, else null.
+	 * Kept for the silent-refresh path (plaud-refresh.ts); the WT is what the
+	 * data API uses. May carry a "bearer " prefix.
+	 */
+	readonly refreshToken: string | null;
 }
 
 export interface PlaudLoginOptions {
@@ -172,6 +187,12 @@ interface SessionLike {
 	clearCache?(): Promise<void>;
 	// Sets the user-agent for every request in this session.
 	setUserAgent?(userAgent: string): void;
+	// Electron Session cookie store. `get` returns httpOnly cookies too (unlike
+	// document.cookie), which is what the silent refresh needs. Guarded at the
+	// call site because it may be absent where the remote module is disabled.
+	cookies?: {
+		get(filter: { url?: string }): Promise<ReadonlyArray<{ name: string; value: string }>>;
+	};
 }
 interface WebContentsLike {
 	executeJavaScript(code: string): Promise<unknown>;
@@ -253,6 +274,41 @@ export async function clearPlaudLoginSession(): Promise<boolean> {
 }
 
 /**
+ * Read the Plaud sign-in partition's cookies for `url` as a `Cookie` header
+ * value (name=value; ...), or null when there are none or the session cookie API
+ * is unavailable on this build. Includes httpOnly cookies (Electron's cookie
+ * store exposes them, unlike document.cookie), which is what the silent refresh
+ * needs. Never throws — a failure resolves to null so the refresh's bearer path
+ * can still carry the request.
+ */
+export async function readPlaudSessionCookieHeader(
+	url: string,
+): Promise<string | null> {
+	const session = requireElectron()?.remote?.session?.fromPartition(
+		PLAUD_PARTITION,
+	);
+	const cookies = session?.cookies;
+	if (cookies === undefined || typeof cookies.get !== 'function') {
+		return null;
+	}
+	try {
+		// The declared element type is { name: string; value: string }; iterate
+		// (rather than Array.isArray, which widens to any[]) and guard each field
+		// defensively in case the remote bridge returns a looser shape.
+		const list = await cookies.get({ url });
+		const parts: string[] = [];
+		for (const cookie of list) {
+			if (typeof cookie.name === 'string' && typeof cookie.value === 'string') {
+				parts.push(`${cookie.name}=${cookie.value}`);
+			}
+		}
+		return parts.length > 0 ? parts.join('; ') : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Open the Plaud sign-in window. Resolves with the captured token (and region)
  * once the web app makes an authenticated request, or null if the user closes
  * the window first or the BrowserWindow API is unavailable on this build.
@@ -275,6 +331,10 @@ class PlaudLoginSession {
 	private settled = false;
 	// Authorization header captured by the session-level listener (primary path).
 	private capturedAuth: string | null = null;
+	// The paired refresh token (typ WRT) seen during login, kept for the silent
+	// refresh path. It flies before the WT, so it is set by the time the WT
+	// arrives and the session settles.
+	private capturedRefresh: string | null = null;
 	private webRequestSession: SessionLike | null = null;
 
 	constructor(
@@ -385,8 +445,13 @@ class PlaudLoginSession {
 		this.note('token captured', 'note', {
 			apiBaseUrl,
 			via: this.capturedAuth !== null ? 'session' : 'page-hook',
+			refreshTokenCaptured: this.capturedRefresh !== null,
 		});
-		this.settle({ token: value, apiBaseUrl });
+		this.settle({
+			token: value,
+			apiBaseUrl,
+			refreshToken: this.capturedRefresh,
+		});
 		this.closeWindow();
 	}
 
@@ -427,11 +492,18 @@ class PlaudLoginSession {
 			session.webRequest.onSendHeaders(SESSION_FILTER, (details) => {
 				const headers = details.requestHeaders ?? {};
 				const auth = headers.Authorization ?? headers.authorization;
-				// Only keep the workspace ACCESS token (typ WT). The refresh
-				// token (WRT) is sent first during login; capturing it is what
-				// produced `-3901 "token type does not match parse mode"`.
-				if (typeof auth === 'string' && isAccessToken(auth)) {
+				if (typeof auth !== 'string') {
+					return;
+				}
+				// Only the workspace ACCESS token (typ WT) works on the data API;
+				// storing the refresh token (WRT) here is what produced
+				// `-3901 "token type does not match parse mode"`. But we DO keep the
+				// WRT separately for the silent-refresh path (plaud-refresh.ts),
+				// where it is a candidate credential, not a data-API token.
+				if (isAccessToken(auth)) {
 					this.capturedAuth = auth;
+				} else if (isRefreshToken(auth)) {
+					this.capturedRefresh = auth;
 				}
 			});
 			this.note('session header capture armed');

--- a/plaud-login.ts
+++ b/plaud-login.ts
@@ -37,6 +37,9 @@ const PLAUD_LOGIN_URL = 'https://web.plaud.ai';
 // not have to sign in every time. Isolated from Obsidian's own web sessions.
 const PLAUD_PARTITION = 'persist:plaud-importer';
 const POLL_INTERVAL_MS = 1000;
+// Silent-refresh giveup. The app boot + auto-auth + first data call took ~30s in
+// practice; 90s gives comfortable headroom before falling back to interactive.
+const DEFAULT_HEADLESS_TIMEOUT_MS = 90 * 1000;
 // Match patterns for Plaud API hosts (covers regional hosts like api-euc1).
 const SESSION_FILTER = { urls: ['*://*.plaud.ai/*'] };
 // A JWT, optionally bearer-prefixed.
@@ -158,6 +161,20 @@ export interface PlaudLoginResult {
 
 export interface PlaudLoginOptions {
 	readonly debugLogger?: DebugLogger;
+	/**
+	 * Silent refresh mode: open the window hidden and expect no user interaction.
+	 * The persistent partition auto-authenticates and the web app mints a fresh
+	 * WT on load, which the same capture grabs. Paired with `timeoutMs` so a
+	 * session that DOES need interaction (e.g. a 30-day-expired login) times out
+	 * and resolves null instead of leaving an invisible window open forever.
+	 */
+	readonly headless?: boolean;
+	/**
+	 * When `headless`, give up and resolve null after this long if no token was
+	 * captured. Ignored for the visible flow (the user drives that). Defaults to
+	 * DEFAULT_HEADLESS_TIMEOUT_MS.
+	 */
+	readonly timeoutMs?: number;
 }
 
 interface ProbeResult {
@@ -187,15 +204,17 @@ interface SessionLike {
 	clearCache?(): Promise<void>;
 	// Sets the user-agent for every request in this session.
 	setUserAgent?(userAgent: string): void;
-	// Electron Session cookie store. `get` returns httpOnly cookies too (unlike
-	// document.cookie), which is what the silent refresh needs. Guarded at the
-	// call site because it may be absent where the remote module is disabled.
-	cookies?: {
-		get(filter: { url?: string }): Promise<ReadonlyArray<{ name: string; value: string }>>;
-	};
 }
 interface WebContentsLike {
 	executeJavaScript(code: string): Promise<unknown>;
+	// Deny/allow popups and new windows the loaded page requests. Present on real
+	// Electron builds; guarded at the call site. We deny all: the sign-in only
+	// needs the main frame's own API call, never a popup, and the Plaud web app
+	// otherwise spawns feedback/analytics popups that Obsidian routes to the
+	// system browser.
+	setWindowOpenHandler?(
+		handler: (details: { url: string }) => { action: 'deny' | 'allow' },
+	): void;
 }
 interface BrowserWindowLike {
 	webContents: WebContentsLike;
@@ -209,7 +228,10 @@ interface BrowserWindowOptions {
 	height?: number;
 	title?: string;
 	autoHideMenuBar?: boolean;
-	webPreferences?: { partition?: string };
+	// false opens the window hidden (silent-refresh mode). Omitted/true is the
+	// visible sign-in window.
+	show?: boolean;
+	webPreferences?: { partition?: string; backgroundThrottling?: boolean };
 }
 interface BrowserWindowConstructor {
 	new (options: BrowserWindowOptions): BrowserWindowLike;
@@ -274,41 +296,6 @@ export async function clearPlaudLoginSession(): Promise<boolean> {
 }
 
 /**
- * Read the Plaud sign-in partition's cookies for `url` as a `Cookie` header
- * value (name=value; ...), or null when there are none or the session cookie API
- * is unavailable on this build. Includes httpOnly cookies (Electron's cookie
- * store exposes them, unlike document.cookie), which is what the silent refresh
- * needs. Never throws — a failure resolves to null so the refresh's bearer path
- * can still carry the request.
- */
-export async function readPlaudSessionCookieHeader(
-	url: string,
-): Promise<string | null> {
-	const session = requireElectron()?.remote?.session?.fromPartition(
-		PLAUD_PARTITION,
-	);
-	const cookies = session?.cookies;
-	if (cookies === undefined || typeof cookies.get !== 'function') {
-		return null;
-	}
-	try {
-		// The declared element type is { name: string; value: string }; iterate
-		// (rather than Array.isArray, which widens to any[]) and guard each field
-		// defensively in case the remote bridge returns a looser shape.
-		const list = await cookies.get({ url });
-		const parts: string[] = [];
-		for (const cookie of list) {
-			if (typeof cookie.name === 'string' && typeof cookie.value === 'string') {
-				parts.push(`${cookie.name}=${cookie.value}`);
-			}
-		}
-		return parts.length > 0 ? parts.join('; ') : null;
-	} catch {
-		return null;
-	}
-}
-
-/**
  * Open the Plaud sign-in window. Resolves with the captured token (and region)
  * once the web app makes an authenticated request, or null if the user closes
  * the window first or the BrowserWindow API is unavailable on this build.
@@ -336,6 +323,10 @@ class PlaudLoginSession {
 	// arrives and the session settles.
 	private capturedRefresh: string | null = null;
 	private webRequestSession: SessionLike | null = null;
+	// Silent-refresh mode: window opens hidden and auto-gives-up after the timeout.
+	private readonly headless: boolean;
+	private readonly timeoutMs: number;
+	private timeoutHandle: number | null = null;
 
 	constructor(
 		options: PlaudLoginOptions,
@@ -343,6 +334,8 @@ class PlaudLoginSession {
 	) {
 		this.debugLogger = options.debugLogger ?? new NoopDebugLogger();
 		this.resolve = resolve;
+		this.headless = options.headless === true;
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_HEADLESS_TIMEOUT_MS;
 	}
 
 	start(): void {
@@ -363,12 +356,46 @@ class PlaudLoginSession {
 				height: 760,
 				title: 'Plaud sign-in',
 				autoHideMenuBar: true,
-				webPreferences: { partition: PLAUD_PARTITION },
+				// Silent refresh opens hidden: the persistent partition auto-
+				// authenticates and the web app mints a fresh WT on load with no
+				// user interaction, which the same capture grabs.
+				show: !this.headless,
+				webPreferences: {
+					partition: PLAUD_PARTITION,
+					// A hidden window is otherwise timer-throttled by Electron, which
+					// would stall the web app's auth/boot in the headless refresh.
+					backgroundThrottling: !this.headless,
+				},
 			});
 		} catch (err) {
 			this.note(`failed to open sign-in window: ${String(err)}`, 'error');
 			this.settle(null);
 			return;
+		}
+
+		// In headless mode a session that genuinely needs interaction (e.g. the
+		// 30-day login finally expired) would otherwise leave an invisible window
+		// open forever. Give up after the timeout and resolve null so the caller
+		// falls back to the interactive flow. No timer in the visible flow — the
+		// user drives that and closing the window resolves null.
+		if (this.headless && Number.isFinite(this.timeoutMs)) {
+			this.timeoutHandle = window.setTimeout(() => {
+				this.note('headless refresh timed out; no token captured');
+				this.settle(null);
+			}, this.timeoutMs);
+		}
+
+		// Deny every popup / new window the page requests, BEFORE loading it. The
+		// Plaud web app fires window.open on load (feedback widget, analytics, an
+		// auth-redirect popup); Obsidian routes those to the system browser, which
+		// spawned stray tabs. We only need the main frame's own API call.
+		const contents = this.win.webContents;
+		if (typeof contents.setWindowOpenHandler === 'function') {
+			try {
+				contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+			} catch (err) {
+				this.note(`could not install window-open handler: ${String(err)}`, 'error');
+			}
 		}
 
 		// If the user closes the window before a token is captured, the caller
@@ -540,8 +567,16 @@ class PlaudLoginSession {
 			return;
 		}
 		this.settled = true;
+		if (this.timeoutHandle !== null) {
+			window.clearTimeout(this.timeoutHandle);
+			this.timeoutHandle = null;
+		}
 		this.stopPolling();
 		this.teardownSessionCapture();
+		// Close the window on every settle path (success closes it too, via
+		// captureToken). Matters for the headless timeout: without this the hidden
+		// window would leak. Guarded/idempotent; a no-op once 'closed' has fired.
+		this.closeWindow();
 		this.resolve(result);
 	}
 

--- a/plaud-refresh-net.ts
+++ b/plaud-refresh-net.ts
@@ -1,0 +1,329 @@
+// Direct, windowless session refresh (Release B, primary path).
+//
+// Replaces the hidden-BrowserWindow re-capture with two API calls on the
+// persistent Plaud sign-in partition. Reverse-engineered from a full login HAR
+// on 2026-07-06 (see dev-docs/plaud-importer/2026-07-06-token-refresh-mechanism.md,
+// "WT-mint endpoint IDENTIFIED"). Both the user token (UT) and workspace token
+// (WT) live ~24h, so after a day both are stale and the refresh is two steps:
+//
+//   1. POST /auth/refresh-user-token           empty body; the URT cookie mints a
+//                                               fresh UT and rotates the URT cookie
+//   2. POST /user-app/auth/workspace/token/{wid}  body {}; the fresh UT cookie
+//                                               mints the 24h WT the data API needs
+//
+// Auth on both calls is the partition's httpOnly cookies, NOT a bearer header
+// (the real requests carry no Authorization; the login response body even
+// returns empty token strings). A session-bound transport is therefore
+// mandatory: it auto-attaches those cookies AND persists call 1's rotated
+// Set-Cookie into the jar so call 2 sees the fresh UT. Manual cookie forwarding
+// would drop the rotation between the two calls.
+//
+// FAIL-SAFE: this module only ever RETURNS a candidate token; it never writes
+// storage. The caller re-validates (typ WT, future exp) before replacing
+// anything, and on any null result falls back to the headless-window path. Every
+// step is guarded and the orchestrator never throws.
+//
+// NOT YET HANDS-ON VALIDATED: exercised only by unit tests with a stubbed
+// transport. The live assumptions (partition retains the api.plaud.ai httpOnly
+// cookies across restarts; the mint call needs no x-device-id) are unproven
+// until Charles runs "Refresh session now" in his vault. A failure here is
+// benign: it returns null and the headless fallback runs.
+
+import { readJwtPayloadClaim } from './plaud-refresh';
+
+// The Plaud web app's sign-in partition. Mirrors PLAUD_PARTITION in
+// plaud-login.ts (kept local so this module has no import cycle with the login
+// window it falls back to).
+const PLAUD_PARTITION = 'persist:plaud-importer';
+
+const REFRESH_USER_TOKEN_PATH = '/auth/refresh-user-token';
+const WORKSPACE_TOKEN_PATH_PREFIX = '/user-app/auth/workspace/token/';
+
+// Plaud's "success" status in a JSON envelope. Anything else is treated as a
+// failure (fall back), except the region-redirect status handled below.
+const STATUS_OK = 0;
+// Region-mismatch soft redirect: HTTP 200 whose body carries the regional host
+// in data.domains.api. Matches detectRegionRedirect() in plaud-client-re.ts.
+const STATUS_REGION_REDIRECT = -302;
+
+// Only ever talk to Plaud's own hosts, even when a redirect body names the
+// target. A tampered redirect must not steer a cookie-authenticated call to an
+// arbitrary origin.
+const ALLOWED_HOST_SUFFIX = '.plaud.ai';
+const ALLOWED_EXACT_HOSTS = new Set(['plaud.ai', 'api.plaud.ai']);
+
+/** A single session-bound POST. Injected so tests drive it without Electron. */
+export interface SessionPost {
+	(
+		url: string,
+		body: string,
+		headers: Readonly<Record<string, string>>,
+	): Promise<{ status: number; text: string }>;
+}
+
+export interface NetRefreshDeps {
+	/** The stored workspace token (may be expired). Source of `wid`/`client_id`. */
+	readonly currentToken: string;
+	/** Current API origin, no trailing slash, e.g. `https://api.plaud.ai`. */
+	readonly baseUrl: string;
+	/** Session-bound transport (partition cookie jar). */
+	readonly post: SessionPost;
+}
+
+export interface NetRefreshResult {
+	/** The fresh workspace token (typ WT). Caller validates before storing. */
+	readonly token: string;
+	/** The rotated workspace refresh token, when the mint returned one. */
+	readonly refreshToken: string | null;
+	/** A regional API origin to persist, when a redirect moved us. */
+	readonly apiBaseUrl: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+/** Parse a JSON envelope, or null when the text is not a JSON object. */
+function parseEnvelope(text: string): Record<string, unknown> | null {
+	try {
+		const parsed: unknown = JSON.parse(text);
+		return isRecord(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The `wid` claim off the stored token, validated to look like a workspace id.
+ * Exported for direct unit testing.
+ */
+export function extractWorkspaceId(token: string): string | null {
+	const wid = readJwtPayloadClaim(token, 'wid');
+	return wid !== null && wid.startsWith('ws_') ? wid : null;
+}
+
+/**
+ * Normalize a URL to its origin (scheme + host, no path/query/userinfo) IF it is
+ * a trusted Plaud https host, else null. The cookie-authenticated POSTs attach
+ * the partition's httpOnly Plaud session, so every target host this module talks
+ * to must pass through here first: a malformed or tampered base/redirect must
+ * never be able to steer those cookies at an arbitrary origin. Exported for
+ * unit testing.
+ */
+export function normalizeTrustedOrigin(raw: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== 'https:') {
+		return null;
+	}
+	const host = parsed.hostname.toLowerCase();
+	const trusted =
+		ALLOWED_EXACT_HOSTS.has(host) || host.endsWith(ALLOWED_HOST_SUFFIX);
+	return trusted ? `${parsed.protocol}//${parsed.host}` : null;
+}
+
+/**
+ * Pull a validated regional origin from a redirect envelope, or null when the
+ * body is not a redirect or the target is not a trusted Plaud https host.
+ * Exported for unit testing.
+ */
+export function readRegionRedirect(envelope: Record<string, unknown>): string | null {
+	if (envelope.status !== STATUS_REGION_REDIRECT) {
+		return null;
+	}
+	const data = envelope.data;
+	if (!isRecord(data)) {
+		return null;
+	}
+	const domains = data.domains;
+	if (!isRecord(domains)) {
+		return null;
+	}
+	const api = domains.api;
+	return typeof api === 'string' ? normalizeTrustedOrigin(api) : null;
+}
+
+/**
+ * Extract the workspace token + rotated refresh token from a mint response,
+ * or null when the envelope is not a success carrying a `workspace_token`
+ * string. Exported for unit testing.
+ */
+export function parseWorkspaceTokenResponse(
+	envelope: Record<string, unknown>,
+): { token: string; refreshToken: string | null } | null {
+	if (envelope.status !== STATUS_OK) {
+		return null;
+	}
+	const data = envelope.data;
+	if (!isRecord(data)) {
+		return null;
+	}
+	const token = data.workspace_token;
+	if (typeof token !== 'string' || token.length === 0) {
+		return null;
+	}
+	const refresh = data.refresh_token;
+	return {
+		token,
+		refreshToken:
+			typeof refresh === 'string' && refresh.length > 0 ? refresh : null,
+	};
+}
+
+// Headers common to Plaud's browser API calls, minus auth (cookies) and the
+// per-request nonce. app-platform/edit-from track the token's client_id so the
+// server's parse-mode check agrees (see plaud-client-re.ts). x-device-id is
+// deliberately omitted: it lives in the partition's localStorage, out of reach
+// without a window, and the mint call authenticates by cookie. If the server
+// turns out to require it, this path fails and the headless fallback runs.
+function baseHeaders(clientId: string): Record<string, string> {
+	return {
+		accept: 'application/json, text/plain, */*',
+		'content-type': 'application/json',
+		'app-platform': clientId,
+		'app-language': 'en',
+		'edit-from': clientId,
+		origin: 'https://web.plaud.ai',
+		referer: 'https://web.plaud.ai/',
+	};
+}
+
+/**
+ * Run the two-step direct refresh. Returns a candidate WT (never stores it), or
+ * null on any failure so the caller falls back to the headless window. Never
+ * throws.
+ */
+export async function performNetRefresh(
+	deps: NetRefreshDeps,
+): Promise<NetRefreshResult | null> {
+	try {
+		const wid = extractWorkspaceId(deps.currentToken);
+		if (wid === null) {
+			return null;
+		}
+		const clientId = readJwtPayloadClaim(deps.currentToken, 'client_id') ?? 'web';
+		const headers = baseHeaders(clientId);
+
+		// Validate the starting host BEFORE any cookie-bearing POST: a malformed
+		// or tampered stored base must never send the partition's Plaud session
+		// cookies to a non-Plaud origin. Redirect targets are validated the same
+		// way inside the loop.
+		let base = normalizeTrustedOrigin(deps.baseUrl);
+		if (base === null) {
+			return null;
+		}
+		let apiBaseUrl: string | null = null;
+		for (let attempt = 0; attempt < 2; attempt++) {
+			const res = await deps.post(
+				`${base}${REFRESH_USER_TOKEN_PATH}`,
+				'{}',
+				headers,
+			);
+			const envelope = parseEnvelope(res.text);
+			if (envelope === null) {
+				return null;
+			}
+			if (envelope.status === STATUS_OK) {
+				break;
+			}
+			const redirect = readRegionRedirect(envelope);
+			if (redirect === null || attempt === 1) {
+				return null;
+			}
+			base = redirect;
+			apiBaseUrl = redirect;
+		}
+
+		// Step 2: mint the workspace token. The fresh UT cookie from step 1 is
+		// already in the session jar, so this call just needs the cookie + wid.
+		const mint = await deps.post(
+			`${base}${WORKSPACE_TOKEN_PATH_PREFIX}${wid}`,
+			'{}',
+			headers,
+		);
+		const mintEnvelope = parseEnvelope(mint.text);
+		if (mintEnvelope === null) {
+			return null;
+		}
+		const parsed = parseWorkspaceTokenResponse(mintEnvelope);
+		if (parsed === null) {
+			return null;
+		}
+		return {
+			token: parsed.token,
+			refreshToken: parsed.refreshToken,
+			apiBaseUrl,
+		};
+	} catch {
+		// A refresh bug must never throw into the timer or the auto-sync tick.
+		return null;
+	}
+}
+
+// --- Electron runtime adapter (guarded; untyped remote surface) --------------
+
+interface ElectronSessionFetchResponse {
+	status: number;
+	text(): Promise<string>;
+}
+interface ElectronSessionLike {
+	fetch?(
+		url: string,
+		options: { method: string; body: string; headers: Record<string, string> },
+	): Promise<ElectronSessionFetchResponse>;
+}
+interface ElectronRemoteLike {
+	session?: { fromPartition(partition: string): ElectronSessionLike };
+}
+interface ElectronLike {
+	remote?: ElectronRemoteLike;
+}
+
+type SessionWithFetch = ElectronSessionLike & {
+	fetch: NonNullable<ElectronSessionLike['fetch']>;
+};
+
+function hasFetch(session: ElectronSessionLike): session is SessionWithFetch {
+	return typeof session.fetch === 'function';
+}
+
+function requireElectron(): ElectronLike | null {
+	const req = (window as { require?: (id: string) => unknown }).require;
+	if (typeof req !== 'function') {
+		return null;
+	}
+	try {
+		return req('electron') as ElectronLike;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build a session-bound POST over the sign-in partition using Electron's
+ * `session.fetch` (Electron 28+, present on Obsidian 1.11.4's runtime). Returns
+ * null when the remote/session/fetch surface is unavailable, so the caller
+ * skips the direct path and uses the headless window instead.
+ */
+export function buildPartitionPost(): SessionPost | null {
+	const session = requireElectron()?.remote?.session?.fromPartition(
+		PLAUD_PARTITION,
+	);
+	if (session === undefined || !hasFetch(session)) {
+		return null;
+	}
+	return async (url, body, headers) => {
+		// Member call (not a detached reference) so `this` stays bound to session.
+		const res = await session.fetch(url, {
+			method: 'POST',
+			body,
+			headers: { ...headers },
+		});
+		const text = await res.text();
+		return { status: res.status, text };
+	};
+}

--- a/plaud-refresh.ts
+++ b/plaud-refresh.ts
@@ -1,0 +1,324 @@
+// Silent Plaud session refresh (Release B).
+//
+// Plaud issues a short access token (JWT typ WT, 24h) and a long refresh token
+// (urt, 30 days, rotated on use). The web app silently POSTs
+// `{apiBase}/auth/refresh-user-token` before the WT expires and gets a fresh
+// WT + URT back, so the browser stays logged in for weeks. Our plugin captured
+// only the WT and never refreshed, so it hard-failed at ~24h. This module
+// replicates that refresh call.
+//
+// The exact credential the endpoint wants is not fully pinned (an httpOnly
+// cookie sent with the request, or an in-memory URT bearer added by the web
+// app's axios interceptor). Live tests showed the WT bearer alone and a bare
+// cross-origin cookie call each fail. So this sends BOTH candidates in one
+// request: the Plaud partition's cookies (read straight from Electron's cookie
+// jar, including httpOnly) AND, when we captured it at sign-in, the rotating
+// refresh token (WRT) as a bearer. One of the two is the real credential.
+//
+// Fail-safe by construction: a caller is only ever told to overwrite the stored
+// token when the endpoint returns HTTP 2xx, `status: 0`, and an access token
+// that decodes as typ WT with a future exp. Every other outcome is a failure
+// the caller falls through on, leaving today's token untouched.
+//
+// The HTTP call and cookie read are injected (RefreshTransport) so the response
+// handling is unit-testable without Electron; main.ts wires the real transport.
+
+import type { DebugLogger } from './debug-logger';
+
+const REFRESH_ENDPOINT_PATH = '/auth/refresh-user-token';
+
+// The refresh response is a soft envelope like the data API's: HTTP 200 with a
+// `status` field. `0` is success; a region mismatch carries the correct host
+// under `data.domains.api` and expects a retry there.
+const REFRESH_SUCCESS_STATUS = 0;
+
+// Trusted hosts a region switch may redirect the refresh to. The request
+// carries credentials, so the redirect target is a trust boundary: only ever
+// follow it to a Plaud host.
+const ALLOWED_HOST_SUFFIX = '.plaud.ai';
+const ALLOWED_EXACT_HOSTS = new Set(['plaud.ai', 'api.plaud.ai']);
+
+// A JWT, optionally bearer-prefixed.
+const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+const ACCESS_TOKEN_TYP = 'WT';
+
+/** One HTTP round-trip the refresh needs, plus a read of the partition cookies. */
+export interface RefreshTransport {
+	/**
+	 * POST the given body to `url` with the given headers. Must map any transport
+	 * failure (offline, TLS) to a rejected promise, and any HTTP status to a
+	 * resolved `{ status, json, text }` (never throw on a 4xx/5xx), mirroring the
+	 * Plaud client's Obsidian `requestUrl` adapter.
+	 */
+	post(req: {
+		readonly url: string;
+		readonly headers: Readonly<Record<string, string>>;
+		readonly body: string;
+	}): Promise<{ status: number; json: unknown; text: string }>;
+	/**
+	 * Return the `Cookie` header value for the given URL from the Plaud sign-in
+	 * partition (including httpOnly cookies), or null when unavailable. Never
+	 * throws — a failure resolves to null so the bearer path can still carry the
+	 * request.
+	 */
+	readCookieHeader(url: string): Promise<string | null>;
+}
+
+export interface RefreshSessionOptions {
+	/** Current Plaud API origin (e.g. https://api.plaud.ai). */
+	readonly apiBaseUrl: string;
+	/** Stored rotating refresh token (WRT) to send as a bearer, or null. */
+	readonly refreshToken: string | null;
+	readonly transport: RefreshTransport;
+	readonly debugLogger?: DebugLogger;
+	/** Injectable clock for testing the exp validation. Defaults to Date.now. */
+	readonly now?: () => number;
+}
+
+export interface RefreshSuccess {
+	readonly ok: true;
+	/** Fresh access token (validated typ WT with a future exp). */
+	readonly accessToken: string;
+	/** Fresh rotating refresh token from the body, or null when absent. */
+	readonly refreshToken: string | null;
+	/** Origin the refresh succeeded against (may differ after a region switch). */
+	readonly apiBaseUrl: string;
+}
+
+export interface RefreshFailure {
+	readonly ok: false;
+	/** Non-identifying reason for the debug log. Never carries a token value. */
+	readonly reason: string;
+}
+
+export type RefreshResult = RefreshSuccess | RefreshFailure;
+
+/** Reads the JWT header `typ`, or null when the value is not a decodable JWT. */
+export function jwtTyp(value: string): string | null {
+	const match = value.replace(/^bearer\s+/i, '').match(JWT_RE);
+	if (match === null) {
+		return null;
+	}
+	const header = decodeJwtSegment(match[0].split('.')[0]);
+	return header !== null && typeof header.typ === 'string' ? header.typ : null;
+}
+
+/**
+ * Reads the JWT `exp` claim as unix MILLISECONDS, or null when the token is not
+ * a decodable JWT or has no numeric `exp`. Used to schedule a refresh ~5 min
+ * before the access token expires and to enforce the fail-safe future-exp check.
+ */
+export function decodeJwtExpMs(value: string): number | null {
+	const match = value.replace(/^bearer\s+/i, '').match(JWT_RE);
+	if (match === null) {
+		return null;
+	}
+	const parts = match[0].split('.');
+	if (parts.length < 2) {
+		return null;
+	}
+	const payload = decodeJwtSegment(parts[1]);
+	if (payload === null || typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) {
+		return null;
+	}
+	return payload.exp * 1000;
+}
+
+function decodeJwtSegment(seg: string): Record<string, unknown> | null {
+	try {
+		const b64 = seg.replace(/-/g, '+').replace(/_/g, '/');
+		const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+		// atob is always present in Obsidian's Electron renderer (and Node 18+);
+		// avoid the Node `Buffer` global, which is untyped in the marketplace
+		// scan's type-checked lint and trips the no-unsafe-* rules.
+		return JSON.parse(atob(padded)) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+/** True when the token decodes as an access token (typ WT) with a future exp. */
+export function isFreshAccessToken(token: string, nowMs: number): boolean {
+	if (jwtTyp(token) !== ACCESS_TOKEN_TYP) {
+		return false;
+	}
+	const exp = decodeJwtExpMs(token);
+	return exp !== null && exp > nowMs;
+}
+
+type ParsedRefresh =
+	| { readonly kind: 'success'; readonly accessToken: string; readonly refreshToken: string | null }
+	| { readonly kind: 'switch'; readonly apiBaseUrl: string }
+	| { readonly kind: 'failure'; readonly reason: string };
+
+/**
+ * Interpret a refresh response body. Success requires `status: 0` and an access
+ * token that is a fresh WT (fail-safe). A non-success body carrying a trusted
+ * `data.domains.api` host is a region switch to retry against. Everything else
+ * is a failure. Pure and exported for unit testing.
+ */
+export function parseRefreshResponse(body: unknown, nowMs: number): ParsedRefresh {
+	if (!isRecord(body)) {
+		return { kind: 'failure', reason: 'response body is not an object' };
+	}
+	const status = typeof body.status === 'number' ? body.status : null;
+	if (status === REFRESH_SUCCESS_STATUS) {
+		const accessToken =
+			typeof body.access_token === 'string' ? body.access_token.trim() : '';
+		if (accessToken.length === 0) {
+			return { kind: 'failure', reason: 'success status but no access_token' };
+		}
+		if (!isFreshAccessToken(accessToken, nowMs)) {
+			// Never hand back a token that is not a fresh WT: the caller would
+			// otherwise overwrite a still-usable token with a worse one.
+			return {
+				kind: 'failure',
+				reason: 'access_token is not a fresh WT (wrong typ or already expired)',
+			};
+		}
+		const refreshToken =
+			typeof body.refresh_token === 'string' && body.refresh_token.trim().length > 0
+				? body.refresh_token.trim()
+				: null;
+		return { kind: 'success', accessToken, refreshToken };
+	}
+	// Region switch: a non-success body may point at the correct regional host.
+	const switchHost = readRegionSwitchHost(body);
+	if (switchHost !== null) {
+		return { kind: 'switch', apiBaseUrl: switchHost };
+	}
+	const msg = typeof body.msg === 'string' && body.msg.length > 0 ? body.msg : '(no message)';
+	return {
+		kind: 'failure',
+		reason: `refresh rejected (status ${status ?? 'absent'}: ${msg})`,
+	};
+}
+
+// Reads a region-switch target from a non-success refresh body. The web app
+// reads `data.domains.api` (falling back to `data.domain`); mirror that and
+// restrict to trusted Plaud https hosts, returning a bare origin.
+function readRegionSwitchHost(body: Record<string, unknown>): string | null {
+	const data = body.data;
+	if (!isRecord(data)) {
+		return null;
+	}
+	const domains = data.domains;
+	const candidate =
+		isRecord(domains) && typeof domains.api === 'string'
+			? domains.api
+			: typeof data.domain === 'string'
+				? data.domain
+				: null;
+	if (candidate === null) {
+		return null;
+	}
+	return normalizePlaudOrigin(candidate);
+}
+
+// Normalize a host into a trusted Plaud https origin (scheme + host, no path,
+// no userinfo), or null when it is not one. Rejects embedded credentials
+// (https://api.plaud.ai@evil.example parses with hostname evil.example).
+function normalizePlaudOrigin(value: string): string | null {
+	const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+	let parsed: URL;
+	try {
+		parsed = new URL(candidate);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== 'https:' || parsed.username !== '' || parsed.password !== '') {
+		return null;
+	}
+	const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+	if (!ALLOWED_EXACT_HOSTS.has(host) && !host.endsWith(ALLOWED_HOST_SUFFIX)) {
+		return null;
+	}
+	return `https://${parsed.host}`.replace(/\/+$/, '');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Attempt one silent session refresh. Sends the Plaud partition cookies and the
+ * stored refresh-token bearer (whichever is present) to
+ * `{apiBase}/auth/refresh-user-token`, following a single region switch. Returns
+ * a fresh WT (+ rotated URT) on success, or a failure the caller falls through
+ * on. Never throws: a transport rejection becomes a `RefreshFailure`.
+ */
+export async function refreshPlaudSession(
+	options: RefreshSessionOptions,
+): Promise<RefreshResult> {
+	const now = options.now ?? (() => Date.now());
+	const bearer =
+		options.refreshToken !== null && options.refreshToken.trim().length > 0
+			? options.refreshToken.trim().replace(/^bearer\s+/i, '')
+			: null;
+
+	const attempt = async (baseUrl: string, depth: number): Promise<RefreshResult> => {
+		const origin = baseUrl.replace(/\/+$/, '');
+		const url = `${origin}${REFRESH_ENDPOINT_PATH}`;
+		const headers: Record<string, string> = {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		};
+		let cookieHeader: string | null = null;
+		try {
+			cookieHeader = await options.transport.readCookieHeader(url);
+		} catch {
+			cookieHeader = null;
+		}
+		if (cookieHeader !== null && cookieHeader.length > 0) {
+			headers.Cookie = cookieHeader;
+		}
+		if (bearer !== null) {
+			headers.Authorization = `Bearer ${bearer}`;
+		}
+
+		let response: { status: number; json: unknown; text: string };
+		try {
+			// Empty JSON object body, matching the web app's `post(url, {}, ...)`.
+			response = await options.transport.post({ url, headers, body: '{}' });
+		} catch (err) {
+			return {
+				ok: false,
+				reason: `transport error: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+
+		logRefresh(options.debugLogger, `POST ${REFRESH_ENDPOINT_PATH} -> ${response.status}`);
+
+		if (response.status < 200 || response.status >= 300) {
+			return { ok: false, reason: `HTTP ${response.status} from refresh endpoint` };
+		}
+
+		const parsed = parseRefreshResponse(response.json, now());
+		if (parsed.kind === 'switch') {
+			if (depth >= 1 || parsed.apiBaseUrl === origin) {
+				return { ok: false, reason: 'refresh region switch did not resolve' };
+			}
+			logRefresh(options.debugLogger, `region switch to ${parsed.apiBaseUrl}, retrying`);
+			return attempt(parsed.apiBaseUrl, depth + 1);
+		}
+		if (parsed.kind === 'failure') {
+			return { ok: false, reason: parsed.reason };
+		}
+		return {
+			ok: true,
+			accessToken: parsed.accessToken,
+			refreshToken: parsed.refreshToken,
+			apiBaseUrl: origin,
+		};
+	};
+
+	return attempt(options.apiBaseUrl, 0);
+}
+
+// Debug breadcrumb. Never logs a token, cookie, or the Authorization header —
+// only the endpoint path and HTTP status, so a copied debug log is safe to share.
+function logRefresh(logger: DebugLogger | undefined, message: string): void {
+	if (logger?.enabled === true) {
+		logger.log({ kind: 'note', endpoint: REFRESH_ENDPOINT_PATH, message });
+	}
+}

--- a/plaud-refresh.ts
+++ b/plaud-refresh.ts
@@ -233,7 +233,11 @@ function normalizePlaudOrigin(value: string): string | null {
 	if (!ALLOWED_EXACT_HOSTS.has(host) && !host.endsWith(ALLOWED_HOST_SUFFIX)) {
 		return null;
 	}
-	return `https://${parsed.host}`.replace(/\/+$/, '');
+	// Rebuild from the NORMALIZED hostname (lowercased, trailing dot stripped)
+	// plus any explicit port, not parsed.host — which would carry a trailing dot
+	// or mixed case through and break equality and cookie/host matching.
+	const portSuffix = parsed.port === '' ? '' : `:${parsed.port}`;
+	return `https://${host}${portSuffix}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -256,8 +260,18 @@ export async function refreshPlaudSession(
 			? options.refreshToken.trim().replace(/^bearer\s+/i, '')
 			: null;
 
-	const attempt = async (baseUrl: string, depth: number): Promise<RefreshResult> => {
-		const origin = baseUrl.replace(/\/+$/, '');
+	// Fail closed: the request carries credentials (cookies + refresh bearer), so
+	// the destination is a trust boundary. Validate the caller-provided base host
+	// too, not just region-switch targets, so a corrupted stored apiBaseUrl can
+	// never steer the credentials at an arbitrary host.
+	const startOrigin = normalizePlaudOrigin(options.apiBaseUrl);
+	if (startOrigin === null) {
+		return { ok: false, reason: 'api base url is not a trusted Plaud https origin' };
+	}
+
+	const attempt = async (origin: string, depth: number): Promise<RefreshResult> => {
+		// `origin` is always a normalized trusted origin (startOrigin, or a
+		// validated switch target).
 		const url = `${origin}${REFRESH_ENDPOINT_PATH}`;
 		const headers: Record<string, string> = {
 			Accept: 'application/json',
@@ -312,7 +326,7 @@ export async function refreshPlaudSession(
 		};
 	};
 
-	return attempt(options.apiBaseUrl, 0);
+	return attempt(startOrigin, 0);
 }
 
 // Debug breadcrumb. Never logs a token, cookie, or the Authorization header —

--- a/plaud-refresh.ts
+++ b/plaud-refresh.ts
@@ -1,97 +1,21 @@
-// Silent Plaud session refresh (Release B).
+// JWT helpers for the silent session refresh (Release B).
 //
-// Plaud issues a short access token (JWT typ WT, 24h) and a long refresh token
-// (urt, 30 days, rotated on use). The web app silently POSTs
-// `{apiBase}/auth/refresh-user-token` before the WT expires and gets a fresh
-// WT + URT back, so the browser stays logged in for weeks. Our plugin captured
-// only the WT and never refreshed, so it hard-failed at ~24h. This module
-// replicates that refresh call.
+// The refresh itself is performed by re-capturing a fresh workspace token (WT)
+// from a hidden sign-in window on the persistent Plaud partition (see
+// plaud-login.ts `openPlaudLogin({ headless: true })`). Empirically the direct
+// `POST /auth/refresh-user-token` call returns a USER token (typ UT, ~30 days),
+// not the WORKSPACE token (typ WT, 24h) the data API needs; Plaud mints the WT
+// in a separate step, which the web app does on load. Letting the app do that
+// and re-capturing the WT (exactly as at login) sidesteps replicating Plaud's
+// token derivation.
 //
-// The exact credential the endpoint wants is not fully pinned (an httpOnly
-// cookie sent with the request, or an in-memory URT bearer added by the web
-// app's axios interceptor). Live tests showed the WT bearer alone and a bare
-// cross-origin cookie call each fail. So this sends BOTH candidates in one
-// request: the Plaud partition's cookies (read straight from Electron's cookie
-// jar, including httpOnly) AND, when we captured it at sign-in, the rotating
-// refresh token (WRT) as a bearer. One of the two is the real credential.
-//
-// Fail-safe by construction: a caller is only ever told to overwrite the stored
-// token when the endpoint returns HTTP 2xx, `status: 0`, and an access token
-// that decodes as typ WT with a future exp. Every other outcome is a failure
-// the caller falls through on, leaving today's token untouched.
-//
-// The HTTP call and cookie read are injected (RefreshTransport) so the response
-// handling is unit-testable without Electron; main.ts wires the real transport.
-
-import type { DebugLogger } from './debug-logger';
-
-const REFRESH_ENDPOINT_PATH = '/auth/refresh-user-token';
-
-// The refresh response is a soft envelope like the data API's: HTTP 200 with a
-// `status` field. `0` is success; a region mismatch carries the correct host
-// under `data.domains.api` and expects a retry there.
-const REFRESH_SUCCESS_STATUS = 0;
-
-// Trusted hosts a region switch may redirect the refresh to. The request
-// carries credentials, so the redirect target is a trust boundary: only ever
-// follow it to a Plaud host.
-const ALLOWED_HOST_SUFFIX = '.plaud.ai';
-const ALLOWED_EXACT_HOSTS = new Set(['plaud.ai', 'api.plaud.ai']);
+// These pure helpers decode the WT's `exp` (to schedule the refresh ~5 min
+// before expiry) and validate a captured token is a fresh WT (fail-safe: never
+// replace the stored token with something that is not a future-dated WT).
 
 // A JWT, optionally bearer-prefixed.
 const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
 const ACCESS_TOKEN_TYP = 'WT';
-
-/** One HTTP round-trip the refresh needs, plus a read of the partition cookies. */
-export interface RefreshTransport {
-	/**
-	 * POST the given body to `url` with the given headers. Must map any transport
-	 * failure (offline, TLS) to a rejected promise, and any HTTP status to a
-	 * resolved `{ status, json, text }` (never throw on a 4xx/5xx), mirroring the
-	 * Plaud client's Obsidian `requestUrl` adapter.
-	 */
-	post(req: {
-		readonly url: string;
-		readonly headers: Readonly<Record<string, string>>;
-		readonly body: string;
-	}): Promise<{ status: number; json: unknown; text: string }>;
-	/**
-	 * Return the `Cookie` header value for the given URL from the Plaud sign-in
-	 * partition (including httpOnly cookies), or null when unavailable. Never
-	 * throws — a failure resolves to null so the bearer path can still carry the
-	 * request.
-	 */
-	readCookieHeader(url: string): Promise<string | null>;
-}
-
-export interface RefreshSessionOptions {
-	/** Current Plaud API origin (e.g. https://api.plaud.ai). */
-	readonly apiBaseUrl: string;
-	/** Stored rotating refresh token (WRT) to send as a bearer, or null. */
-	readonly refreshToken: string | null;
-	readonly transport: RefreshTransport;
-	readonly debugLogger?: DebugLogger;
-	/** Injectable clock for testing the exp validation. Defaults to Date.now. */
-	readonly now?: () => number;
-}
-
-export interface RefreshSuccess {
-	readonly ok: true;
-	/** Fresh access token (validated typ WT with a future exp). */
-	readonly accessToken: string;
-	/** Fresh rotating refresh token from the body, or null when absent. */
-	readonly refreshToken: string | null;
-	/** Origin the refresh succeeded against (may differ after a region switch). */
-	readonly apiBaseUrl: string;
-}
-
-export interface RefreshFailure {
-	readonly ok: false;
-	/** Non-identifying reason for the debug log. Never carries a token value. */
-	readonly reason: string;
-}
-
-export type RefreshResult = RefreshSuccess | RefreshFailure;
 
 /** Reads the JWT header `typ`, or null when the value is not a decodable JWT. */
 export function jwtTyp(value: string): string | null {
@@ -124,6 +48,29 @@ export function decodeJwtExpMs(value: string): number | null {
 	return payload.exp * 1000;
 }
 
+/**
+ * Reads a string claim from the JWT payload, or null when the value is not a
+ * decodable JWT or the claim is absent / not a string. Used by the direct
+ * net-refresh path to pull `wid` (workspace id) and `client_id` off the stored
+ * workspace token without a separate API round-trip.
+ */
+export function readJwtPayloadClaim(value: string, claim: string): string | null {
+	const match = value.replace(/^bearer\s+/i, '').match(JWT_RE);
+	if (match === null) {
+		return null;
+	}
+	const parts = match[0].split('.');
+	if (parts.length < 2) {
+		return null;
+	}
+	const payload = decodeJwtSegment(parts[1]);
+	if (payload === null) {
+		return null;
+	}
+	const raw = payload[claim];
+	return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
 function decodeJwtSegment(seg: string): Record<string, unknown> | null {
 	try {
 		const b64 = seg.replace(/-/g, '+').replace(/_/g, '/');
@@ -144,195 +91,4 @@ export function isFreshAccessToken(token: string, nowMs: number): boolean {
 	}
 	const exp = decodeJwtExpMs(token);
 	return exp !== null && exp > nowMs;
-}
-
-type ParsedRefresh =
-	| { readonly kind: 'success'; readonly accessToken: string; readonly refreshToken: string | null }
-	| { readonly kind: 'switch'; readonly apiBaseUrl: string }
-	| { readonly kind: 'failure'; readonly reason: string };
-
-/**
- * Interpret a refresh response body. Success requires `status: 0` and an access
- * token that is a fresh WT (fail-safe). A non-success body carrying a trusted
- * `data.domains.api` host is a region switch to retry against. Everything else
- * is a failure. Pure and exported for unit testing.
- */
-export function parseRefreshResponse(body: unknown, nowMs: number): ParsedRefresh {
-	if (!isRecord(body)) {
-		return { kind: 'failure', reason: 'response body is not an object' };
-	}
-	const status = typeof body.status === 'number' ? body.status : null;
-	if (status === REFRESH_SUCCESS_STATUS) {
-		const accessToken =
-			typeof body.access_token === 'string' ? body.access_token.trim() : '';
-		if (accessToken.length === 0) {
-			return { kind: 'failure', reason: 'success status but no access_token' };
-		}
-		if (!isFreshAccessToken(accessToken, nowMs)) {
-			// Never hand back a token that is not a fresh WT: the caller would
-			// otherwise overwrite a still-usable token with a worse one.
-			return {
-				kind: 'failure',
-				reason: 'access_token is not a fresh WT (wrong typ or already expired)',
-			};
-		}
-		const refreshToken =
-			typeof body.refresh_token === 'string' && body.refresh_token.trim().length > 0
-				? body.refresh_token.trim()
-				: null;
-		return { kind: 'success', accessToken, refreshToken };
-	}
-	// Region switch: a non-success body may point at the correct regional host.
-	const switchHost = readRegionSwitchHost(body);
-	if (switchHost !== null) {
-		return { kind: 'switch', apiBaseUrl: switchHost };
-	}
-	const msg = typeof body.msg === 'string' && body.msg.length > 0 ? body.msg : '(no message)';
-	return {
-		kind: 'failure',
-		reason: `refresh rejected (status ${status ?? 'absent'}: ${msg})`,
-	};
-}
-
-// Reads a region-switch target from a non-success refresh body. The web app
-// reads `data.domains.api` (falling back to `data.domain`); mirror that and
-// restrict to trusted Plaud https hosts, returning a bare origin.
-function readRegionSwitchHost(body: Record<string, unknown>): string | null {
-	const data = body.data;
-	if (!isRecord(data)) {
-		return null;
-	}
-	const domains = data.domains;
-	const candidate =
-		isRecord(domains) && typeof domains.api === 'string'
-			? domains.api
-			: typeof data.domain === 'string'
-				? data.domain
-				: null;
-	if (candidate === null) {
-		return null;
-	}
-	return normalizePlaudOrigin(candidate);
-}
-
-// Normalize a host into a trusted Plaud https origin (scheme + host, no path,
-// no userinfo), or null when it is not one. Rejects embedded credentials
-// (https://api.plaud.ai@evil.example parses with hostname evil.example).
-function normalizePlaudOrigin(value: string): string | null {
-	const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
-	let parsed: URL;
-	try {
-		parsed = new URL(candidate);
-	} catch {
-		return null;
-	}
-	if (parsed.protocol !== 'https:' || parsed.username !== '' || parsed.password !== '') {
-		return null;
-	}
-	const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
-	if (!ALLOWED_EXACT_HOSTS.has(host) && !host.endsWith(ALLOWED_HOST_SUFFIX)) {
-		return null;
-	}
-	// Rebuild from the NORMALIZED hostname (lowercased, trailing dot stripped)
-	// plus any explicit port, not parsed.host — which would carry a trailing dot
-	// or mixed case through and break equality and cookie/host matching.
-	const portSuffix = parsed.port === '' ? '' : `:${parsed.port}`;
-	return `https://${host}${portSuffix}`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
- * Attempt one silent session refresh. Sends the Plaud partition cookies and the
- * stored refresh-token bearer (whichever is present) to
- * `{apiBase}/auth/refresh-user-token`, following a single region switch. Returns
- * a fresh WT (+ rotated URT) on success, or a failure the caller falls through
- * on. Never throws: a transport rejection becomes a `RefreshFailure`.
- */
-export async function refreshPlaudSession(
-	options: RefreshSessionOptions,
-): Promise<RefreshResult> {
-	const now = options.now ?? (() => Date.now());
-	const bearer =
-		options.refreshToken !== null && options.refreshToken.trim().length > 0
-			? options.refreshToken.trim().replace(/^bearer\s+/i, '')
-			: null;
-
-	// Fail closed: the request carries credentials (cookies + refresh bearer), so
-	// the destination is a trust boundary. Validate the caller-provided base host
-	// too, not just region-switch targets, so a corrupted stored apiBaseUrl can
-	// never steer the credentials at an arbitrary host.
-	const startOrigin = normalizePlaudOrigin(options.apiBaseUrl);
-	if (startOrigin === null) {
-		return { ok: false, reason: 'api base url is not a trusted Plaud https origin' };
-	}
-
-	const attempt = async (origin: string, depth: number): Promise<RefreshResult> => {
-		// `origin` is always a normalized trusted origin (startOrigin, or a
-		// validated switch target).
-		const url = `${origin}${REFRESH_ENDPOINT_PATH}`;
-		const headers: Record<string, string> = {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-		};
-		let cookieHeader: string | null = null;
-		try {
-			cookieHeader = await options.transport.readCookieHeader(url);
-		} catch {
-			cookieHeader = null;
-		}
-		if (cookieHeader !== null && cookieHeader.length > 0) {
-			headers.Cookie = cookieHeader;
-		}
-		if (bearer !== null) {
-			headers.Authorization = `Bearer ${bearer}`;
-		}
-
-		let response: { status: number; json: unknown; text: string };
-		try {
-			// Empty JSON object body, matching the web app's `post(url, {}, ...)`.
-			response = await options.transport.post({ url, headers, body: '{}' });
-		} catch (err) {
-			return {
-				ok: false,
-				reason: `transport error: ${err instanceof Error ? err.message : String(err)}`,
-			};
-		}
-
-		logRefresh(options.debugLogger, `POST ${REFRESH_ENDPOINT_PATH} -> ${response.status}`);
-
-		if (response.status < 200 || response.status >= 300) {
-			return { ok: false, reason: `HTTP ${response.status} from refresh endpoint` };
-		}
-
-		const parsed = parseRefreshResponse(response.json, now());
-		if (parsed.kind === 'switch') {
-			if (depth >= 1 || parsed.apiBaseUrl === origin) {
-				return { ok: false, reason: 'refresh region switch did not resolve' };
-			}
-			logRefresh(options.debugLogger, `region switch to ${parsed.apiBaseUrl}, retrying`);
-			return attempt(parsed.apiBaseUrl, depth + 1);
-		}
-		if (parsed.kind === 'failure') {
-			return { ok: false, reason: parsed.reason };
-		}
-		return {
-			ok: true,
-			accessToken: parsed.accessToken,
-			refreshToken: parsed.refreshToken,
-			apiBaseUrl: origin,
-		};
-	};
-
-	return attempt(startOrigin, 0);
-}
-
-// Debug breadcrumb. Never logs a token, cookie, or the Authorization header —
-// only the endpoint path and HTTP status, so a copied debug log is safe to share.
-function logRefresh(logger: DebugLogger | undefined, message: string): void {
-	if (logger?.enabled === true) {
-		logger.log({ kind: 'note', endpoint: REFRESH_ENDPOINT_PATH, message });
-	}
 }


### PR DESCRIPTION
## Release B: silent Plaud session refresh (issue #5)

Follows Release A (#39, one-click reconnect). Plaud's access token expires about every 24 hours, which pauses background auto-sync roughly daily. This renews the session quietly before the token expires, so auto-sync and imports keep working without a manual reconnect.

> Targeted for a **BETA (BRAT) release, not the marketplace**. The refresh path cannot be exercised in CI (it needs live Plaud session cookies), so it ships to beta testers first for hands-on validation before any production tag.

### How it works: two paths, direct first

**Primary (direct, windowless) `plaud-refresh-net.ts`.** The WT-mint endpoint was reverse-engineered from a full login HAR: `POST /user-app/auth/workspace/token/{wid}` returns the 24h workspace token in `data.workspace_token`. Both the user token (UT) and workspace token (WT) live ~24h, so the refresh is two cookie-authenticated calls in sequence:

1. `POST /auth/refresh-user-token` (empty body) - the URT cookie mints a fresh UT and rotates the URT cookie.
2. `POST /user-app/auth/workspace/token/{wid}` (body `{}`) - the fresh UT cookie mints the WT the data API needs.

Both run over Electron `session.fetch` bound to the `persist:plaud-importer` partition, so the httpOnly cookies auto-attach **and** call 1's rotated `Set-Cookie` is in the jar for call 2. `wid` and `client_id` are read off the stored token, so there is no extra lookup call. Auth is the partition cookies only (the real requests carry no Authorization header; the login response body even returns empty token strings).

**Fallback (headless window).** When `session.fetch` is unavailable, no token is stored, or any step fails, `tryRefreshSession` falls back to the prior hidden-`BrowserWindow` re-capture: the web app mints the WT on load and the same `onSendHeaders` capture used at sign-in grabs it. Slower and heavier, but needs no knowledge of the credential, so a wrong assumption in the direct path can never regress behavior.

### Fail-safe by construction

Both paths funnel through one shared gate, `applyRefreshedToken`: the stored token is replaced **only** when the candidate decodes as `typ: WT` with a future `exp`. Every other outcome (network error, non-zero status, expired/wrong-type token, malformed body, torn-down plugin) leaves all stored values untouched and falls back to the Release A reconnect prompt. A failed or disabled refresh can never make things worse than today.

Before any cookie-bearing POST, the target host is validated against Plaud's own hosts (`normalizeTrustedOrigin`), so a malformed or tampered base/redirect can never send the partition's httpOnly Plaud cookies to a non-Plaud origin.

### What changed since the earlier revision of this PR

- **`plaud-refresh-net.ts`** (new): the direct two-call refresh. Pure parsers (`extractWorkspaceId`, `parseWorkspaceTokenResponse`, `readRegionRedirect`, `normalizeTrustedOrigin`) with an injected `SessionPost` transport, so the logic is unit-tested without Electron; a guarded `buildPartitionPost` adapter over `session.fetch`. Never throws.
- **`plaud-refresh.ts`**: JWT helpers, plus `readJwtPayloadClaim` to pull `wid`/`client_id` off the stored token.
- **`main.ts`**: `tryNetRefresh` (primary) ahead of the headless fallback inside `tryRefreshSession`; shared `applyRefreshedToken` fail-safe; `keepSessionAlive` setting (default on); proactive timer (~5 min before `exp`, failure backoff); reactive refresh on a token-rejected auto-sync tick; **Refresh session now** command. Timer cleared in `onunload`; refreshes serialized (`refreshInFlight`/`reauthInFlight`); writes guarded against a torn-down plugin.

### Testing

- `npm run build`, `npm run lint` (incl. submission + icon checks), `npm test` all green (**906 tests**; new `plaud-refresh-net.test.ts` covers the two-call orchestration, region-redirect hop, host-trust rejection, malformed/throwing transport, and the pure parsers).
- Codex pre-commit review of the full diff: confirmed fail-safe, lifecycle, re-entrancy, `session.fetch` this-binding, cookie-jar reuse, and never-throws. It found one real bug - the stored base URL was POSTed before any trust check - which is fixed (`normalizeTrustedOrigin` up front) and covered by a test.

### Not yet hands-on validated

I cannot exercise the real refresh: it only runs against Plaud's live endpoint with the maintainer's session cookies. **Validation is @ckelsoe running "Refresh session now" and watching auto-sync survive past 24h.** The command forces a refresh regardless of whether the current token is fresh, so it proves the whole path in seconds. Two live assumptions in the direct path are unproven until then: that the partition retains the `api.plaud.ai` httpOnly cookies across restarts, and that the mint call needs no `x-device-id`. If either is wrong, the direct path returns null and the headless fallback runs.
