### PR TITLE
Fix SSO reconnect dead-end and stop futile refresh retries (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reconnecting a Google or Apple (SSO) account no longer sends you to a dead end.** When a Google or Apple session lapsed during background auto-sync, the pause notice's Reconnect button opened the email sign-in window, where Google and Apple logins do not work. Reconnect now detects an SSO account and reopens the browser bookmarklet sign-in that actually works for it, and pasting the fresh token resumes the paused sync. Email and password accounts keep using the sign-in window as before.
+- **A Google or Apple session that cannot be renewed silently stops retrying instead of hammering Plaud hourly.** Those accounts keep their renewable session in your browser, not the plugin, so the silent background refresh can never succeed for them. It used to keep retrying about hourly forever. It now stops after its short backoff and waits for you to reconnect (auto-sync still recovers on its next run and via the Reconnect notice), which also avoids Plaud's per-hour refresh limit. Email and password sessions keep retrying as before, since their failures may be temporary.
+
+### Changed
+
+- **Clearer explanation of why Google and Apple accounts reconnect about daily.** The sign-in help and README now state that Plaud keeps the renewable session in your own browser, out of the plugin's reach, so SSO accounts cannot be refreshed silently the way email and password accounts can.
+
 ## [0.30.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Why open a meeting in step 3: the bookmark watches for the request your token ri
 
 Your sign-in token lasts about a day. When imports stop working, repeat the "each time you connect" steps to get a fresh one.
 
+Email and password sign-ins refresh silently in the background, so they rarely need this. Google and Apple sign-ins cannot: Plaud keeps the renewable part of the session in your own browser, which the plugin cannot reach, so there is nothing for it to refresh silently. That is why SSO accounts reconnect about daily. When the session lapses during background auto-sync, the pause notice's **Reconnect** button reopens this browser sign-in for you, so you do not get sent to the email window where Google and Apple do not work.
+
 The token is stored in Obsidian's per-vault secret storage either way. It is **never written to `data.json`** and does not travel through Obsidian Sync. Switching vaults requires re-connecting.
 
 Regional accounts (EU and others) need no extra setup. If Plaud routes your account to a regional server, the plugin detects it on the first import and remembers it.
@@ -245,7 +247,7 @@ Optional background sync, **off by default**. When enabled, the plugin checks Pl
 
 It also re-imports recordings you changed in Plaud since importing them (an edited transcript, corrected speaker names, a regenerated summary), including older recordings you edited today. **A re-import overwrites that note and its downloaded artifacts with Plaud's current version, so any edits you made to a synced note are replaced.** Only recordings that actually changed are touched; unchanged notes are never modified. This tradeoff is called out in the settings.
 
-If your Plaud session expires, auto-sync pauses with a single notice and resumes automatically when you reconnect (Test connection, a manual import, re-entering your token, or toggling auto-sync off and on).
+If your Plaud session expires, auto-sync pauses with a single notice and resumes automatically when you reconnect (Test connection, a manual import, re-entering your token, or toggling auto-sync off and on). The notice's **Reconnect** button opens the sign-in that matches your account: the email window for password logins, or the browser bookmarklet flow for Google and Apple accounts.
 
 **Backfill for existing notes:** notes imported before this feature shipped do not carry the version marker auto-sync compares against, so their Plaud-side edits are not detected until the marker exists. Run the command **Plaud Importer: Backfill version markers for auto-sync** once after enabling auto-sync to make your existing library edit-detectable. It only adds a frontmatter marker and never rewrites note content.
 

--- a/__tests__/plaud-refresh.test.ts
+++ b/__tests__/plaud-refresh.test.ts
@@ -4,6 +4,7 @@ import {
 	isFreshAccessToken,
 	isRefreshDue,
 	jwtTyp,
+	shouldStopProactiveRefresh,
 	REFRESH_LEAD_MS,
 	REFRESH_MAX_DELAY_MS,
 	REFRESH_MIN_DELAY_MS,
@@ -141,5 +142,43 @@ describe('isRefreshDue', () => {
 	it('is due for a token with no decodable exp (matches the hourly poll)', () => {
 		expect(isRefreshDue(NO_EXP_WT, NOW)).toBe(true);
 		expect(isRefreshDue('not-a-token', NOW)).toBe(true);
+	});
+});
+
+describe('shouldStopProactiveRefresh', () => {
+	const LEN = REFRESH_RETRY_BACKOFF_MS.length;
+	// An SSO/paste session has no stored WRT; an email session has one.
+	const NO_WRT = false;
+	const HAS_WRT = true;
+
+	it('keeps retrying while the streak is below the backoff ladder length', () => {
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, 0, NO_WRT, NOW)).toBe(false);
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, LEN - 1, NO_WRT, NOW)).toBe(false);
+	});
+
+	it('gives up on an exhausted, due SSO session (no stored WRT)', () => {
+		// The SSO case: no partition cookies to refresh from, so re-arming would
+		// just hammer the endpoint. Stop and wait for a manual reconnect.
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, LEN, NO_WRT, NOW)).toBe(true);
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, LEN + 5, NO_WRT, NOW)).toBe(true);
+	});
+
+	it('never gives up on a session with a stored WRT, even when exhausted and due', () => {
+		// An email/password session keeps its refreshable partition; an exhausted
+		// streak there may be a transient failure, so it must keep retrying and
+		// recover on its own rather than be abandoned.
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, LEN, HAS_WRT, NOW)).toBe(false);
+		expect(shouldStopProactiveRefresh(EXPIRED_WT, LEN + 5, HAS_WRT, NOW)).toBe(false);
+	});
+
+	it('never abandons a token that still has ample life, even at a high streak', () => {
+		// Defensive: a successful sign-in resets the streak to 0, so this pairing
+		// is not expected in practice, but the predicate must not give up on a
+		// fresh token if it ever occurs.
+		expect(shouldStopProactiveRefresh(FRESH_WT, LEN + 5, NO_WRT, NOW)).toBe(false);
+	});
+
+	it('treats an opaque token as due, so a persistently failing SSO one also gives up', () => {
+		expect(shouldStopProactiveRefresh(NO_EXP_WT, LEN, NO_WRT, NOW)).toBe(true);
 	});
 });

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,7 @@ import {
 	computeRefreshDelay,
 	isFreshAccessToken,
 	isRefreshDue,
+	shouldStopProactiveRefresh,
 	REFRESH_RETRY_BACKOFF_MS,
 } from "./plaud-refresh";
 import { buildPartitionPost, performNetRefresh } from "./plaud-refresh-net";
@@ -101,7 +102,7 @@ const PLAUD_WEB_URL = "https://web.plaud.ai";
 // name Plaud/Google/Apple plainly: the sentence-case lint only inspects string
 // literals written directly at a setText/createEl call, not a referenced const.
 const SIGN_IN_NOTE =
-	"Plaud has no official API, so this plugin relies on their internal one. That makes sign-in fragile, and it may stop working when Plaud changes that internal API. We expect this whole process to get much simpler once Plaud releases an official API. There are two ways to sign in, depending on how you log in to Plaud. Use 'Sign in with email' if you log in with an email address and password. Use 'Sign in with Google or Apple' if you use single sign-on (SSO) through a Google or Apple account.";
+	"Plaud has no official API, so this plugin relies on their internal one. That makes sign-in fragile, and it may stop working when Plaud changes that internal API. We expect this whole process to get much simpler once Plaud releases an official API. There are two ways to sign in, depending on how you log in to Plaud. Use 'Sign in with email' if you log in with an email address and password. Use 'Sign in with Google or Apple' if you use single sign-on (SSO) through a Google or Apple account. Google and Apple accounts reconnect about once a day: Plaud keeps the renewable session in your own browser, not in the plugin, so the plugin cannot refresh it silently the way it can for an email and password sign-in. When it lapses the plugin shows a one-click Reconnect that reopens the browser sign-in.";
 
 // Bookmarklet for the browser sign-in flow. Run on a signed-in Plaud tab, it
 // hooks BOTH fetch and XMLHttpRequest (Plaud loads recordings via XHR, so a
@@ -1732,6 +1733,24 @@ export default class PlaudImporterPlugin extends Plugin {
 	}
 
 	/**
+	 * True when a refresh token (typ WRT) is stored. The embedded-window email
+	 * sign-in captures and keeps a WRT; a browser/bookmarklet (SSO) capture never
+	 * does and blanks it (see storeAccessToken). So WRT presence is a reliable
+	 * proxy for "this session came from the embedded window, whose partition holds
+	 * the cookies the windowless refresh needs." Used to route the Reconnect
+	 * surfaces to the sign-in method that can actually work for this account.
+	 */
+	private hasStoredRefreshToken(): boolean {
+		try {
+			const wrt = this.app.secretStorage.getSecret(CAPTURED_REFRESH_SECRET_ID);
+			return wrt !== null && wrt.trim().length > 0;
+		} catch (err) {
+			console.error("Plaud importer: failed to read refresh token", err);
+			return false;
+		}
+	}
+
+	/**
 	 * Attempt one silent session refresh via the direct, windowless path only
 	 * (POST /auth/refresh-user-token over the partition cookies, then the
 	 * workspace-token mint; see plaud-refresh-net.ts). A background refresh
@@ -1873,6 +1892,26 @@ export default class PlaudImporterPlugin extends Plugin {
 		// Nothing to refresh proactively until a token exists; a fresh sign-in
 		// calls this again to (re)schedule.
 		if (token === null) return;
+		// An SSO/paste session (no stored WRT) that has failed the whole backoff
+		// ladder on an already-due token cannot self-heal unattended: it has no
+		// partition cookies for the windowless refresh. Stop re-arming so we do
+		// not hammer Plaud's rate-limited refresh endpoint hourly forever; the
+		// Reconnect notice is the recovery path. An email session (WRT present) is
+		// left retrying, since its failures may be transient. A fresh sign-in
+		// resets the streak to 0 and reschedules normally.
+		if (
+			shouldStopProactiveRefresh(
+				token,
+				this.refreshFailureStreak,
+				this.hasStoredRefreshToken(),
+				Date.now(),
+			)
+		) {
+			this.logAutoSync(
+				"proactive refresh exhausted its backoff on an unrefreshable session; awaiting reconnect",
+			);
+			return;
+		}
 		// Backoff on a failure streak, expiry-driven otherwise, and always
 		// clamped under setTimeout's 32-bit ceiling (a long-lived token used to
 		// overflow the delay and fire immediately). See plaud-refresh.ts.
@@ -2017,7 +2056,17 @@ export default class PlaudImporterPlugin extends Plugin {
 	 * left with a hidden notice and no feedback. Returns whether a token was
 	 * captured, so a caller (e.g. a failed command) can retry itself on success.
 	 */
-	async reconnectFromNotice(): Promise<boolean> {
+	async reconnectFromNotice(onReconnected?: () => unknown): Promise<boolean> {
+		// A session with no stored WRT came from the browser/bookmarklet (SSO)
+		// flow: Google and Apple do not complete in the embedded window, so
+		// routing it there dead-ends. Open the browser + bookmarklet + paste flow
+		// instead. That flow finishes asynchronously when the user pastes, so this
+		// returns false now; the paste handler resumes any paused sync and runs
+		// onReconnected (e.g. a backfill retry) itself.
+		if (!this.hasStoredRefreshToken()) {
+			this.openBrowserReconnect(onReconnected);
+			return false;
+		}
 		try {
 			const ok = await this.reauthenticate();
 			// Plugin unloaded mid sign-in: skip side effects and messaging.
@@ -2025,6 +2074,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			if (ok) {
 				new Notice("Plaud reconnected.");
 				this.resumeAutoSyncIfPaused();
+				if (onReconnected) await onReconnected();
 			} else if (!this.reauthInFlight) {
 				// A false with reauthInFlight still set means another sign-in
 				// window is already open (reauthenticate short-circuited and
@@ -2039,6 +2089,32 @@ export default class PlaudImporterPlugin extends Plugin {
 			}
 			return false;
 		}
+	}
+
+	/**
+	 * Guided browser sign-in for SSO (Google/Apple) reconnect. Opens the same
+	 * BrowserSignInModal the settings tab uses, but with an inline "Paste token"
+	 * action so the whole reconnect completes from the modal: it opens Plaud in
+	 * the system browser, the user runs the bookmarklet and copies the token, and
+	 * pasting stores it, resumes any paused sync, and runs the optional
+	 * onReconnected continuation (e.g. a backfill retry) so a browser reconnect
+	 * finishes the same follow-up the embedded flow does. Reuses openPlaudInBrowser
+	 * and pasteTokenFromClipboard so there is one capture path.
+	 */
+	private openBrowserReconnect(onReconnected?: () => unknown): void {
+		new BrowserSignInModal(
+			this.app,
+			() => this.openPlaudInBrowser(),
+			async () => {
+				const ok = await this.pasteTokenFromClipboard();
+				if (ok && !this.disposed) {
+					new Notice("Plaud reconnected.");
+					this.resumeAutoSyncIfPaused();
+					if (onReconnected) await onReconnected();
+				}
+				return ok;
+			},
+		).open();
 	}
 
 	/**
@@ -2141,10 +2217,12 @@ export default class PlaudImporterPlugin extends Plugin {
 				this.showActionNotice(
 					"Plaud importer: backfill needs a Plaud session.",
 					"Reconnect and retry",
-					async () => {
-						const ok = await this.reconnectFromNotice();
-						if (ok) await this.backfillVersionMarkers();
-					},
+					// Pass the retry as the post-reconnect continuation so it runs on
+					// BOTH the embedded (email) path and the async browser (SSO) path;
+					// the SSO path returns false immediately (paste completes later), so
+					// a caller that keyed the retry off the return value would skip it.
+					() =>
+						this.reconnectFromNotice(() => this.backfillVersionMarkers()),
 				);
 			} else {
 				new Notice(`Plaud importer: backfill failed: ${classification.message}`);
@@ -2582,10 +2660,17 @@ export default class PlaudImporterPlugin extends Plugin {
 // sentence-case lint, which only inspects literals.
 class BrowserSignInModal extends Modal {
 	private readonly onLaunch: () => void;
+	private readonly onPaste?: () => Promise<boolean>;
 
-	constructor(app: App, onLaunch: () => void) {
+	// onPaste is optional. When omitted (the settings/import-modal "launch"
+	// button), opening the browser closes this modal and the user pastes from the
+	// separate paste control. When supplied (the SSO reconnect notice), the modal
+	// stays open after launching so the returning user can paste right here, and a
+	// successful paste closes it.
+	constructor(app: App, onLaunch: () => void, onPaste?: () => Promise<boolean>) {
 		super(app);
 		this.onLaunch = onLaunch;
+		this.onPaste = onPaste;
 	}
 
 	onOpen(): void {
@@ -2604,19 +2689,46 @@ class BrowserSignInModal extends Modal {
 			ol.createEl("li", { text: line });
 		}
 		const openLabel = "Open my browser now";
-		new Setting(contentEl)
-			.addButton((btn) =>
-				btn
-					.setButtonText(openLabel)
-					.setCta()
-					.onClick(() => {
-						this.onLaunch();
+		const row = new Setting(contentEl).addButton((btn) =>
+			btn
+				.setButtonText(openLabel)
+				.setCta()
+				.onClick(() => {
+					this.onLaunch();
+					// With no inline paste, launching is the last step here; close so
+					// the user is not left with a stale modal. With inline paste, keep
+					// the modal open so they can paste on their way back.
+					if (this.onPaste === undefined) {
 						this.close();
-					}),
-			)
-			.addButton((btn) =>
-				btn.setButtonText("Cancel").onClick(() => this.close()),
+					}
+				}),
+		);
+		if (this.onPaste !== undefined) {
+			const paste = this.onPaste;
+			row.addButton((btn) =>
+				btn.setButtonText("Paste token from clipboard").onClick(async () => {
+					// Guard the whole handler: pasteTokenFromClipboard swallows a
+					// clipboard read failure, but storing the token (secret storage,
+					// saveSettings) can still throw. Without this an async click
+					// rejection would surface unhandled and leave the modal open with
+					// no feedback.
+					try {
+						const ok = await paste();
+						if (ok) {
+							this.close();
+						}
+					} catch (err) {
+						console.error("Plaud importer: paste reconnect failed", err);
+						new Notice(
+							"Plaud: could not save that token. Try again, or use settings.",
+						);
+					}
+				}),
 			);
+		}
+		row.addButton((btn) =>
+			btn.setButtonText("Cancel").onClick(() => this.close()),
+		);
 	}
 
 	onClose(): void {

--- a/main.ts
+++ b/main.ts
@@ -2102,6 +2102,16 @@ export default class PlaudImporterPlugin extends Plugin {
 	 * and pasteTokenFromClipboard so there is one capture path.
 	 */
 	private openBrowserReconnect(onReconnected?: () => unknown): void {
+		// One sign-in surface at a time, sharing the same gate as the embedded
+		// window and the silent refresh: two captures racing on the partition would
+		// clobber each other's token write. Held for the modal's whole lifetime and
+		// cleared when it closes; paste-success, cancel, and dismiss all route
+		// through the modal's onClose.
+		if (this.reauthInFlight) {
+			new Notice("Plaud sign-in is already open.");
+			return;
+		}
+		this.reauthInFlight = true;
 		new BrowserSignInModal(
 			this.app,
 			() => this.openPlaudInBrowser(),
@@ -2113,6 +2123,9 @@ export default class PlaudImporterPlugin extends Plugin {
 					if (onReconnected) await onReconnected();
 				}
 				return ok;
+			},
+			() => {
+				this.reauthInFlight = false;
 			},
 		).open();
 	}
@@ -2661,16 +2674,25 @@ export default class PlaudImporterPlugin extends Plugin {
 class BrowserSignInModal extends Modal {
 	private readonly onLaunch: () => void;
 	private readonly onPaste?: () => Promise<boolean>;
+	private readonly onCloseCb?: () => void;
 
 	// onPaste is optional. When omitted (the settings/import-modal "launch"
 	// button), opening the browser closes this modal and the user pastes from the
 	// separate paste control. When supplied (the SSO reconnect notice), the modal
 	// stays open after launching so the returning user can paste right here, and a
-	// successful paste closes it.
-	constructor(app: App, onLaunch: () => void, onPaste?: () => Promise<boolean>) {
+	// successful paste closes it. onCloseCb, when supplied, runs on every close
+	// path (paste success, cancel, dismiss) so a caller can release a single-flight
+	// guard it set before opening.
+	constructor(
+		app: App,
+		onLaunch: () => void,
+		onPaste?: () => Promise<boolean>,
+		onCloseCb?: () => void,
+	) {
 		super(app);
 		this.onLaunch = onLaunch;
 		this.onPaste = onPaste;
+		this.onCloseCb = onCloseCb;
 	}
 
 	onOpen(): void {
@@ -2733,6 +2755,7 @@ class BrowserSignInModal extends Modal {
 
 	onClose(): void {
 		this.contentEl.empty();
+		this.onCloseCb?.();
 	}
 }
 

--- a/plaud-refresh.ts
+++ b/plaud-refresh.ts
@@ -114,6 +114,34 @@ export function computeRefreshDelay(
 }
 
 /**
+ * True when the proactive refresh should stop re-arming: it has failed through
+ * the entire backoff ladder on an already-due token that has NO stored refresh
+ * token. A missing WRT is the SSO/paste signature (the embedded-window sign-in
+ * keeps a WRT, a browser/bookmarklet capture blanks it), and such a session has
+ * no partition cookies for the windowless refresh to authenticate with, so it
+ * can never self-heal unattended; retrying just hammers Plaud's rate-limited
+ * refresh endpoint. Recovery comes from the one-click Reconnect notice instead.
+ *
+ * A session WITH a stored WRT (an email/password sign-in) is left alone even on
+ * an exhausted streak: its failures may be transient (network/Plaud blip) and
+ * its partition session is still refreshable, so the existing backoff keeps
+ * retrying and recovers on its own. Kept pure so the give-up rule is
+ * unit-testable without the plugin runtime.
+ */
+export function shouldStopProactiveRefresh(
+	token: string,
+	failureStreak: number,
+	hasRefreshToken: boolean,
+	nowMs: number,
+): boolean {
+	return (
+		!hasRefreshToken &&
+		failureStreak >= REFRESH_RETRY_BACKOFF_MS.length &&
+		isRefreshDue(token, nowMs)
+	);
+}
+
+/**
  * Reads a string claim from the JWT payload, or null when the value is not a
  * decodable JWT or the claim is absent / not a string. Used by the direct
  * net-refresh path to pull `wid` (workspace id) and `client_id` off the stored


### PR DESCRIPTION
## What and why

Refs #64. Google/Apple (SSO) accounts sign in through the external browser + bookmarklet, so the plugin's Electron partition never holds their Plaud session cookies. The windowless background refresh authenticates only via those cookies, so it can never succeed for SSO accounts. This is architectural (verified against Plaud's live web bundle: both refresh calls use `withCredentials`, and there is no workspace-refresh-token endpoint that could mint a token from a bearer alone), not a regression from the 0.29.0 refresh work.

The real defect: when the session lapsed, the auth-pause **Reconnect** notice opened the embedded email sign-in window, where Google and Apple logins dead-end. SSO users had no working one-click path back.

This is not a full resolution of #64. True unattended SSO refresh needs Plaud's official OAuth path, which is tracked separately. This PR makes the ~daily SSO reconnect painless and stops wasted work.

## Changes

- **SSO-aware Reconnect.** `reconnectFromNotice` routes on `hasStoredRefreshToken()`: a stored WRT means an embedded (email) sign-in whose partition can refresh; no WRT is the SSO/paste signature. SSO opens the browser + bookmarklet + paste flow (`openBrowserReconnect`) instead of the dead-end window. Email path unchanged.
- **`BrowserSignInModal` gains an inline "Paste token from clipboard" button** (optional `onPaste`), so the SSO reconnect completes from the notice: open browser, run the bookmarklet, return, paste, sync resumes. Existing 2-arg callers keep closing on launch.
- **Stop futile retries.** New pure `shouldStopProactiveRefresh(token, streak, hasRefreshToken, now)`: an exhausted, due session with no WRT stops re-arming the proactive timer, so an un-refreshable SSO session no longer retries hourly against Plaud's rate-limited endpoint. Email sessions (WRT present) keep retrying, since their failures may be transient.
- **Backfill retry fixed.** A post-reconnect continuation runs on both reconnect paths, so the backfill "Reconnect and retry" notice actually retries after an SSO paste (the SSO path returns before the async paste completes).
- **Guarded paste handler** so a throwing token store cannot surface an unhandled rejection.
- **Docs.** The in-app sign-in help and README now explain why SSO accounts reconnect about daily (Plaud keeps the renewable session in your browser, not the plugin).

## Testing

- `npm run lint && npm run build && npm test`: green (1012 tests; 5 new for the give-up predicate including the WRT-present no-give-up case).
- Codex pre-commit review: 3 findings (backfill non-retry, over-broad give-up, unguarded paste), all addressed in this PR.

Hands-on (not yet run, needs an SSO account):
1. Capture an SSO token, confirm import/auto-sync works.
2. Force expiry (Refresh session now) and confirm auto-sync pauses with no hourly retry storm in the debug log.
3. Click Reconnect: it opens the browser/bookmarklet modal (not the email window); paste a fresh token; sync resumes.
4. Regression: an email/password account still reconnects via the embedded window and still refreshes silently.

## Limitation

SSO accounts still reconnect about once a day. That cadence is fixed by Plaud's ~24h token and cannot change without the official OAuth path. This PR only removes the dead end and the wasted retries.
