### PR TITLE
Default subfolder template to {{YYYY}}/{{MM}} (issue #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **New installs now file recordings into dated `{{YYYY}}/{{MM}}` subfolders by default.** The subfolder template previously defaulted to empty, which wrote every note flat into the output folder and surprised users who expected a dated layout. Fresh installs now get a year/month folder tree out of the box. This only affects new installs: if you already set (or deliberately cleared) the subfolder template, your choice is untouched. Set it back to empty under Settings if you prefer a flat layout (issue #45).
+
 ## [0.25.0-beta.1] - 2026-07-07
 
 > Beta release for BRAT testers. The background session renewal talks to Plaud's live endpoint, which cannot be exercised in CI, so it ships to beta first for hands-on validation. Use **Refresh session now** to confirm it works in your vault.

--- a/main.ts
+++ b/main.ts
@@ -441,7 +441,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	secretId: "",
 	apiBaseUrl: "https://api.plaud.ai",
 	outputFolder: "Plaud",
-	subfolderTemplate: "",
+	subfolderTemplate: "{{YYYY}}/{{MM}}",
 	noteNameTemplate: DEFAULT_NOTE_NAME_TEMPLATE,
 	datetimeTemplate: "",
 	forbiddenCharReplacement: "-",


### PR DESCRIPTION
Closes #45.

Splits from #5 (wishlist item 5, raised by @Sybawoods). The subfolder template defaulted to empty, so out of the box every note was written flat into the output folder. A user expecting a dated structure was surprised.

## Change

Default `subfolderTemplate` to `{{YYYY}}/{{MM}}` (year folder, then month folder). Fresh installs get a dated tree automatically.

## Scope and safety

- Only new installs are affected. An existing user has their choice already persisted in `data.json` (whether a custom template or a deliberately cleared empty one), so no current layout is force-migrated.
- The note writer still supports a flat layout: its own fallback stays empty (`subfolderTemplate ?? ''`), so clearing the setting reverts to flat. Only the settings default changed.
- `resolveSubfolder` already treats `/` as a nested-folder separator, so `{{YYYY}}/{{MM}}` produces `2026/07` with no new path logic.

## Verification

Local: lint (+ submission and icon pre-checks), build, 906 tests pass. No test asserted the old empty default, so none broke.