### PR TITLE
Keep email sign-in navigation in-window: strip the host's will-navigate reroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Email sign-in truly no longer opens plaud.ai in your web browser.** The 0.30.2 fix hardened the popup blocker, but the real leak turned out to be different: Obsidian 1.13 (which auto-installed in late June) began rerouting every page navigation inside plugin windows to your default browser, so when Plaud's site redirected itself to its login page, that redirect landed in your browser as a stray tab. The sign-in window now keeps its navigation to itself. Verified end to end against Obsidian 1.13.2: the login redirect stays inside the in-app window and nothing opens externally. If the plugin ever cannot apply this protection, it refuses to open the sign-in window rather than leak sign-in URLs to your browser.
+
 ## [0.30.2] - 2026-07-17
 
 ### Fixed

--- a/plaud-login.ts
+++ b/plaud-login.ts
@@ -190,6 +190,11 @@ interface SessionLike {
 }
 interface WebContentsLike {
 	executeJavaScript(code: string): Promise<unknown>;
+	// EventEmitter surface, forwarded synchronously to the real main-process
+	// webContents by the remote proxy. Used to strip the host's will-navigate
+	// listener from this plugin-owned window (see start()).
+	listenerCount?(eventName: string): number;
+	removeAllListeners?(eventName: string): unknown;
 	// Deny/allow popups and new windows the loaded page requests. Present on real
 	// Electron builds; guarded at the call site. We deny all: the sign-in only
 	// needs the main frame's own API call, never a popup, and the Plaud web app
@@ -346,11 +351,45 @@ class PlaudLoginSession {
 			return;
 		}
 
+		const contents = this.win.webContents;
+
+		// Obsidian 1.13+ attaches a main-process will-navigate listener to every
+		// top-level window. It cancels any navigation off Obsidian's own app://
+		// origin and reroutes the URL to shell.openExternal, so Plaud's own login
+		// redirect (web.plaud.ai -> /login) opened as a stray tab in the user's
+		// default browser. Strip that listener from THIS window only; the page
+		// then navigates in-window like a normal browser window. Safe to call on
+		// older Obsidian builds without the listener (count is simply 0). Remote
+		// method calls execute synchronously in the main process, and the
+		// listener is attached during the BrowserWindow constructor
+		// (web-contents-created), so this cannot race the attach. Verified live
+		// against Obsidian 1.13.2 on 2026-07-17: with the listener a page
+		// navigation logs "Opening URL:" in the main process and opens the
+		// default browser; with it removed the same navigation stays in-window.
+		try {
+			if (typeof contents.removeAllListeners !== 'function') {
+				throw new Error('webContents.removeAllListeners unavailable');
+			}
+			const before = contents.listenerCount?.('will-navigate') ?? null;
+			contents.removeAllListeners('will-navigate');
+			const after = contents.listenerCount?.('will-navigate') ?? null;
+			this.note('host navigation guard removed', 'note', { before, after });
+			if (after !== null && after !== 0) {
+				throw new Error(`removal incomplete, ${String(after)} listener(s) remain`);
+			}
+		} catch (err) {
+			this.note(`could not remove host navigation guard: ${String(err)}`, 'error');
+			// Fail closed: loading the page with the guard attached would spray
+			// sign-in URLs into the user's default browser. settle() closes the
+			// window.
+			this.settle(null);
+			return;
+		}
+
 		// Deny every popup / new window the page requests, BEFORE loading it. The
 		// Plaud web app fires window.open on load (feedback widget, analytics, an
-		// auth-redirect popup); Obsidian routes those to the system browser, which
-		// spawned stray tabs. We only need the main frame's own API call.
-		const contents = this.win.webContents;
+		// auth-redirect popup); without a deny handler the host routes those to
+		// the system browser. We only need the main frame's own API call.
 		if (typeof contents.setWindowOpenHandler === 'function') {
 			try {
 				// The deny must reach Electron SYNCHRONOUSLY in the main process. A
@@ -397,6 +436,14 @@ class PlaudLoginSession {
 				return;
 			}
 			const contents = this.win.webContents;
+			// Re-strip the host's navigation guard as defense in depth. Nothing
+			// re-attaches it on 1.13 (isSecured guard in the host), but a 1s no-op
+			// is cheap insurance against future host changes.
+			try {
+				contents.removeAllListeners?.('will-navigate');
+			} catch {
+				// Window mid-teardown; the 'closed' handler settles the session.
+			}
 			// Keep the in-page hook installed as a fallback to the session-level
 			// capture. Idempotent; a full navigation wipes the patched fetch.
 			try {


### PR DESCRIPTION
## Symptom (regression of the stray-tab class, reported on 0.30.2)

Email sign-in opens the in-app window AND plaud.ai opens in the system browser. The 0.30.2 popup fix did not resolve it.

## Root cause (empirically proven)

Obsidian 1.13 attaches a main-process `will-navigate` listener to every top-level window: any navigation off Obsidian's own `app://` origin is cancelled and rerouted to `shell.openExternal`. Plaud's web app redirects itself to `/login` on load; that page-initiated navigation was shipped to the default browser. Version bisect over Obsidian release bundles: listener absent through 1.12.7, present in 1.13.x. This machine updated 1.11.7 -> 1.13.1 on 2026-06-22, which is when the leak started. No plugin change caused it; no prior fix (popup deny, hidden-window removal) addressed the navigation path.

## Fix

Strip the listener from the plugin-owned sign-in window immediately after construction. Remote method calls execute synchronously in the main process and the listener attaches during the BrowserWindow constructor, so the removal cannot race. Re-strip on each poll tick as defense in depth. Fail closed (settle null, window closed) if removal is unavailable or incomplete, with listener counts logged. Scope is this window only; Obsidian's policy on its own windows is untouched, and the popup deny handler stays.

## Verification (live, CDP-driven against Obsidian 1.13.2)

- Control: with the listener attached, a page navigation produced `Opening URL: https://web.plaud.ai/login...` in Obsidian's main-process stdout and opened the default browser.
- Treatment: after removal (count 1 -> 0), the same navigation stayed in-window.
- Full E2E with the built plugin: sign-in opens, page redirects in-window to `web.plaud.ai/login`, listener count 0, zero new `Opening URL:` lines, no external browser.
- Lint, build, 1012 tests green. Codex pre-commit review clean.