### PR TITLE
Clarify auto-sync duplicate handling; lock the safe fallback (issue #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Changed
 
-- **The Duplicate handling setting now explains what background auto-sync does.** "Ask each time" has no dialog to show during an unattended sync, so background sync already imports new recordings and overwrites changed ones without prompting; only manual imports honor "Ask each time". The setting description now says this so the behavior is not a surprise. No behavior change (issue #43).
+- **The Duplicate handling setting now explains what background auto-sync does.** "Ask each time" has no dialog to show during an unattended sync, so background sync never prompts: it overwrites a note when its recording changed in Plaud. Only manual imports honor "Ask each time". The setting description now says this so the behavior is not a surprise. No behavior change (issue #43).
 
 ## [0.25.0-beta.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **The Duplicate handling setting now explains what background auto-sync does.** "Ask each time" has no dialog to show during an unattended sync, so background sync already imports new recordings and overwrites changed ones without prompting; only manual imports honor "Ask each time". The setting description now says this so the behavior is not a surprise. No behavior change (issue #43).
+
 ## [0.25.0-beta.1] - 2026-07-07
 
 > Beta release for BRAT testers. The background session renewal talks to Plaud's live endpoint, which cannot be exercised in CI, so it ships to beta first for hands-on validation. Use **Refresh session now** to confirm it works in your vault.

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -1716,6 +1716,17 @@ describe('renameRecordingNote', () => {
 });
 
 describe('NoteWriter', () => {
+	// Locks the #43 safe fallback's second guard: a background auto-sync tick
+	// builds its writer with skip/overwrite and never a prompt callback, so if a
+	// refactor ever let onDuplicate='prompt' reach a headless writer, construction
+	// throws instead of silently stalling with no dialog to answer it.
+	it("throws when onDuplicate is 'prompt' without a promptOnDuplicate callback", () => {
+		const vault = makeFakeVault();
+		expect(
+			() => new NoteWriter(vault, { outputFolder: 'Plaud', onDuplicate: 'prompt' }),
+		).toThrow("a promptOnDuplicate callback is required");
+	});
+
 	it('creates the output folder if it does not exist', async () => {
 		const vault = makeFakeVault();
 		const writer = new NoteWriter(vault, { outputFolder: 'Plaud', onDuplicate: 'skip' });

--- a/main.ts
+++ b/main.ts
@@ -272,7 +272,7 @@ const FORBIDDEN_CHAR_REPLACEMENT_DESC =
 // prompts (skip-for-new, overwrite-for-changed); see importAutoSyncCandidates
 // (issue #43).
 const DUPLICATE_HANDLING_DESC =
-	"What to do when a note for the recording already exists in the output folder. During background auto-sync there is no prompt, so new recordings are imported and changed ones overwrite; 'Ask each time' applies to manual imports only.";
+	"What to do when a note for the recording already exists in the output folder. Background auto-sync never shows this prompt: it overwrites the note when the recording changed in Plaud. 'Ask each time' applies to manual imports only.";
 
 // Description for the silent-refresh toggle (Release B). Held in a const so the
 // declarative (1.13+) and imperative (1.12) settings paths show identical text

--- a/main.ts
+++ b/main.ts
@@ -265,6 +265,15 @@ const NOTE_NAME_TEMPLATE_FOOTNOTE =
 const FORBIDDEN_CHAR_REPLACEMENT_DESC =
 	"Character that replaces a slash, colon, or other character a file name or folder cannot contain, for example one that appears in a recording title. Must be a single character; the default is a dash.";
 
+// Description for the duplicate-handling dropdown. Held in a const so the
+// declarative (1.13+) and imperative (1.12) settings paths show identical text
+// and the sentence-case lint inspects one literal. The second sentence clarifies
+// that 'Ask each time' does not apply during background auto-sync, which never
+// prompts (skip-for-new, overwrite-for-changed); see importAutoSyncCandidates
+// (issue #43).
+const DUPLICATE_HANDLING_DESC =
+	"What to do when a note for the recording already exists in the output folder. During background auto-sync there is no prompt, so new recordings are imported and changed ones overwrite; 'Ask each time' applies to manual imports only.";
+
 // Description for the silent-refresh toggle (Release B). Held in a const so the
 // declarative (1.13+) and imperative (1.12) settings paths show identical text
 // and the sentence-case lint inspects one literal.
@@ -1256,6 +1265,14 @@ export default class PlaudImporterPlugin extends Plugin {
 		const fetchAudioUrl = selection.includeAudio
 			? (id: PlaudRecordingId) => client.getAudioTempUrl(id)
 			: undefined;
+		// The policy is constrained to skip | overwrite (never 'prompt'): a
+		// background tick has no dialog, so 'Ask each time' would have nothing to
+		// answer it. options.onDuplicate (which may be 'prompt' from settings) is
+		// spread in but overridden here, so the user's manual-import setting can
+		// never reach the headless writer. This is the #43 safe fallback; keep the
+		// override even when refactoring, or a background run could stall. The
+		// NoteWriter constructor also throws on 'prompt' without a callback, so a
+		// regression fails loud rather than hanging.
 		const makeWriter = (policy: "skip" | "overwrite"): NoteWriter =>
 			new NoteWriter(this.app.vault, {
 				...options,
@@ -2603,7 +2620,7 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 		this.addDropdownRow(
 			containerEl,
 			"Duplicate handling",
-			"What to do when a note for the recording already exists in the output folder.",
+			DUPLICATE_HANDLING_DESC,
 			"onDuplicate",
 			{ skip: "Skip", overwrite: "Overwrite", prompt: "Ask each time" },
 		);
@@ -3491,7 +3508,7 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 					},
 					{
 						name: "Duplicate handling",
-						desc: "What to do when a note for the recording already exists in the output folder.",
+						desc: DUPLICATE_HANDLING_DESC,
 						control: {
 							type: "dropdown",
 							key: "onDuplicate",


### PR DESCRIPTION
Closes #43.

Splits from #5 (wishlist item 3, raised by @Sybawoods). Concern: with auto-sync there is no dialog, so "Ask each time" duplicate handling cannot work unattended and could stall a background run.

## Finding

The stall cannot happen today. Two guards already exist:

1. `importAutoSyncCandidates` (main.ts) builds its writer with `onDuplicate` constrained to `"skip" | "overwrite"` (skip-for-new, overwrite-for-changed). The settings `onDuplicate` (which may be `'prompt'`) is spread in but overridden, so it never reaches the headless writer.
2. `NoteWriter`'s constructor throws when `onDuplicate === 'prompt'` without a `promptOnDuplicate` callback, so a future regression fails loud rather than hanging.

So the requested safe fallback is already the behavior. The real gap was that nothing told the user, whose mental model is that auto-sync would prompt.

## Change (both halves of the issue, honestly)

- **Warn / clarify:** the Duplicate handling setting description now states that background sync never prompts (new imported, changed overwritten) and that "Ask each time" applies to manual imports only. Extracted to a shared `DUPLICATE_HANDLING_DESC` const so the declarative (1.13+) and imperative (1.12) render paths cannot drift.
- **Lock the fallback:** a `// #43` comment marks the policy override as the safe fallback to preserve across refactors, and a regression test asserts the fail-loud constructor guard.

No behavior change.

## Verification

Local: lint (+ submission and icon pre-checks), build, 907 tests pass (+1 new). Codex pre-commit review: sound, no findings; independently confirmed no other headless writer path can receive `'prompt'` and no stray copy of the old description literal remains.