### PR TITLE
Fix email sign-in popup leak: deny handler must return synchronously over the remote bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Email sign-in no longer also opens plaud.ai in your web browser.** The in-app sign-in window is meant to block the popups Plaud's web page fires while it loads, but the block was silently broken, so those popups escaped to your default browser as stray tabs. The block now actually holds: clicking Sign in with email opens only the in-app window. The Google and Apple sign-in flow still opens your browser, which is intentional.
+
 ## [0.30.1] - 2026-07-10
 
 ### Fixed

--- a/plaud-login.ts
+++ b/plaud-login.ts
@@ -219,6 +219,11 @@ interface BrowserWindowConstructor {
 interface ElectronRemoteLike {
 	session?: { fromPartition(partition: string): SessionLike };
 	BrowserWindow?: BrowserWindowConstructor;
+	// Wraps a constant so a main-process API sees it as a function whose return
+	// value is available SYNCHRONOUSLY. A plain renderer callback crosses the
+	// remote bridge asynchronously, so its return value never reaches the
+	// main-process caller.
+	createFunctionWithReturnValue?<T>(this: void, returnValue: T): () => T;
 }
 interface ElectronLike {
 	remote?: ElectronRemoteLike;
@@ -317,7 +322,8 @@ class PlaudLoginSession {
 		// authenticated request the web app makes is recorded automatically.
 		this.armSessionCapture();
 
-		const BrowserWindow = requireElectron()?.remote?.BrowserWindow;
+		const remote = requireElectron()?.remote;
+		const BrowserWindow = remote?.BrowserWindow;
 		if (BrowserWindow === undefined) {
 			this.note('BrowserWindow unavailable; sign-in window cannot open', 'error');
 			this.settle(null);
@@ -347,7 +353,21 @@ class PlaudLoginSession {
 		const contents = this.win.webContents;
 		if (typeof contents.setWindowOpenHandler === 'function') {
 			try {
-				contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+				// The deny must reach Electron SYNCHRONOUSLY in the main process. A
+				// plain renderer callback crosses the remote bridge asynchronously,
+				// so its return value is lost and every popup escapes to the system
+				// browser (the stray-tab defect). createFunctionWithReturnValue
+				// serializes the constant deny into the main process; the plain
+				// callback remains only as a last resort on builds without it.
+				const makeSyncReturn = remote?.createFunctionWithReturnValue;
+				if (typeof makeSyncReturn === 'function') {
+					contents.setWindowOpenHandler(
+						makeSyncReturn({ action: 'deny' as const }),
+					);
+				} else {
+					this.note('createFunctionWithReturnValue unavailable; popup deny may not hold', 'error');
+					contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+				}
 			} catch (err) {
 				this.note(`could not install window-open handler: ${String(err)}`, 'error');
 			}


### PR DESCRIPTION
## Symptom

Clicking Sign in with email opened the in-app sign-in window (correct) and ALSO opened plaud.ai in the system browser (wrong). Only the Google/Apple SSO flow is supposed to open the system browser.

## Root cause

The sign-in BrowserWindow installs `setWindowOpenHandler(() => ({action: 'deny'}))` to suppress the popups Plaud's web page fires on load. That `webContents` is an `@electron/remote` proxy, and remote transports ordinary callbacks asynchronously, so the synchronous `{action: 'deny'}` return value never reached Electron's main process. Every popup escaped to the system browser as a stray tab.

Latent since 2d34f5a (silent session refresh); masked for a while when c5c87b6 stopped the background refresh from loading the page in a hidden window.

## Fix

Wrap the deny in `remote.createFunctionWithReturnValue({action: 'deny'})`, the remote API that serializes a constant synchronous return value into the main process. The plain callback stays only as a last-resort fallback (with an error note) on builds lacking that API, so email sign-in still opens everywhere. The SSO path (`BrowserSignInModal` -> `openPlaudInBrowser`) is untouched.

## Validation

- Lint (scorecard ruleset + submission pre-check), build, and all 1012 tests green locally.
- Codex pre-commit review: clean, API usage verified against the @electron/remote source.