### PR TITLE
Fix #61: restore summary metadata on the newer summary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Fixed
 
+- **The `plaud-model`, `plaud-template`, `plaud-headline`, `plaud-category`, and `plaud-summary-id` frontmatter fields are populated again.** After Plaud moved AI summaries onto a newer generation path, the plugin fetched only the summary text and dropped all of this metadata, so notes (and any MP3 you uploaded) came in with none of those properties. The plugin now reads the metadata from the same recording detail it already downloads, so the fields return. The template value now prefers Plaud's readable template name (for example "Adaptive Summary") over its internal code. If a future Plaud change relocates a field again, the import still succeeds without it and a debug log names the field that could not be found.
 - **A placeholder stub's `plaud-placeholder` marker no longer lingers after real content arrives.** The marker was missing from the plugin's reserved-key set; it is now reserved, so a later real import clears it as intended.
 
 ## [0.27.2] - 2026-07-08

--- a/__tests__/summary-metadata.test.ts
+++ b/__tests__/summary-metadata.test.ts
@@ -1,0 +1,136 @@
+import { findSummaryMetadata } from '../plaud-client-re';
+
+// Golden fixture: the STRUCTURE of a real `/file/detail/{id}` response,
+// captured live from web.plaud.ai on 2026-07-09 while diagnosing issue #61
+// (a recording with an "Adaptive Summary" template generated on model
+// gpt-5.5). Values are synthetic/redacted; the NESTING is verbatim to the
+// live payload — the summary metadata is split across the `auto_sum_note`
+// entry's `extra` and `extra_data`, which is exactly the shape that broke
+// the old flat-`/ai/transsumm`-envelope parse. If Plaud moves these fields
+// again, re-capture and diff this fixture: the failing assertion names the
+// field that moved.
+const DETAIL_2026_07_09 = {
+	status: 0,
+	msg: 'ok',
+	request_id: 'redacted',
+	data: {
+		file_id: 'redacted-file-id',
+		file_name: '07-08 Example recording',
+		content_list: [
+			{ data_type: 'transaction', extra: {} },
+			{ data_type: 'outline', extra: {} },
+			{ data_type: 'transaction_polish', extra: {} },
+			{
+				data_type: 'auto_sum_note',
+				extra: {
+					summary_id: '20260708183602-v2@redacted',
+					summ_type: 'AI-CHOICE',
+					summ_type_type: 'system',
+					used_template: {
+						template_type: 'official',
+						template_id: 'AI-CHOICE',
+						template_version_id: '',
+						template_name: 'Adaptive Summary',
+					},
+				},
+			},
+		],
+		extra_data: {
+			model: 'gpt-5.5',
+			aiContentHeader: {
+				headline: 'Example headline for the recording',
+				category: 'Adaptive Summary',
+				original_category: 'Adaptive Summary',
+				industry_category: 'redacted-industry',
+				summary_id: '20260708183602-v2@redacted',
+				used_template: {
+					template_id: 'AI-CHOICE',
+					template_type: 'official',
+					template_version_id: '',
+				},
+				recommend_questions: [
+					{ category: 'key_insights' },
+					{ category: 'subtext' },
+				],
+			},
+			used_template: {
+				template_id: 'AI-CHOICE',
+				template_type: 'official',
+				template_version_id: '',
+			},
+		},
+	},
+};
+
+const endpoint = '/file/detail/redacted';
+
+describe('findSummaryMetadata (issue #61 — newer summary path)', () => {
+	it('resolves template, model, headline, category, summary_id from the drift-era detail shape', () => {
+		expect(findSummaryMetadata(DETAIL_2026_07_09, endpoint)).toEqual({
+			template: 'Adaptive Summary',
+			model: 'gpt-5.5',
+			headline: 'Example headline for the recording',
+			category: 'Adaptive Summary',
+			summaryId: '20260708183602-v2@redacted',
+		});
+	});
+
+	it('prefers the human-readable template_name over the summ_type code', () => {
+		expect(findSummaryMetadata(DETAIL_2026_07_09, endpoint).template).toBe(
+			'Adaptive Summary',
+		);
+	});
+
+	it('scopes category to aiContentHeader, not industry_category / original_category / per-question category', () => {
+		expect(findSummaryMetadata(DETAIL_2026_07_09, endpoint).category).toBe(
+			'Adaptive Summary',
+		);
+	});
+
+	it('does not bleed category into a nested per-question category when the header lacks a direct one', () => {
+		const noDirectCategory = {
+			data: {
+				content_list: [
+					{ data_type: 'auto_sum_note', extra: { summ_type: 'meeting' } },
+				],
+				extra_data: {
+					model: 'gpt-5.5',
+					aiContentHeader: {
+						headline: 'A headline',
+						// no direct `category`, but recommend_questions each carry one
+						recommend_questions: [
+							{ category: 'key_insights' },
+							{ category: 'subtext' },
+						],
+					},
+				},
+			},
+		};
+		const md = findSummaryMetadata(noDirectCategory, endpoint);
+		expect(md.category).toBeUndefined();
+		expect(md.headline).toBe('A headline');
+	});
+
+	it('falls back to summ_type when no template_name is present', () => {
+		const noTemplateName = {
+			data: {
+				content_list: [
+					{ data_type: 'auto_sum_note', extra: { summ_type: 'meeting' } },
+				],
+				extra_data: { model: 'gpt-5.5' },
+			},
+		};
+		const md = findSummaryMetadata(noTemplateName, endpoint);
+		expect(md.template).toBe('meeting');
+		expect(md.model).toBe('gpt-5.5');
+	});
+
+	it('returns {} when the summary metadata subtrees are absent (older recording)', () => {
+		const bare = { data: { file_id: 'x', content_list: [] } };
+		expect(findSummaryMetadata(bare, endpoint)).toEqual({});
+	});
+
+	it('throws on a structurally invalid response (no data envelope)', () => {
+		expect(() => findSummaryMetadata({ status: 0 }, endpoint)).toThrow();
+	});
+});

--- a/__tests__/summary-metadata.test.ts
+++ b/__tests__/summary-metadata.test.ts
@@ -125,6 +125,31 @@ describe('findSummaryMetadata (issue #61 — newer summary path)', () => {
 		expect(md.model).toBe('gpt-5.5');
 	});
 
+	it('resolves language from extra_data when Plaud includes it, alongside the other fields', () => {
+		const withLanguage = {
+			data: {
+				content_list: [
+					{
+						data_type: 'auto_sum_note',
+						extra: {
+							summ_type: 'meeting',
+							used_template: { template_name: 'Meeting Notes' },
+						},
+					},
+				],
+				extra_data: {
+					model: 'gpt-5.5',
+					language: 'en',
+					aiContentHeader: { headline: 'H', category: 'Meeting' },
+				},
+			},
+		};
+		const md = findSummaryMetadata(withLanguage, endpoint);
+		expect(md.language).toBe('en');
+		expect(md.template).toBe('Meeting Notes');
+		expect(md.model).toBe('gpt-5.5');
+	});
+
 	it('returns {} when the summary metadata subtrees are absent (older recording)', () => {
 		const bare = { data: { file_id: 'x', content_list: [] } };
 		expect(findSummaryMetadata(bare, endpoint)).toEqual({});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-refresh.ts plaud-refresh-net.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/plaud-refresh.test.ts __tests__/plaud-refresh-net.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
+		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-refresh.ts plaud-refresh-net.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/summary-metadata.test.ts __tests__/plaud-refresh.test.ts __tests__/plaud-refresh-net.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts --max-warnings 0 && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -519,6 +519,48 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 				});
 			}
 		}
+		// Summary metadata (template, model, headline, category, summary_id)
+		// lives in the detail envelope, scattered across the auto_sum_note
+		// entry's `extra` and `extra_data`. Pull it with a scoped, drift-
+		// resilient resolver (findSummaryMetadata) so a future relocation is a
+		// one-line key-list edit there rather than silent data loss — the exact
+		// failure mode of issue #61, where this metadata stopped appearing once
+		// Plaud moved summaries off the flat /ai/transsumm envelope onto the
+		// auto_sum_note path, which previously built a bare { id, text }.
+		// Best-effort: a throw here must never abort the bundle.
+		let summaryMetadata: SummaryMetadata = {};
+		if (newerSummaryMarkdown !== null) {
+			try {
+				summaryMetadata = findSummaryMetadata(rawDetail, detailEndpoint);
+			} catch (err) {
+				if (this.debugLogger?.enabled === true) {
+					this.debugLogger.log({
+						kind: 'parsed',
+						endpoint: detailEndpoint,
+						message: `summary-metadata extraction failed for ${id}; frontmatter extras omitted: ${describeUnknownError(err)}`,
+						payload: { summaryMetadataError: describeUnknownError(err) },
+					});
+				}
+			}
+			// Loud-not-silent: a recording that HAS a summary but yields no
+			// resolvable metadata is the signature of a Plaud shape change.
+			// Name the unresolved fields so the drift is diagnosable from a
+			// debug log now, instead of surfacing weeks later as a "properties
+			// missing" bug report (issue #61).
+			if (this.debugLogger?.enabled === true) {
+				const missing = DRIFT_SIGNAL_FIELDS.filter(
+					(field) => summaryMetadata[field] === undefined,
+				);
+				if (missing.length > 0) {
+					this.debugLogger.log({
+						kind: 'parsed',
+						endpoint: detailEndpoint,
+						message: `summary present but ${missing.length} known metadata field(s) unresolved for ${id} (possible Plaud shape drift): ${missing.join(', ')}`,
+						payload: { unresolvedSummaryMetadata: missing },
+					});
+				}
+			}
+		}
 		const aiKeywords = findAiKeywords(rawDetail, detailEndpoint);
 		const attachments = findAttachmentAssets(rawDetail, detailEndpoint);
 		const nestedAssetLinks = findNestedAssetLinks(rawDetail, detailEndpoint);
@@ -528,7 +570,9 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 		];
 
 		const newerSummary: Summary | null =
-			newerSummaryMarkdown !== null ? { id, text: newerSummaryMarkdown } : null;
+			newerSummaryMarkdown !== null
+				? { id, text: newerSummaryMarkdown, ...summaryMetadata }
+				: null;
 
 		let polishedTranscript: Transcript | null = null;
 		// Prefer the polished transcript (real speaker names from Plaud's
@@ -1741,6 +1785,188 @@ export function findAiKeywords(
 		}
 	}
 	return out;
+}
+
+/**
+ * The optional {@link Summary} fields Plaud carries as metadata around a
+ * generated summary. Doubles as the checklist the bundle fetch uses to
+ * detect shape drift: a summary present with every one of these unresolved
+ * is the drift signal (issue #61).
+ */
+export type SummaryMetadata = Pick<
+	Summary,
+	'headline' | 'category' | 'language' | 'template' | 'model' | 'summaryId'
+>;
+
+// Fields expected on every AI-generated summary. Their combined absence when
+// a summary IS present is the shape-drift signal the bundle fetch logs.
+// `language` is deliberately excluded: Plaud omits it for many recordings, so
+// it is resolved when present but never counted as "missing" (that would make
+// the drift log fire on normal recordings and drown out the real signal).
+const DRIFT_SIGNAL_FIELDS: readonly (keyof SummaryMetadata)[] = [
+	'headline',
+	'category',
+	'template',
+	'model',
+	'summaryId',
+];
+
+// Depth cap for the scoped resolver. Plaud's detail envelope nests the
+// fields we want at most ~4 levels deep (content_list[] -> extra ->
+// used_template -> template_name); 8 leaves headroom for a reshuffle while
+// still guaranteeing a pathological or cyclic payload can never spin.
+const MAX_RESOLVE_DEPTH = 8;
+
+/**
+ * Recursively search `root` for the first property named `key` whose value
+ * is a non-empty string, preferring a direct (shallower, earlier) match
+ * over a deeper one. Depth-bounded and cycle-guarded. Returns the trimmed
+ * string, or undefined when no such property exists.
+ */
+function findStringByKey(
+	root: unknown,
+	key: string,
+	depth: number,
+	maxDepth: number,
+	seen: Set<object>,
+): string | undefined {
+	if (depth > maxDepth || root === null || typeof root !== 'object') {
+		return undefined;
+	}
+	if (seen.has(root)) {
+		return undefined;
+	}
+	seen.add(root);
+	if (!Array.isArray(root)) {
+		const direct = (root as Record<string, unknown>)[key];
+		if (typeof direct === 'string' && direct.trim().length > 0) {
+			return direct.trim();
+		}
+	}
+	for (const value of Object.values(root as Record<string, unknown>)) {
+		if (value !== null && typeof value === 'object') {
+			const hit = findStringByKey(value, key, depth + 1, maxDepth, seen);
+			if (hit !== undefined) {
+				return hit;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Scoped, drift-resilient field resolver. Tries each name in `keyNames` in
+ * order and returns the first non-empty string found within `root` down to
+ * `maxDepth` levels. Key-name order is the preference axis: every occurrence
+ * of keyNames[0] is checked before keyNames[1], so a caller can prefer a
+ * human-readable field (`template_name`) over a code (`summ_type`).
+ *
+ * `maxDepth` bounds how far the search descends. Pass 0 for a direct-only
+ * lookup — the right choice for a field documented to live directly on its
+ * scoped subtree (e.g. `aiContentHeader.category`), so the search can never
+ * bleed into an unrelated nested `category` (such as a per-question one).
+ * Use a deeper bound only when the value is legitimately nested (e.g.
+ * `used_template.template_name`).
+ */
+function resolveString(
+	root: unknown,
+	keyNames: readonly string[],
+	maxDepth = MAX_RESOLVE_DEPTH,
+): string | undefined {
+	for (const key of keyNames) {
+		const hit = findStringByKey(root, key, 0, maxDepth, new Set());
+		if (hit !== undefined) {
+			return hit;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Locate the `extra` object of the `auto_sum_note` entry in a detail
+ * response's `content_list`, or undefined when absent. This entry carries
+ * the summary's own `summ_type`, `summary_id`, and `used_template`.
+ */
+function findAutoSumNoteExtra(
+	data: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	const list = data.content_list;
+	if (!Array.isArray(list)) {
+		return undefined;
+	}
+	for (const item of list) {
+		if (
+			isRecord(item) &&
+			item.data_type === 'auto_sum_note' &&
+			isRecord(item.extra)
+		) {
+			return item.extra;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Extract summary metadata from a `/file/detail/{id}` response for the
+ * newer (`auto_sum_note`) summary path.
+ *
+ * The fields are scattered: `summ_type` / `used_template.template_name` /
+ * `summary_id` sit on the auto_sum_note entry's `extra`, while `model` and
+ * `aiContentHeader.headline` / `category` sit on `extra_data`. Rather than
+ * hardcode one exact path per field — the brittleness that produced issue
+ * #61 when Plaud moved this data off the flat `/ai/transsumm` envelope —
+ * each field is resolved by NAME within a scoped subtree, with an ordered
+ * list of accepted names. A future relocation within these subtrees needs
+ * no code change; a rename is a one-line key-list edit here.
+ *
+ * Scoped and bounded so a generic key never matches the wrong branch:
+ * `category` is resolved inside `aiContentHeader`, not the whole envelope
+ * (which also carries `industry_category`, `original_category`, and a
+ * per-question `category` on every recommended question).
+ *
+ * Best-effort: returns `{}` for any absent field, and throws only via
+ * {@link requireDataEnvelope} on a structurally invalid top-level response,
+ * which the caller isolates.
+ */
+export function findSummaryMetadata(
+	raw: unknown,
+	endpoint: string,
+): SummaryMetadata {
+	const data = requireDataEnvelope(raw, endpoint);
+	const extraData = isRecord(data.extra_data) ? data.extra_data : undefined;
+	const header =
+		extraData !== undefined && isRecord(extraData.aiContentHeader)
+			? extraData.aiContentHeader
+			: undefined;
+	const summaryExtra = findAutoSumNoteExtra(data);
+
+	// Narrowest scope first to avoid cross-branch bleed, widening to the
+	// whole envelope only as a last resort.
+	const templateScope = summaryExtra ?? extraData ?? data;
+	const idScope = summaryExtra ?? extraData ?? data;
+	const headerScope = header ?? extraData ?? data;
+	const modelScope = extraData ?? data;
+
+	// `template_name` is legitimately nested (under `used_template`), so it
+	// needs a deep search. Every other field is documented to sit directly on
+	// its scoped subtree, so resolve it direct-only (maxDepth 0) — this keeps a
+	// generic key like `category` from bleeding into a nested unrelated one
+	// (e.g. a per-question `category` under `recommend_questions`).
+	const template = resolveString(templateScope, ['template_name', 'summ_type']);
+	const model = resolveString(modelScope, ['model'], 0);
+	const headline = resolveString(headerScope, ['headline'], 0);
+	const category = resolveString(headerScope, ['category'], 0);
+	const summaryId = resolveString(idScope, ['summary_id'], 0);
+	const language = resolveString(modelScope, ['language'], 0);
+
+	return {
+		...(headline !== undefined && { headline }),
+		...(category !== undefined && { category }),
+		...(language !== undefined && { language }),
+		...(template !== undefined && { template }),
+		...(model !== undefined && { model }),
+		...(summaryId !== undefined && { summaryId }),
+	};
 }
 
 /**

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -542,11 +542,13 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 					});
 				}
 			}
-			// Loud-not-silent: a recording that HAS a summary but yields no
-			// resolvable metadata is the signature of a Plaud shape change.
-			// Name the unresolved fields so the drift is diagnosable from a
-			// debug log now, instead of surfacing weeks later as a "properties
-			// missing" bug report (issue #61).
+			// Loud-not-silent: on a recording that HAS a summary, one or more
+			// unresolved drift-signal fields is the signature of a Plaud shape
+			// change (the #61 drift moved several at once, but a future rename
+			// may move just one, so we log on any absence, not only total
+			// absence). Name the unresolved fields so the drift is diagnosable
+			// from a debug log now, instead of surfacing weeks later as a
+			// "properties missing" bug report (issue #61).
 			if (this.debugLogger?.enabled === true) {
 				const missing = DRIFT_SIGNAL_FIELDS.filter(
 					(field) => summaryMetadata[field] === undefined,
@@ -1798,8 +1800,9 @@ export type SummaryMetadata = Pick<
 	'headline' | 'category' | 'language' | 'template' | 'model' | 'summaryId'
 >;
 
-// Fields expected on every AI-generated summary. Their combined absence when
-// a summary IS present is the shape-drift signal the bundle fetch logs.
+// Fields expected on every AI-generated summary. When a summary IS present,
+// any one of these going unresolved is the shape-drift signal the bundle
+// fetch logs.
 // `language` is deliberately excluded: Plaud omits it for many recordings, so
 // it is resolved when present but never counted as "missing" (that would make
 // the drift log fire on normal recordings and drown out the real signal).
@@ -1818,10 +1821,14 @@ const DRIFT_SIGNAL_FIELDS: readonly (keyof SummaryMetadata)[] = [
 const MAX_RESOLVE_DEPTH = 8;
 
 /**
- * Recursively search `root` for the first property named `key` whose value
- * is a non-empty string, preferring a direct (shallower, earlier) match
- * over a deeper one. Depth-bounded and cycle-guarded. Returns the trimmed
- * string, or undefined when no such property exists.
+ * Search `root` for a property named `key` whose value is a non-empty string.
+ * Traversal is depth-first: at each node the node's own `key` is checked
+ * before descending, so a direct match beats that node's descendants — but
+ * because branches are visited in order, a deeper match in an earlier branch
+ * can be returned before a shallower match in a later branch. This is why
+ * callers that need precision pass `maxDepth: 0` (direct-only) and scope
+ * `root` to the narrowest relevant subtree. Depth-bounded and cycle-guarded.
+ * Returns the trimmed string, or undefined when no such property exists.
  */
 function findStringByKey(
 	root: unknown,


### PR DESCRIPTION
Fixes #61.

## Problem
Plaud moved AI summaries onto a newer `auto_sum_note` generation path. On that path the client built a bare `{ id, text }` Summary (`plaud-client-re.ts` `fetchFileDetailBundle`) and dropped every metadata field, so `plaud-model`, `plaud-template`, `plaud-headline`, `plaud-category`, and `plaud-summary-id` stopped appearing in frontmatter. It also never appeared for MP3 uploads (they take the same path). The `buildSummary` code that reads this metadata was only wired to the legacy `/ai/transsumm` path, used as a fallback.

The data was never gone: it is in the `/file/detail/{id}` response the plugin already fetches, just relocated into `content_list[].extra` (`summ_type`, `summary_id`, `used_template.template_name`) and `extra_data` (`model`, `aiContentHeader.headline`/`category`). Confirmed by a live capture from web.plaud.ai on 2026-07-09.

## Fix
- **`findSummaryMetadata(raw, endpoint)`** — a scoped, by-name resolver. Each field is found by key name within a scoped subtree, with an ordered accept-list, so a future relocation is a one-line key-list edit rather than silent data loss. `template` prefers the readable `used_template.template_name` ("Adaptive Summary") over the `summ_type` code ("AI-CHOICE").
- Fields documented to sit directly on their subtree resolve **direct-only** (`maxDepth 0`) so a generic key like `category` cannot bleed into a nested unrelated one (e.g. a per-question `category`). Only `template` searches deep to reach `used_template.template_name`. The resolver is depth-bounded and cycle-guarded.
- **Drift diagnostic:** when a summary is present but the known metadata is unresolved, a debug log names the missing fields, so the next Plaud shape change is diagnosable instead of silent (`language` is excluded from the checklist since Plaud legitimately omits it).
- **Golden-fixture regression test** whose structure is verbatim from the live capture (values synthetic/redacted). If Plaud moves a field again, the failing assertion names it.

## Verification
- `npm run build` clean, `npm run lint` clean (+ submission and icon pre-checks), `npm test` 990/990.
- Codex pre-commit review run; both findings (category deep-bleed, noisy language diagnostic) addressed, the first with a dedicated regression test.
- Not yet hands-on validated in Obsidian against a live import.