### PR TITLE
Document Plaud finalize-before-import behavior (issue #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ See [PRIVACY.md](./PRIVACY.md) for the full privacy policy and liability disclai
 - **"Could not reach Plaud.AI"** — network or DNS issue on your side, or Plaud is down. Retry from the modal's **Retry** button.
 - **"Plaud returned data in an unexpected shape"** — Plaud changed their API. File an issue with the debug log attached (see [Debug logging](#debug-logging)).
 - **Import silently "skipped"** — your duplicate handling was set to Skip and the note already existed. Switch to **Ask each time** (default since 0.2.0) or **Overwrite**.
+- **A brand-new recording will not import yet.** A recording does not become available to import until you have opened Plaud (web or app) and its cloud has finished finalizing the recording. Until then the plugin cannot see it. Open Plaud, let it finish processing, then run the import again. This is a Plaud-side step, not a plugin limitation.
 
 ## Support and issues
 


### PR DESCRIPTION
Closes #47.

Splits from #5 (wishlist item 7, raised by @Sybawoods). A new recording is not importable until Plaud web/app has been opened and its cloud has finalized the recording. This caught a user out until they opened Plaud and it synced.

Adds one Troubleshooting bullet setting that expectation and framing it as a Plaud-side step, not a plugin limitation.

Doc-only, no code surface. No version bump or tag: the line rides to the marketplace on the next release.