### PR TITLE
Preserve unknown frontmatter on re-import (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **New setting "Preserve unknown frontmatter on re-import" (on by default).** When a re-import overwrites a note, any frontmatter property you added yourself, or that another tool wrote, is now kept instead of being dropped. Before this, a re-import rebuilt the whole frontmatter block from the plugin's own fields plus your declared extra-frontmatter rows, so a property that downstream automation wrote straight into the note was lost on the next overwrite. Reserved plugin fields still refresh, and you can still let the plugin manage a specific property by adding it as an extra-frontmatter row with preserve turned off. Turn the setting off to restore the old rebuild-from-scratch behavior.
+
+### Fixed
+
+- **A placeholder stub's `plaud-placeholder` marker no longer lingers after real content arrives.** The marker was missing from the plugin's reserved-key set; it is now reserved, so a later real import clears it as intended.
+
 ## [0.27.2] - 2026-07-08
 
 ### Fixed

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -1668,6 +1668,86 @@ describe('formatFrontmatter custom rows', () => {
 	});
 });
 
+// formatFrontmatter preserve-unknown passthrough (#58) ----------------------
+
+describe('formatFrontmatter preserve-unknown passthrough', () => {
+	// Positional args after customRows: existingValues (the note's current
+	// frontmatter, already serialized) then preserveUnknown.
+	const call = (
+		existing: ReadonlyMap<string, string> | undefined,
+		preserveUnknown: boolean,
+		customRows?: readonly CustomFrontmatterRow[],
+	): string =>
+		formatFrontmatter(
+			makeRecording(),
+			[],
+			null,
+			undefined,
+			undefined,
+			undefined,
+			customRows,
+			existing,
+			preserveUnknown,
+		);
+
+	it('keeps an undeclared foreign key on re-import when on', () => {
+		const fm = call(new Map([['project-status', 'shipped']]), true);
+		expect(fm).toMatch(/^project-status: shipped$/m);
+	});
+
+	it('drops the undeclared foreign key when off (old behavior)', () => {
+		const fm = call(new Map([['project-status', 'shipped']]), false);
+		expect(fm).not.toMatch(/^project-status:/m);
+	});
+
+	it('still refreshes a reserved plugin key even when on', () => {
+		// A stale reserved value in the existing note must not be carried through;
+		// reserved keys are the plugin's to regenerate.
+		const fm = call(new Map([['source', 'stale']]), true);
+		expect(fm).toMatch(/^source: plaud$/m);
+		expect(fm).not.toMatch(/^source: stale$/m);
+	});
+
+	it('lets a declared custom row control its key, not the passthrough', () => {
+		// status is a declared row with preserve off, so it regenerates from the
+		// template; the passthrough must not re-add the existing value on top.
+		const fm = call(new Map([['status', 'done']]), true, [
+			{ key: 'status', value: 'unprocessed', preserve: false },
+		]);
+		expect(fm).toMatch(/^status: unprocessed$/m);
+		expect(fm).not.toMatch(/^status: done$/m);
+	});
+
+	it('carries multiple foreign keys, appended after the built-in fields', () => {
+		const fm = call(
+			new Map([
+				['project-status', 'shipped'],
+				['owner', 'charles'],
+			]),
+			true,
+		);
+		expect(fm).toMatch(/^project-status: shipped$/m);
+		expect(fm).toMatch(/^owner: charles$/m);
+		expect(fm.indexOf('source: plaud')).toBeLessThan(
+			fm.indexOf('project-status:'),
+		);
+	});
+
+	it('is a no-op on first creation (no existing frontmatter) even when on', () => {
+		const fm = call(undefined, true);
+		expect(fm).toMatch(/^source: plaud$/m);
+		expect(fm).not.toMatch(/^project-status:/m);
+	});
+
+	it('never carries the plaud-placeholder marker onto real content', () => {
+		// plaud-placeholder is a reserved plugin marker on a stub. When real content
+		// supersedes the stub the flag must vanish, not be preserved as a foreign
+		// key. Regression guard for the RESERVED_FRONTMATTER_KEYS gap #58 surfaced.
+		const fm = call(new Map([['plaud-placeholder', 'true']]), true);
+		expect(fm).not.toMatch(/^plaud-placeholder:/m);
+	});
+});
+
 describe('renderCustomFrontmatterPreview', () => {
 	it('renders each row against the preview context', () => {
 		const lines = renderCustomFrontmatterPreview([

--- a/main.ts
+++ b/main.ts
@@ -279,6 +279,12 @@ const FORBIDDEN_CHAR_REPLACEMENT_DESC =
 // wording scopes the setting to manual imports: background auto-sync runs
 // headless with skip-for-new / overwrite-for-changed and never prompts, so
 // 'Ask each time' has no dialog to answer during a sync tick (issue #43).
+// Description for the preserve-unknown-frontmatter toggle (#58). Held in a const
+// so the declarative (1.13+) and imperative (1.12) settings paths show identical
+// text and the sentence-case lint inspects one literal.
+const PRESERVE_UNKNOWN_FRONTMATTER_DESC =
+	"On by default. When a re-import overwrites a note, keep any frontmatter property you added yourself, or that another tool wrote, that the plugin does not manage. Leave this on so downstream automation and hand-added properties survive a re-import. To let the plugin manage and refresh a specific property instead, add it as an extra frontmatter row with preserve turned off.";
+
 const DUPLICATE_HANDLING_NAME = "Duplicate handling for manual imports";
 const DUPLICATE_HANDLING_DESC =
 	"Controls what happens when you run Import recent recordings and a note for the recording already exists. Skip keeps your copy, overwrite replaces it, and ask each time prompts you for each one. Automatic sync ignores this and never prompts.";
@@ -439,6 +445,13 @@ interface PlaudImporterSettings {
 	// row's value may use {{ }} tokens; preserve keeps the note's existing value on
 	// re-import. Empty (the default) writes no extra properties.
 	customFrontmatter: CustomFrontmatterRow[];
+	// When on, a re-import keeps any frontmatter property the user (or their
+	// downstream automation) added that the plugin does not manage and that is not
+	// a declared Extra frontmatter row, instead of dropping it on overwrite (#58).
+	// Default on: silently losing user-written properties is the worse failure. To
+	// let the plugin manage a specific property instead, declare it as an Extra
+	// frontmatter row with preserve off.
+	preserveUnknownFrontmatter: boolean;
 	// Single character that replaces a forbidden filename/folder character (the
 	// Windows-forbidden set, control codes, and brackets in a note name), and the
 	// path separators inside a {{title}} folder token. Default "-". Validated to a
@@ -536,6 +549,7 @@ const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	customFrontmatter: [
 		{ key: "Recording Source", value: "Plaud Importer", preserve: true },
 	],
+	preserveUnknownFrontmatter: true,
 	forbiddenCharReplacement: "-",
 	onDuplicate: "prompt",
 	showRibbonIcon: true,
@@ -948,6 +962,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			noteNameTemplate: this.settings.noteNameTemplate,
 			datetimeTemplate: this.settings.datetimeTemplate,
 			customFrontmatter: this.settings.customFrontmatter,
+			preserveUnknownFrontmatter: this.settings.preserveUnknownFrontmatter,
 			forbiddenCharReplacement: this.settings.forbiddenCharReplacement,
 			onDuplicate: this.settings.onDuplicate,
 			includeTranscript: this.settings.includeTranscript,
@@ -2866,6 +2881,12 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 				CUSTOM_FRONTMATTER_INTRO,
 			),
 		);
+		this.addToggleRow(
+			containerEl,
+			"Preserve unknown frontmatter on re-import",
+			PRESERVE_UNKNOWN_FRONTMATTER_DESC,
+			"preserveUnknownFrontmatter",
+		);
 		this.addTextRow(
 			containerEl,
 			"Forbidden character replacement",
@@ -3961,6 +3982,14 @@ class PlaudImporterSettingsTab extends PluginSettingTab {
 						searchable: false,
 						render: (setting: Setting) =>
 							this.renderCustomFrontmatterControl(setting),
+					},
+					{
+						name: "Preserve unknown frontmatter on re-import",
+						desc: PRESERVE_UNKNOWN_FRONTMATTER_DESC,
+						control: {
+							type: "toggle",
+							key: "preserveUnknownFrontmatter",
+						},
 					},
 					{
 						name: "Forbidden character replacement",

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -147,6 +147,14 @@ export interface NoteWriterOptions {
 	 */
 	readonly customFrontmatter?: readonly CustomFrontmatterRow[];
 	/**
+	 * When true, a re-import keeps any existing frontmatter key the user added by
+	 * hand (or via downstream automation) that is neither a reserved plugin key
+	 * nor a declared custom row, instead of dropping it (#58). Defaults to true at
+	 * the plugin layer; a headless caller omitting it gets the non-destructive
+	 * behavior. See `preserveUnknownFrontmatter` in FormatMarkdownOptions.
+	 */
+	readonly preserveUnknownFrontmatter?: boolean;
+	/**
 	 * Character that replaces a forbidden filename/folder character (the Windows
 	 * set plus control codes; brackets too in a note name). Defaults to '-'.
 	 * Applied to both the note name and each resolved subfolder segment, and to
@@ -1218,6 +1226,10 @@ export const RESERVED_FRONTMATTER_KEYS: ReadonlySet<string> = new Set([
 	'plaud-note-id',
 	'plaud-summary-id',
 	'plaud-summary-version',
+	// Marker on a placeholder stub (writePlaceholderNote). Reserved so the
+	// preserve-unknown passthrough (#58) never carries it onto real content when a
+	// later import supersedes the stub, and so a custom row cannot claim it.
+	'plaud-placeholder',
 ]);
 
 /**
@@ -1363,6 +1375,7 @@ export function formatFrontmatter(
 	datetimeTemplate?: string,
 	customRows?: readonly CustomFrontmatterRow[],
 	existingValues?: ReadonlyMap<string, string>,
+	preserveUnknown = false,
 ): string {
 	const duration = Number.isFinite(recording.durationSeconds)
 		? Math.max(0, Math.floor(recording.durationSeconds))
@@ -1478,6 +1491,23 @@ export function formatFrontmatter(
 				serialized = expanded.length > 0 ? yamlScalar(expanded) : '';
 			}
 			entries.set(key, serialized);
+		}
+	}
+
+	// Passthrough for foreign keys (#58). On a re-import the whole block is rebuilt
+	// from the plugin's own keys plus declared custom rows, so a key the user (or
+	// their downstream automation) added by hand and never declared would be
+	// dropped. When preserveUnknown is on, carry through any existing key that is
+	// neither a reserved plugin key (those always refresh) nor already emitted (a
+	// built-in or a declared row). Appended last, after first-seen plugin order,
+	// so foreign keys read naturally at the end. existingValues holds serialized
+	// YAML, so the stored value is emit-ready. Only fires on the overwrite path
+	// (existingValues present); on first creation there is nothing to preserve.
+	if (preserveUnknown && existingValues) {
+		for (const [key, value] of existingValues) {
+			if (!RESERVED_FRONTMATTER_KEYS.has(key) && !entries.has(key)) {
+				entries.set(key, value);
+			}
 		}
 	}
 
@@ -2142,6 +2172,15 @@ export interface FormatMarkdownOptions {
 	 * `extractFrontmatterValues`.
 	 */
 	readonly existingFrontmatter?: ReadonlyMap<string, string>;
+	/**
+	 * When true, a re-import carries through any existing frontmatter key that is
+	 * neither a reserved plugin key nor a declared custom row, instead of dropping
+	 * it (#58). Lets user- or automation-added keys survive an overwrite without
+	 * being enumerated in the Extra frontmatter setting. Defaults to false here;
+	 * the plugin passes the user's setting (which defaults on). Only has an effect
+	 * on the overwrite path, where `existingFrontmatter` is supplied.
+	 */
+	readonly preserveUnknownFrontmatter?: boolean;
 }
 
 export function formatMarkdown(
@@ -2175,6 +2214,7 @@ export function formatMarkdown(
 			options.datetimeTemplate,
 			options.customFrontmatter,
 			options.existingFrontmatter,
+			options.preserveUnknownFrontmatter,
 		),
 		'',
 		`# ${expandedTitle}`,
@@ -2425,6 +2465,7 @@ export class NoteWriter {
 	private readonly noteNameTemplate: string;
 	private readonly datetimeTemplate: string;
 	private readonly customFrontmatter: readonly CustomFrontmatterRow[];
+	private readonly preserveUnknownFrontmatter: boolean;
 	private readonly forbiddenCharReplacement: string;
 	private readonly existingPathForPlaudId?: (plaudId: string) => string | null;
 	private readonly migrateExistingNote?: (
@@ -2464,6 +2505,9 @@ export class NoteWriter {
 				: DEFAULT_NOTE_NAME_TEMPLATE;
 		this.datetimeTemplate = options.datetimeTemplate ?? '';
 		this.customFrontmatter = options.customFrontmatter ?? [];
+		// Default true: a headless caller (or hand-edited data.json) that omits this
+		// gets the non-destructive behavior, matching DEFAULT_SETTINGS.
+		this.preserveUnknownFrontmatter = options.preserveUnknownFrontmatter ?? true;
 		// Defense-in-depth: the settings layer validates this, but a headless caller
 		// or hand-edited data.json could pass anything, so fall back to '-' for an
 		// unusable value rather than sanitizing with a forbidden character.
@@ -2483,6 +2527,7 @@ export class NoteWriter {
 			noteNameTemplate: this.noteNameTemplate,
 			datetimeTemplate: this.datetimeTemplate,
 			customFrontmatter: this.customFrontmatter,
+			preserveUnknownFrontmatter: this.preserveUnknownFrontmatter,
 		};
 	}
 


### PR DESCRIPTION
Closes #58 (sub-issue of #44, part 1).

## Problem

On an overwrite re-import, `formatFrontmatter` rebuilds the whole frontmatter block from the plugin's reserved keys plus declared Extra-frontmatter rows. Any key the user (or their downstream automation) added by hand and never declared is dropped. The per-property preserve shipped in 0.25.0 (#53) is an allowlist: it only protects keys you type into settings and toggle preserve on. Sybawoods' nightly pipeline writes arbitrary keys straight into the note, so enumerating them is exactly what he wants to avoid.

## Change

New global setting **Preserve unknown frontmatter on re-import** (default ON). When on, a passthrough after the custom-rows loop in `formatFrontmatter` carries through any existing key that is neither reserved nor already emitted.

| Key type | Behavior |
|---|---|
| Undeclared foreign key | Auto-preserved (passthrough) |
| Declared row, preserve ON | Kept (existing) |
| Declared row, preserve OFF | Refreshed from template |
| Reserved plugin key | Always refreshed |

Opt out per key by declaring it as an Extra-frontmatter row with preserve off. Turn the setting off to restore the old rebuild-from-scratch behavior.

Default ON because silently losing user-written frontmatter is the worse failure. Existing users get it via the `Object.assign(DEFAULT_SETTINGS, stored)` merge.

## Also fixed

`plaud-placeholder` (the placeholder-stub marker) was missing from `RESERVED_FRONTMATTER_KEYS`. The passthrough surfaced it: the stub flag was wrongly preserved onto real content. Now reserved, so a later real import clears it as intended. Regression test added.

## Scope / threading

Flag threaded settings -> buildImportRuntimeOptions -> NoteWriterOptions -> NoteWriter ctor -> FormatMarkdownOptions -> formatFrontmatter. Toggle added to both the imperative (1.12) and declarative (1.13+) settings render paths, with a shared description const so they cannot drift.

## Verification

lint (+ submission and icon pre-checks), build, 983 tests pass (7 new: passthrough on/off, reserved-still-refreshes, declared-row-wins, multi-key order, create-path no-op, plaud-placeholder guard). Codex pre-commit: no findings (verified passthrough can't resurrect reserved keys or clobber declared rows, default-on end-to-end incl. upgrade merge, RESERVED completeness, and no missed call sites).

Not yet hands-on validated in a real vault; the frontmatter logic is pure and covered by jest, but a live round-trip (add a foreign key, re-import, confirm it survives) is a good manual check before release.