### PR TITLE
Fix silent session refresh spawning hourly browser windows (beta #5)

### DIFF
--- a/__tests__/plaud-refresh-net.test.ts
+++ b/__tests__/plaud-refresh-net.test.ts
@@ -221,4 +221,37 @@ describe('performNetRefresh', () => {
 			performNetRefresh({ currentToken: STORED_WT, baseUrl: 'https://api.plaud.ai', post }),
 		).resolves.toBeNull();
 	});
+
+	it('redacts a JWT-shaped string from a logged error body', async () => {
+		const jwt = 'aaaaaaaa.bbbbbbbb.cccccccc';
+		const { post } = recordingPost([{ status: 200, text: `oops ${jwt} boom` }]);
+		const logged: Array<{ body?: string }> = [];
+		const result = await performNetRefresh({
+			currentToken: STORED_WT,
+			baseUrl: 'https://api.plaud.ai',
+			post,
+			log: (_message, payload) => logged.push(payload as { body?: string }),
+		});
+		expect(result).toBeNull();
+		const bodies = logged
+			.map((p) => p?.body)
+			.filter((b): b is string => typeof b === 'string')
+			.join(' ');
+		expect(bodies).toContain('[redacted-token]');
+		expect(bodies).not.toContain(jwt);
+	});
+
+	it('never throws when the injected log sink throws', async () => {
+		const post: SessionPost = () => Promise.reject(new Error('down'));
+		await expect(
+			performNetRefresh({
+				currentToken: STORED_WT,
+				baseUrl: 'https://api.plaud.ai',
+				post,
+				log: () => {
+					throw new Error('logger boom');
+				},
+			}),
+		).resolves.toBeNull();
+	});
 });

--- a/main.ts
+++ b/main.ts
@@ -1643,16 +1643,21 @@ export default class PlaudImporterPlugin extends Plugin {
 		const post = buildPartitionPost();
 		if (post === null) {
 			// No session.fetch on this runtime; the window path is the only option.
+			this.logAutoSync(
+				"net refresh unavailable: no partition session.fetch transport (Electron remote/session/fetch missing); falling back to the window",
+			);
 			return false;
 		}
 		const token = this.currentAccessToken();
 		if (token === null) {
+			this.logAutoSync("net refresh skipped: no stored access token");
 			return false;
 		}
 		const result = await performNetRefresh({
 			currentToken: token,
 			baseUrl: this.settings.apiBaseUrl,
 			post,
+			log: (message, payload) => this.logAutoSync(message, payload),
 		});
 		if (this.disposed || result === null) {
 			return false;

--- a/plaud-refresh-net.ts
+++ b/plaud-refresh-net.ts
@@ -68,6 +68,25 @@ export interface NetRefreshDeps {
 	readonly baseUrl: string;
 	/** Session-bound transport (partition cookie jar). */
 	readonly post: SessionPost;
+	/**
+	 * Optional diagnostic sink. Called at each step/failure so one debug run
+	 * pinpoints why the direct path fell back to the window. Only ever receives
+	 * HTTP status, the envelope's numeric status, and a short body snippet of a
+	 * FAILING response; never a token value.
+	 */
+	readonly log?: (message: string, payload?: unknown) => void;
+}
+
+/** First 200 chars of a response body, for a failure diagnostic. */
+function bodySnippet(text: string): string {
+	return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+}
+
+/** A human-readable `message`/`msg` field off an envelope, when present. */
+function envelopeMessage(envelope: Record<string, unknown>): string | undefined {
+	if (typeof envelope.message === 'string') return envelope.message;
+	if (typeof envelope.msg === 'string') return envelope.msg;
+	return undefined;
 }
 
 export interface NetRefreshResult {
@@ -200,9 +219,11 @@ function baseHeaders(clientId: string): Record<string, string> {
 export async function performNetRefresh(
 	deps: NetRefreshDeps,
 ): Promise<NetRefreshResult | null> {
+	const log = deps.log ?? ((): void => {});
 	try {
 		const wid = extractWorkspaceId(deps.currentToken);
 		if (wid === null) {
+			log('net refresh aborted: stored token has no wid claim to mint against');
 			return null;
 		}
 		const clientId = readJwtPayloadClaim(deps.currentToken, 'client_id') ?? 'web';
@@ -214,6 +235,9 @@ export async function performNetRefresh(
 		// way inside the loop.
 		let base = normalizeTrustedOrigin(deps.baseUrl);
 		if (base === null) {
+			log('net refresh aborted: stored base URL is not a trusted Plaud host', {
+				baseUrl: deps.baseUrl,
+			});
 			return null;
 		}
 		let apiBaseUrl: string | null = null;
@@ -225,6 +249,10 @@ export async function performNetRefresh(
 			);
 			const envelope = parseEnvelope(res.text);
 			if (envelope === null) {
+				log('net refresh step 1 (refresh-user-token): non-JSON response', {
+					httpStatus: res.status,
+					body: bodySnippet(res.text),
+				});
 				return null;
 			}
 			if (envelope.status === STATUS_OK) {
@@ -232,6 +260,11 @@ export async function performNetRefresh(
 			}
 			const redirect = readRegionRedirect(envelope);
 			if (redirect === null || attempt === 1) {
+				log('net refresh step 1 (refresh-user-token): non-OK envelope', {
+					httpStatus: res.status,
+					envelopeStatus: envelope.status,
+					message: envelopeMessage(envelope),
+				});
 				return null;
 			}
 			base = redirect;
@@ -247,19 +280,32 @@ export async function performNetRefresh(
 		);
 		const mintEnvelope = parseEnvelope(mint.text);
 		if (mintEnvelope === null) {
+			log('net refresh step 2 (workspace token mint): non-JSON response', {
+				httpStatus: mint.status,
+				body: bodySnippet(mint.text),
+			});
 			return null;
 		}
 		const parsed = parseWorkspaceTokenResponse(mintEnvelope);
 		if (parsed === null) {
+			log('net refresh step 2 (workspace token mint): no workspace_token', {
+				httpStatus: mint.status,
+				envelopeStatus: mintEnvelope.status,
+				message: envelopeMessage(mintEnvelope),
+			});
 			return null;
 		}
+		log('net refresh succeeded via the direct (windowless) path');
 		return {
 			token: parsed.token,
 			refreshToken: parsed.refreshToken,
 			apiBaseUrl,
 		};
-	} catch {
+	} catch (err) {
 		// A refresh bug must never throw into the timer or the auto-sync tick.
+		log('net refresh threw', {
+			error: err instanceof Error ? err.message : String(err),
+		});
 		return null;
 	}
 }
@@ -273,7 +319,12 @@ interface ElectronSessionFetchResponse {
 interface ElectronSessionLike {
 	fetch?(
 		url: string,
-		options: { method: string; body: string; headers: Record<string, string> },
+		options: {
+			method: string;
+			body: string;
+			headers: Record<string, string>;
+			credentials?: 'include' | 'omit' | 'same-origin';
+		},
 	): Promise<ElectronSessionFetchResponse>;
 }
 interface ElectronRemoteLike {
@@ -318,10 +369,15 @@ export function buildPartitionPost(): SessionPost | null {
 	}
 	return async (url, body, headers) => {
 		// Member call (not a detached reference) so `this` stays bound to session.
+		// credentials:'include' is REQUIRED: these POSTs authenticate purely with
+		// the partition's httpOnly Plaud cookies, and fetch's default same-origin
+		// credentials mode would send none (the call has no document origin that
+		// matches api.plaud.ai), so the refresh would silently 401/return empty.
 		const res = await session.fetch(url, {
 			method: 'POST',
 			body,
 			headers: { ...headers },
+			credentials: 'include',
 		});
 		const text = await res.text();
 		return { status: res.status, text };

--- a/plaud-refresh-net.ts
+++ b/plaud-refresh-net.ts
@@ -77,9 +77,18 @@ export interface NetRefreshDeps {
 	readonly log?: (message: string, payload?: unknown) => void;
 }
 
-/** First 200 chars of a response body, for a failure diagnostic. */
+/**
+ * First 200 chars of a response body, for a failure diagnostic, with any
+ * JWT-shaped substring redacted first. A failing auth/refresh response should
+ * not carry a token, but redacting guarantees the debug logger's no-secrets
+ * contract holds even if one ever slips into an error body.
+ */
 function bodySnippet(text: string): string {
-	return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+	const redacted = text.replace(
+		/[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+		'[redacted-token]',
+	);
+	return redacted.length > 200 ? `${redacted.slice(0, 200)}…` : redacted;
 }
 
 /** A human-readable `message`/`msg` field off an envelope, when present. */
@@ -219,7 +228,15 @@ function baseHeaders(clientId: string): Record<string, string> {
 export async function performNetRefresh(
 	deps: NetRefreshDeps,
 ): Promise<NetRefreshResult | null> {
-	const log = deps.log ?? ((): void => {});
+	// Wrap the injected sink so a throwing logger can never break this function's
+	// "never throws" contract (it runs in the background refresh timer).
+	const log = (message: string, payload?: unknown): void => {
+		try {
+			deps.log?.(message, payload);
+		} catch {
+			// A logging failure must not propagate into the timer or the sync tick.
+		}
+	};
 	try {
 		const wid = extractWorkspaceId(deps.currentToken);
 		if (wid === null) {


### PR DESCRIPTION
## Summary

Fixes the beta silent session refresh (issue #5), which was opening a browser window to `web.plaud.ai` roughly every hour (10+ overnight) instead of renewing the session quietly.

**Root cause:** the windowless refresh (`plaud-refresh-net.ts`) authenticates purely with the sign-in partition's httpOnly Plaud cookies, but `session.fetch` was called without `credentials: 'include'`. Fetch's default same-origin credentials mode sent no cookies, so both refresh POSTs failed → the code fell back to a hidden sign-in window → the page leaked a visible external window → the failure backoff reopened it hourly.

Confirmed fixed by a hands-on `Refresh session now` run: the direct path now succeeds windowlessly and reschedules ~24h out with a zero failure streak.

## Changes

- **`plaud-refresh-net.ts`**: `buildPartitionPost` sends `credentials: 'include'` so the partition cookies actually attach. `performNetRefresh` gains an optional `log` sink and now reports the exact failure at each step (which POST, HTTP status, envelope status, a short body snippet) instead of returning `null` silently. Never logs token values.
- **`main.ts`**: `tryNetRefresh` passes the logger through and logs when no `session.fetch` transport exists (so a debug run distinguishes "transport missing" from "auth failed").

## Test plan

- [x] `Refresh session now` with Debug on logs `net refresh succeeded via the direct (windowless) path`, `session refreshed (manual, direct)`, and reschedules ~24h out (`failureStreak: 0`) — no window opened.
- [ ] Overnight: no `web.plaud.ai` windows appear on their own.
- [ ] A genuine 30-day expiry still surfaces the reconnect prompt (unchanged fallback).

Automated: full suite green (941), lint and build clean.
