### PR TITLE
Fix #52 card image: repoint on import + one-time repair for older notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The card image in an imported note no longer shows "could not be found."** Plaud's AI summary embeds its card poster with an inline link that only resolves inside Plaud's own app. The plugin already downloads that image into the note's attachments folder, but left the summary's original embed pointing at Plaud. It now repoints the inline embed at the local copy, so the card renders in Obsidian (issue #52).
+
 ## [0.25.0] - 2026-07-08
 
 Promotes the background session refresh previewed in 0.25.0-beta.1 to a stable release, with the hourly-window bug fixed, and adds user-defined frontmatter and a dated default subfolder layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Plaud Importer will be documented in this file.
 ### Fixed
 
 - **The card image in an imported note no longer shows "could not be found."** Plaud's AI summary embeds its card poster with an inline link that only resolves inside Plaud's own app. The plugin already downloads that image into the note's attachments folder, but left the summary's original embed pointing at Plaud. It now repoints the inline embed at the local copy, so the card renders in Obsidian (issue #52).
+- **A one-time command repairs the card image in notes you imported earlier.** The fix above only applies as notes are imported, so notes imported before it keep the broken card. Run **Repair card image links from older imports (one-time)** from the command palette to repoint those existing notes at the card already in their attachments folder. It only touches this plugin's notes, is safe to run more than once, and reports how many it fixed. Notes whose card was never downloaded are left for a re-import (issue #52).
 
 ## [0.25.0] - 2026-07-08
 

--- a/__tests__/attachment-importer.test.ts
+++ b/__tests__/attachment-importer.test.ts
@@ -1,4 +1,7 @@
-import { inferAssetExtension } from '../attachment-importer';
+import {
+	inferAssetExtension,
+	rewriteInlineSummaryEmbeds,
+} from '../attachment-importer';
 import type { AttachmentAsset } from '../plaud-client';
 
 function asset(overrides: Partial<AttachmentAsset> = {}): AttachmentAsset {
@@ -55,5 +58,91 @@ describe('inferAssetExtension', () => {
 		expect(
 			inferAssetExtension(asset({ url: 'https://s3.test/blob?sig=x' }), '\x00\x01', ''),
 		).toBe('bin');
+	});
+});
+
+describe('rewriteInlineSummaryEmbeds', () => {
+	// Regression for issue #52: Plaud's newer AI summary embeds the card poster
+	// as an inline `![alt](permanent/...)` link that only resolves inside
+	// Plaud's app. The importer downloads the same asset locally; the summary
+	// embed must be repointed at the local copy or Obsidian shows
+	// "could not be found".
+	it('repoints an inline Plaud poster embed at the downloaded local asset (#52)', () => {
+		const plaudUrl =
+			'permanent/e2506c1e4048400f8dfecacc50bc3028/abc/summary_poster/card_20260706192510-v2@1024';
+		const body =
+			'## Summary\n\nMeeting recap.\n\n![PLAUD NOTE](' + plaudUrl + ')\n\nEnd.\n';
+		const out = rewriteInlineSummaryEmbeds(
+			body,
+			new Map([[plaudUrl, 'Meetings/Standup-assets/00ec8400-card.png']]),
+		);
+		expect(out).toContain('![[Meetings/Standup-assets/00ec8400-card.png]]');
+		expect(out).not.toContain('summary_poster');
+		expect(out).not.toContain('](permanent/');
+	});
+
+	it('leaves an unmapped embed untouched (external image the user referenced)', () => {
+		const body = '![diagram](https://example.com/diagram.png)\n';
+		const out = rewriteInlineSummaryEmbeds(
+			body,
+			new Map([['permanent/x/card_y', 'note-assets/card.png']]),
+		);
+		expect(out).toBe(body);
+	});
+
+	it('returns the content unchanged when the rewrite map is empty', () => {
+		const body = '![PLAUD NOTE](permanent/x/summary_poster/card_y)\n';
+		expect(rewriteInlineSummaryEmbeds(body, new Map())).toBe(body);
+	});
+
+	it('does not disturb existing `![[...]]` wikilink embeds in the managed section', () => {
+		const body = '## Images and Attachments\n\n![[note-assets/00ec8400-card.png]]\n';
+		const out = rewriteInlineSummaryEmbeds(
+			body,
+			new Map([['permanent/x/card_y', 'note-assets/00ec8400-card.png']]),
+		);
+		expect(out).toBe(body);
+	});
+
+	it('handles the angle-bracket and title variants of an inline embed', () => {
+		const url = 'permanent/x/summary_poster/card_z';
+		const body =
+			'![a](<' + url + '> "Poster")\n![b](' + url + ' "Poster")\n';
+		const out = rewriteInlineSummaryEmbeds(
+			body,
+			new Map([[url, 'n-assets/card.png']]),
+		);
+		expect(out).toBe('![[n-assets/card.png]]\n![[n-assets/card.png]]\n');
+	});
+
+	// The rewrite key is the whole target string, query suffix included; it must
+	// equal asset.url (the extractor's normalized link) exactly. Locks the
+	// handoff's key-match risk: a differing suffix silently no-ops rather than
+	// partial-matching the wrong asset.
+	it('requires an exact key match including any query suffix (#52 risk)', () => {
+		const url = 'permanent/x/summary_poster/card_z?v=abc';
+		const body = '![PLAUD NOTE](' + url + ')\n';
+		expect(
+			rewriteInlineSummaryEmbeds(body, new Map([[url, 'n-assets/card.png']])),
+		).toContain('![[n-assets/card.png]]');
+		expect(
+			rewriteInlineSummaryEmbeds(
+				body,
+				new Map([
+					['permanent/x/summary_poster/card_z?v=OTHER', 'n-assets/card.png'],
+				]),
+			),
+		).toBe(body);
+	});
+
+	// Scope of #52: only markdown image embeds are repointed. An `<img>` tag or a
+	// bare URL is downloaded by the importer but left as-is here (documented gap).
+	it('rewrites only markdown image embeds, not <img> tags or bare URLs', () => {
+		const url = 'permanent/x/summary_poster/card_z';
+		const map = new Map([[url, 'n-assets/card.png']]);
+		const html = '<img src="' + url + '">\n';
+		const bare = 'See ' + url + ' for the card.\n';
+		expect(rewriteInlineSummaryEmbeds(html, map)).toBe(html);
+		expect(rewriteInlineSummaryEmbeds(bare, map)).toBe(bare);
 	});
 });

--- a/__tests__/attachment-importer.test.ts
+++ b/__tests__/attachment-importer.test.ts
@@ -1,6 +1,8 @@
 import {
 	inferAssetExtension,
 	rewriteInlineSummaryEmbeds,
+	isLocalCardImage,
+	repairLegacyCardEmbeds,
 } from '../attachment-importer';
 import type { AttachmentAsset } from '../plaud-client';
 
@@ -144,5 +146,61 @@ describe('rewriteInlineSummaryEmbeds', () => {
 		const bare = 'See ' + url + ' for the card.\n';
 		expect(rewriteInlineSummaryEmbeds(html, map)).toBe(html);
 		expect(rewriteInlineSummaryEmbeds(bare, map)).toBe(bare);
+	});
+});
+
+// DEPRECATED one-time #52 migration; remove these with the repair command.
+describe('isLocalCardImage', () => {
+	it('matches a downloaded card poster image', () => {
+		expect(isLocalCardImage('abc123-card.png')).toBe(true);
+		expect(isLocalCardImage('abc123-card2.jpg')).toBe(true);
+		expect(isLocalCardImage('card.webp')).toBe(true);
+	});
+
+	it('does not match non-card, non-image, or non-boundary names', () => {
+		expect(isLocalCardImage('abc123-mindmap.png')).toBe(false);
+		expect(isLocalCardImage('abc123-card.html')).toBe(false);
+		expect(isLocalCardImage('abc123-card-file.png')).toBe(false);
+		expect(isLocalCardImage('flashcard.png')).toBe(false);
+		expect(isLocalCardImage('abc123-audio.ogg')).toBe(false);
+	});
+});
+
+describe('repairLegacyCardEmbeds', () => {
+	const brokenBody =
+		'## Summary\n\n![PLAUD NOTE](permanent/e25/abc/summary_poster/card_2026@1024)\n\nEnd.\n';
+
+	it('repoints a broken card embed at the single local card image', () => {
+		const r = repairLegacyCardEmbeds(brokenBody, [
+			'Meetings/Note-assets/abc-card.png',
+		]);
+		expect(r.repointed).toBe(1);
+		expect(r.unrepairable).toBe(0);
+		expect(r.content).toContain('![[Meetings/Note-assets/abc-card.png]]');
+		expect(r.content).not.toContain('summary_poster');
+	});
+
+	it('leaves the embed and counts it unrepairable when no local card exists', () => {
+		const r = repairLegacyCardEmbeds(brokenBody, []);
+		expect(r.repointed).toBe(0);
+		expect(r.unrepairable).toBe(1);
+		expect(r.content).toBe(brokenBody);
+	});
+
+	it('does not guess when the card match is ambiguous (2+ local cards)', () => {
+		const r = repairLegacyCardEmbeds(brokenBody, [
+			'n-assets/a-card.png',
+			'n-assets/a-card2.png',
+		]);
+		expect(r.repointed).toBe(0);
+		expect(r.unrepairable).toBe(1);
+		expect(r.content).toBe(brokenBody);
+	});
+
+	it('is a no-op on a note that has no broken card embed (idempotent)', () => {
+		const clean = '## Summary\n\n![[n-assets/a-card.png]]\n';
+		const r = repairLegacyCardEmbeds(clean, ['n-assets/a-card.png']);
+		expect(r.repointed).toBe(0);
+		expect(r.content).toBe(clean);
 	});
 });

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -1330,6 +1330,65 @@ export function rewriteInlineSummaryEmbeds(
 	});
 }
 
+// ===========================================================================
+// DEPRECATED ONE-TIME MIGRATION (issue #52) — REMOVE IN A FUTURE VERSION.
+//
+// The rewrite above fixes card embeds only on (re)import. Notes imported BEFORE
+// that fix keep the broken inline embed. The pure helpers below back a one-time,
+// user-run "Repair card image links from older imports" command that repoints
+// those existing notes at the card already sitting in their `-assets` folder.
+// Once users have run it (a release or two out), delete this block, the command
+// in main.ts, and their tests.
+// ===========================================================================
+
+/**
+ * One-time #52 migration helper (REMOVE IN A FUTURE VERSION). True when a
+ * filename is a downloaded card poster image. The importer names card posters
+ * `<idPrefix>-card.<ext>` (or `card2`, ...), so the base ends with `card` or
+ * `card<n>` and the extension is an image type.
+ */
+export function isLocalCardImage(fileName: string): boolean {
+	return /(?:^|-)card\d*\.(?:png|jpe?g|gif|webp|bmp|svg)$/i.test(fileName);
+}
+
+/** One-time #52 migration result (REMOVE IN A FUTURE VERSION). */
+export interface CardRepairResult {
+	readonly content: string;
+	/** How many broken inline card embeds were repointed at a local copy. */
+	readonly repointed: number;
+	/** Broken card embeds left as-is (no local card, or an ambiguous match). */
+	readonly unrepairable: number;
+}
+
+/**
+ * One-time #52 migration (REMOVE IN A FUTURE VERSION).
+ * Repoint an ALREADY-IMPORTED note's broken inline card-poster embed
+ * (`![...](.../summary_poster/...)`) at the card image already downloaded into
+ * its `-assets` folder. Conservative: only touches embeds whose target carries
+ * Plaud's `summary_poster` marker, and only repoints when EXACTLY ONE local card
+ * image is available (0 or an ambiguous 2+ are left alone and counted). Existing
+ * `![[...]]` wikilinks are never matched, so re-running is a no-op.
+ */
+export function repairLegacyCardEmbeds(
+	content: string,
+	cardAssetPaths: readonly string[],
+): CardRepairResult {
+	const brokenCard =
+		/!\[[^\]]*]\(\s*<?([^)\s>]*summary_poster[^)\s>]*)>?(?:\s+"[^"]*")?\s*\)/g;
+	const target = cardAssetPaths.length === 1 ? cardAssetPaths[0] : null;
+	let repointed = 0;
+	let unrepairable = 0;
+	const out = content.replace(brokenCard, (whole) => {
+		if (target === null) {
+			unrepairable += 1;
+			return whole;
+		}
+		repointed += 1;
+		return `![[${target}]]`;
+	});
+	return { content: out, repointed, unrepairable };
+}
+
 /**
  * Choose a file extension for a downloaded attachment from its MIME hint,
  * URL, and body. Mime wins, then a real extension on the URL, then a JSON

--- a/attachment-importer.ts
+++ b/attachment-importer.ts
@@ -110,6 +110,11 @@ export class AttachmentImporter {
 		const mindmapLinks: string[] = [];
 		const cardLinks: string[] = [];
 		const payloadToPath = new Map<string, string>();
+		// Maps a downloaded asset's ORIGINAL Plaud link (asset.url, the same
+		// normalized string the summary extractor produced) to its local vault
+		// path, so inline `![](permanent/...)` embeds in the summary body can be
+		// repointed at the local copy after download (issue #52).
+		const summaryEmbedRewrites = new Map<string, string>();
 		const renderedLinks = new Set<string>();
 		const namingCounters: AttachmentNamingCounters = {
 			mindmapImage: 0,
@@ -343,6 +348,7 @@ export class AttachmentImporter {
 						existingPath,
 					});
 					if (this.isImageExtension(ext)) {
+						summaryEmbedRewrites.set(asset.url, existingPath);
 						pushRenderedAsset(kind, existingPath, true);
 					} else {
 						pushRenderedAsset(kind, existingPath, false);
@@ -367,6 +373,7 @@ export class AttachmentImporter {
 					byteLength: bytes.byteLength,
 				});
 				if (this.isImageExtension(ext)) {
+					summaryEmbedRewrites.set(asset.url, attachmentPath);
 					pushRenderedAsset(kind, attachmentPath, true);
 				} else {
 					pushRenderedAsset(kind, attachmentPath, false);
@@ -478,7 +485,9 @@ export class AttachmentImporter {
 				attachmentUrls: attachments.map((a) => this.sanitizeUrlForDebug(a.url)),
 			});
 		}
-		if (genericLinks.length + mindmapLinks.length + cardLinks.length === 0) {
+		const hasManagedLinks =
+			genericLinks.length + mindmapLinks.length + cardLinks.length > 0;
+		if (!hasManagedLinks && summaryEmbedRewrites.size === 0) {
 			this.logAttachmentDebug('attachment import completed with no rendered links', {
 				notePath,
 			});
@@ -486,7 +495,15 @@ export class AttachmentImporter {
 		}
 
 		await this.app.vault.process(noteFile, (content) => {
-			const withoutManagedSection = this.stripManagedAttachmentsSection(content);
+			// Repoint Plaud's inline `![](permanent/...)` summary embeds at the
+			// local copies we just downloaded (issue #52) BEFORE building the
+			// managed section. The managed section uses `![[...]]` wikilinks,
+			// which the inline-embed regex never matches, so ordering is safe.
+			const repointed = rewriteInlineSummaryEmbeds(content, summaryEmbedRewrites);
+			if (!hasManagedLinks) {
+				return repointed;
+			}
+			const withoutManagedSection = this.stripManagedAttachmentsSection(repointed);
 			const trimmed = withoutManagedSection.replace(/\s+$/, '');
 			const section: string[] = [
 				'## Images and Attachments',
@@ -1278,6 +1295,39 @@ export class AttachmentImporter {
 			'\n',
 		);
 	}
+}
+
+/**
+ * Repoint Plaud's inline image embeds in a note body at the locally
+ * downloaded copies. Plaud's newer AI summary markdown embeds its card
+ * poster (and any other picture) as `![alt](permanent/.../summary_poster/...)`
+ * — a path that only resolves inside Plaud's own app, so Obsidian renders it
+ * as "could not be found" (issue #52). The importer downloads the same asset
+ * into the note's `-assets` folder; this rewrites every inline embed whose
+ * target matches a downloaded asset into an Obsidian wikilink embed
+ * `![[<local path>]]`. Embeds whose target is not in the map (external images
+ * the user intentionally referenced) are left untouched.
+ *
+ * `urlToLocalPath` is keyed by the SAME normalized link string the extractor
+ * produced (see `normalizeSummaryLink`), so the captured target is normalized
+ * identically before lookup. Exported as a pure function so the rewrite is
+ * unit-testable without the vault/network plumbing in AttachmentImporter.
+ */
+export function rewriteInlineSummaryEmbeds(
+	content: string,
+	urlToLocalPath: ReadonlyMap<string, string>,
+): string {
+	if (urlToLocalPath.size === 0) {
+		return content;
+	}
+	// Inline markdown image: ![alt](<target>) with an optional angle-bracket
+	// wrapper and an optional "title". Capture the bare target only.
+	const inlineImage = /!\[[^\]]*]\(\s*<?([^)\s>]+)>?(?:\s+"[^"]*")?\s*\)/g;
+	return content.replace(inlineImage, (whole, rawTarget: string) => {
+		const normalized = rawTarget.replace(/^<|>$/g, '').replace(/^['"]|['"]$/g, '');
+		const local = urlToLocalPath.get(normalized);
+		return local !== undefined ? `![[${local}]]` : whole;
+	});
 }
 
 /**

--- a/main.ts
+++ b/main.ts
@@ -636,6 +636,9 @@ export default class PlaudImporterPlugin extends Plugin {
 	// entry point (settings, the auth-pause notice, the backfill retry), so
 	// stacked stale notices cannot launch clobbering capture sessions.
 	private reauthInFlight = false;
+	// DEPRECATED one-time #52 repair: guards against a double-invoke running two
+	// bulk vault scans at once. REMOVE with the repair command.
+	private repairInFlight = false;
 	// Sticky action notices (e.g. the auth-pause "Reconnect") tracked so
 	// onunload can hide any still on screen before their click handlers can run
 	// plugin work after the plugin is gone.
@@ -995,46 +998,79 @@ export default class PlaudImporterPlugin extends Plugin {
 	// again), and never touches non-Plaud notes. Notes whose card was never
 	// downloaded are left for a re-import and counted in the report.
 	private async repairLegacyCardLinks(): Promise<void> {
+		if (this.disposed) {
+			return;
+		}
+		if (this.repairInFlight) {
+			new Notice("Plaud importer: card link repair is already running.");
+			return;
+		}
+		this.repairInFlight = true;
 		let notesRepaired = 0;
 		let linksRepointed = 0;
 		let notesNeedingReimport = 0;
-		for (const file of this.app.vault.getMarkdownFiles()) {
-			if (!this.isPlaudNote(file)) {
-				continue;
-			}
-			let content: string;
-			try {
-				content = await this.app.vault.read(file);
-			} catch {
-				continue;
-			}
-			// Cheap prefilter: Plaud's card poster path always carries this marker.
-			if (!content.includes("summary_poster")) {
-				continue;
-			}
-			const assetsPath = file.path.replace(/\.md$/i, "-assets");
-			const folder = this.app.vault.getFolderByPath(assetsPath);
-			const cardPaths: string[] = [];
-			if (folder !== null) {
-				for (const child of folder.children) {
-					if (child instanceof TFile && isLocalCardImage(child.name)) {
-						cardPaths.push(child.path);
+		try {
+			for (const file of this.app.vault.getMarkdownFiles()) {
+				// Stop cleanly if the plugin unloads mid-scan.
+				if (this.disposed) {
+					return;
+				}
+				if (!this.isPlaudNote(file)) {
+					continue;
+				}
+				let content: string;
+				try {
+					content = await this.app.vault.read(file);
+				} catch {
+					continue;
+				}
+				if (this.disposed) {
+					return;
+				}
+				// Cheap prefilter: Plaud's card poster path always carries this marker.
+				if (!content.includes("summary_poster")) {
+					continue;
+				}
+				const assetsPath = file.path.replace(/\.md$/i, "-assets");
+				const folder = this.app.vault.getFolderByPath(assetsPath);
+				const cardPaths: string[] = [];
+				if (folder !== null) {
+					for (const child of folder.children) {
+						if (child instanceof TFile && isLocalCardImage(child.name)) {
+							cardPaths.push(child.path);
+						}
 					}
 				}
-			}
-			const result = repairLegacyCardEmbeds(content, cardPaths);
-			if (result.repointed > 0) {
+				// Gate the write on the read content, but recompute inside process on
+				// the FRESH content so a concurrent edit is never clobbered.
+				const preview = repairLegacyCardEmbeds(content, cardPaths);
+				if (preview.repointed === 0) {
+					if (preview.unrepairable > 0) {
+						notesNeedingReimport += 1;
+					}
+					continue;
+				}
+				let written = { repointed: 0, unrepairable: 0 };
 				try {
-					await this.app.vault.process(file, () => result.content);
-					notesRepaired += 1;
-					linksRepointed += result.repointed;
+					await this.app.vault.process(file, (fresh) => {
+						const r = repairLegacyCardEmbeds(fresh, cardPaths);
+						written = { repointed: r.repointed, unrepairable: r.unrepairable };
+						return r.content;
+					});
 				} catch {
 					// A single-note write failure must not abort the whole batch.
+					continue;
+				}
+				if (written.repointed > 0) {
+					notesRepaired += 1;
+					linksRepointed += written.repointed;
+				}
+				if (written.unrepairable > 0) {
+					notesNeedingReimport += 1;
 				}
 			}
-			if (result.unrepairable > 0) {
-				notesNeedingReimport += 1;
-			}
+		} finally {
+			this.repairInFlight = false;
 		}
 		const tail =
 			notesNeedingReimport > 0

--- a/main.ts
+++ b/main.ts
@@ -48,7 +48,12 @@ import {
 	type TagMode,
 	type CustomFrontmatterRow,
 } from "./note-writer";
-import { AttachmentImporter } from "./attachment-importer";
+import {
+	AttachmentImporter,
+	// DEPRECATED one-time #52 migration; remove with the repair command below.
+	isLocalCardImage,
+	repairLegacyCardEmbeds,
+} from "./attachment-importer";
 import {
 	buildPlaudIdIndex,
 	buildPlaudIdIndexWithColdCheck,
@@ -722,6 +727,18 @@ export default class PlaudImporterPlugin extends Plugin {
 			},
 		});
 
+		// DEPRECATED ONE-TIME MIGRATION (issue #52) — REMOVE IN A FUTURE VERSION.
+		// The import-time fix only repoints card embeds on (re)import; notes
+		// imported before it keep the broken inline embed. This user-invoked
+		// (never automatic) command repairs those existing notes in place.
+		this.addCommand({
+			id: "repair-legacy-card-links",
+			name: "Repair card image links from older imports (one-time)",
+			callback: () => {
+				void this.repairLegacyCardLinks();
+			},
+		});
+
 		// Issue B: let the user rename an imported recording from Obsidian and
 		// keep its `<base>-assets` folder in sync. A palette command and a note
 		// context-menu item both open the rename prompt; a vault rename listener
@@ -968,6 +985,63 @@ export default class PlaudImporterPlugin extends Plugin {
 			file instanceof TFile &&
 			file.extension === "md" &&
 			this.plaudIdOf(file) !== null
+		);
+	}
+
+	// DEPRECATED ONE-TIME MIGRATION (issue #52) — REMOVE IN A FUTURE VERSION.
+	// Scans this plugin's imported notes for Plaud's broken inline card-poster
+	// embed and repoints each at the card image already in the note's `-assets`
+	// folder. User-invoked only, idempotent (a repointed wikilink is not matched
+	// again), and never touches non-Plaud notes. Notes whose card was never
+	// downloaded are left for a re-import and counted in the report.
+	private async repairLegacyCardLinks(): Promise<void> {
+		let notesRepaired = 0;
+		let linksRepointed = 0;
+		let notesNeedingReimport = 0;
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			if (!this.isPlaudNote(file)) {
+				continue;
+			}
+			let content: string;
+			try {
+				content = await this.app.vault.read(file);
+			} catch {
+				continue;
+			}
+			// Cheap prefilter: Plaud's card poster path always carries this marker.
+			if (!content.includes("summary_poster")) {
+				continue;
+			}
+			const assetsPath = file.path.replace(/\.md$/i, "-assets");
+			const folder = this.app.vault.getFolderByPath(assetsPath);
+			const cardPaths: string[] = [];
+			if (folder !== null) {
+				for (const child of folder.children) {
+					if (child instanceof TFile && isLocalCardImage(child.name)) {
+						cardPaths.push(child.path);
+					}
+				}
+			}
+			const result = repairLegacyCardEmbeds(content, cardPaths);
+			if (result.repointed > 0) {
+				try {
+					await this.app.vault.process(file, () => result.content);
+					notesRepaired += 1;
+					linksRepointed += result.repointed;
+				} catch {
+					// A single-note write failure must not abort the whole batch.
+				}
+			}
+			if (result.unrepairable > 0) {
+				notesNeedingReimport += 1;
+			}
+		}
+		const tail =
+			notesNeedingReimport > 0
+				? ` ${notesNeedingReimport} note${notesNeedingReimport === 1 ? "" : "s"} had a broken card with no local copy; re-import those.`
+				: "";
+		new Notice(
+			`Plaud Importer: repaired ${linksRepointed} card link${linksRepointed === 1 ? "" : "s"} in ${notesRepaired} note${notesRepaired === 1 ? "" : "s"}.${tail}`,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Fixes issue #52: the card image in an imported note renders as "could not be found."

Plaud's AI summary markdown carries an inline embed authored by Plaud's server — `![PLAUD NOTE](permanent/.../summary_poster/card_...)` — a path that only resolves inside Plaud's app. The importer already downloads that same asset into the note's `-assets` folder and links it in its managed `### Card` section, but copied the summary body verbatim, so the note ended up with two links to one image: Plaud's (broken in Obsidian) and the plugin's (correct). This repoints Plaud's inline embed at the local copy.

## Changes (`attachment-importer.ts` + its test)

- New exported pure fn `rewriteInlineSummaryEmbeds(content, urlToLocalPath)` — repoints an inline markdown image embed at its downloaded local copy as an `![[...]]` wikilink on a map hit; unmapped embeds and existing wikilinks are untouched.
- A `summaryEmbedRewrites` map (`asset.url` → local path) populated at the two image-save sites, applied in the existing `vault.process` pass before the managed section is rebuilt; the early-return guard is widened so a note with only inline embeds (no managed links) is still processed.

## Verification

- Full suite green (948 → +4 new = the pure fn plus key-match and scope cases). `tsc`, lint, build clean. Applies cleanly on top of 0.25.0 (zero file overlap with that release).
- **Key-match confirmed safe.** `normalizeSummaryLink` and the rewrite's normalization are equivalent (both strip `<>`/quotes on a whitespace-free capture), and both pull the target from the same summary markdown, so the lookup hits for the reported card embed. Tests lock exact-match-including-query-suffix behavior.

## Not covered here (by design)

- **Integration wiring (map population + `vault.process`) is not jest-tested.** The project's `obsidian` mock is intentionally inert ("behavioral testing of Obsidian runtime belongs in manual smoke-tests, not jest"). This is validated by a hands-on smoke test in a real vault before merge — importing a recording whose summary carries a card poster and confirming the card renders locally.
- Only markdown `![]()` embeds are repointed; an `<img>` tag or bare URL is downloaded but left as-is (locked by a test).
- Card artifact disabled → asset not downloaded → the broken embed is left in place (out of #52 scope).

## Also: one-time repair command for existing notes

The rewrite above only fixes card embeds as notes are (re)imported. Notes imported *before* this keep the broken card. So this PR also adds a **user-invoked** command **"Repair card image links from older imports (one-time)"** (never automatic — it mass-edits notes, so it needs explicit consent):

- Pure `isLocalCardImage()` + `repairLegacyCardEmbeds()` in `attachment-importer.ts` — conservative (only `summary_poster` embeds; only repoints when exactly one local card image exists; idempotent). Both tested.
- A scan handler in `main.ts` scoped to this plugin's notes (`plaud-id` frontmatter), reporting a count and flagging notes whose card was never downloaded for a re-import.
- Clearly banner-marked `REMOVE IN A FUTURE VERSION` in both files (and the CHANGELOG) so it can be deleted once users have run it.

## Test plan (hands-on, before merge)

- [ ] Import a recording whose AI summary includes a card poster; the card renders (no "could not be found").
- [ ] A summary with no card is unaffected.
- [ ] Re-import (overwrite) still renders the card.
- [ ] On a note imported before this fix, run the repair command; the card renders and the Notice reports the count. Running it again is a no-op.
