### PR TITLE
Dismiss the auth-pause prompt when the session recovers (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ### Fixed
 
-- **The "session expired" prompt now goes away once your session is working again.** When background sync ran into an expired session it paused itself and showed a reconnect prompt. That prompt deliberately has no timeout, so it cannot disappear before you read it, but nothing ever took it back down. If the session recovered on its own, which is easiest to hit when Obsidian wakes from sleep and a background renewal finishes just after a sync attempt already failed, imports carried on normally while the prompt sat there asking you to reconnect a session that was already fine. Every path that clears the pause now clears the prompt with it (issue #88).
+- **The "session expired" prompt now goes away once your session is working again.** When background sync ran into an expired session it paused itself and showed a reconnect prompt. That prompt deliberately has no timeout, so it cannot disappear before you read it, but nothing ever took it back down. If the session recovered on its own, which is easiest to hit when Obsidian wakes from sleep and a background renewal finishes just after a sync attempt already failed, imports carried on normally while the prompt sat there asking you to reconnect a session that was already fine. Every path that clears the pause now clears the prompt with it, and the prompt is no longer raised at all if the plugin is shutting down while a background check is still finishing (issue #88).
 
 ## [0.36.0] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Plaud Importer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "session expired" prompt now goes away once your session is working again.** When background sync ran into an expired session it paused itself and showed a reconnect prompt. That prompt deliberately has no timeout, so it cannot disappear before you read it, but nothing ever took it back down. If the session recovered on its own, which is easiest to hit when Obsidian wakes from sleep and a background renewal finishes just after a sync attempt already failed, imports carried on normally while the prompt sat there asking you to reconnect a session that was already fine. Every path that clears the pause now clears the prompt with it (issue #88).
+
 ## [0.36.0] - 2026-07-26
 
 ### Added

--- a/main.ts
+++ b/main.ts
@@ -735,6 +735,13 @@ export default class PlaudImporterPlugin extends Plugin {
 	// reconnect, and the later expiry warning would stack a second prompt on
 	// top of it. Cleared wherever sessionExpiryNotice is.
 	private sessionRefreshFailureNotice: Notice | null = null;
+	// The auto-sync auth-pause "Reconnect" prompt, held for the same reason as
+	// the two notices above (issue #88). It also has no duration, and a paused
+	// session can now heal with NO user action: a background refresh finishing
+	// after a tick already paused. Without a handle nothing can take the prompt
+	// down, so it outlives the pause it describes and invites a reconnect the
+	// plugin no longer needs. Cleared by clearAutoSyncPauseNotice().
+	private autoSyncPauseNotice: Notice | null = null;
 	/**
 	 * True when unattended renewal has stopped for the current credential and
 	 * will not resume without a reconnect. Read by the settings tab so its
@@ -1081,6 +1088,7 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 		this.actionNotices.clear();
 		this.sessionExpiryNotice = null;
+		this.autoSyncPauseNotice = null;
 		// Obsidian auto-detaches ribbon icons on unload; clear our
 		// state so a subsequent onload starts from a known baseline.
 		this.ribbonIconEl = null;
@@ -2309,8 +2317,16 @@ export default class PlaudImporterPlugin extends Plugin {
 					classification.category === "not-configured"
 						? "Plaud auto-sync paused: no Plaud token is configured."
 						: "Plaud auto-sync paused: your session expired.";
-				this.showActionNotice(lead, "Reconnect", () =>
-					this.reconnectFromNotice(),
+				// Held so a session that heals itself can take this down (issue
+				// #88). Clearing first keeps the field the single owner of
+				// whatever is on screen: a tick short-circuits while paused, so
+				// today there is nothing to replace, but that is the tick
+				// guard's property rather than this call site's.
+				this.clearAutoSyncPauseNotice();
+				this.autoSyncPauseNotice = this.showActionNotice(
+					lead,
+					"Reconnect",
+					() => this.reconnectFromNotice(),
 				);
 			}
 			this.logAutoSync("tick failed", {
@@ -2355,8 +2371,27 @@ export default class PlaudImporterPlugin extends Plugin {
 		this.logAutoSync("auto-sync scheduled", { minutes });
 	}
 
+	/**
+	 * Take down the auth-pause "Reconnect" prompt if one is on screen (issue
+	 * #88). Same three steps reconcileSessionExpiryWarning() uses for the expiry
+	 * and renewal-failure notices: hide it, drop it from the onunload sweep set
+	 * so dismissed notices do not accumulate there, and null the handle.
+	 */
+	private clearAutoSyncPauseNotice(): void {
+		if (this.autoSyncPauseNotice === null) return;
+		this.autoSyncPauseNotice.hide();
+		this.actionNotices.delete(this.autoSyncPauseNotice);
+		this.autoSyncPauseNotice = null;
+	}
+
 	/** Clear an auth pause and run a tick soon. Called on token re-save / test / toggle. */
 	resumeAutoSyncIfPaused(): void {
+		// Above the paused check on purpose. The prompt and the pause state can
+		// come apart: a resume that already ran, or a path that cleared the pause
+		// without coming through here, leaves state un-paused with the prompt
+		// still up. Behind the early return that prompt would be stranded on
+		// screen for the rest of the session.
+		this.clearAutoSyncPauseNotice();
 		if (!this.autoSyncState.paused) return;
 		this.autoSyncState = nextAutoSyncState(this.autoSyncState, "ok");
 		this.logAutoSync("auto-sync resumed after re-auth");

--- a/main.ts
+++ b/main.ts
@@ -2317,17 +2317,26 @@ export default class PlaudImporterPlugin extends Plugin {
 					classification.category === "not-configured"
 						? "Plaud auto-sync paused: no Plaud token is configured."
 						: "Plaud auto-sync paused: your session expired.";
-				// Held so a session that heals itself can take this down (issue
-				// #88). Clearing first keeps the field the single owner of
-				// whatever is on screen: a tick short-circuits while paused, so
-				// today there is nothing to replace, but that is the tick
-				// guard's property rather than this call site's.
-				this.clearAutoSyncPauseNotice();
-				this.autoSyncPauseNotice = this.showActionNotice(
-					lead,
-					"Reconnect",
-					() => this.reconnectFromNotice(),
-				);
+				// Lifecycle re-check AFTER this method's awaits, not just at its
+				// top: onunload hides every sticky action notice and clears the
+				// set, so a duration-0 prompt created after that sweep is
+				// untracked, outlives the plugin, and sits on screen until the
+				// user clicks it away. The log below still runs either way, so an
+				// unload race stays visible in a debug capture.
+				if (!this.disposed) {
+					// Held so a session that heals itself can take this down
+					// (issue #88). Clearing first keeps the field the single
+					// owner of whatever is on screen: a tick short-circuits
+					// while paused, so today there is nothing to replace, but
+					// that is the tick guard's property rather than this call
+					// site's.
+					this.clearAutoSyncPauseNotice();
+					this.autoSyncPauseNotice = this.showActionNotice(
+						lead,
+						"Reconnect",
+						() => this.reconnectFromNotice(),
+					);
+				}
 			}
 			this.logAutoSync("tick failed", {
 				outcome,


### PR DESCRIPTION
Fixes #88.

## The defect

The auto-sync auth-pause notice is created with duration 0 on purpose: an authentication prompt should not vanish before it is read. But its handle was discarded at the call site, so it landed only in `actionNotices`, which exists for the onunload sweep rather than for targeted dismissal. Nothing could take it down.

Since 0.36.0 a paused session can heal with **no user action at all**, when a background renewal finishes just after a tick already paused. The prompt then outlived the pause it described and invited a reconnect the plugin no longer needed.

## The change

Hold the notice in a field, exactly as `sessionExpiryNotice` and `sessionRefreshFailureNotice` already are, and clear it in `resumeAutoSyncIfPaused()`.

The teardown sits **above** that method's already-resumed early return. The prompt and the pause state can come apart (a resume that already ran, or a path that cleared the pause without coming through here), and behind the return a stranded prompt would stay on screen for the rest of the session.

All twelve `resumeAutoSyncIfPaused` call sites funnel through this one method, so every path the issue lists is covered without touching any of them.

## Blast radius

This plugin's auth code has regressed repeatedly when touched, so the scope was constrained up front and the constraint is checkable on the diff rather than on the reasoning:

- `main.ts` only, 37 insertions and 2 deletions.
- No line in the diff mentions `secretStorage`, `saveSettings`, `storeAccessToken`, or `PLAUD_PARTITION`.
- `plaud-login.ts` and `plaud-refresh-net.ts` are untouched, along with the capture probe paths and 0.36.0's renewal.

The four touched locations are a `Notice` field declaration, a discarded return value inside the auto-sync tick's `catch`, a method that only mutates `autoSyncState`, and one line in the unload sweep. None reads a credential.

## Deliberate non-change

Not unified with the two inline teardowns in `reconcileSessionExpiryWarning`. Those two clear together because a credential changed; this one clears because a pause ended. Unifying them would couple unrelated lifecycles and reach into auth-adjacent code outside this PR's scope.

## Verification

**Local gate green:** lint (including `check-submission.mjs` and `check-icons.mjs`), build, 1153 tests across 20 suites.

**Those tests are not evidence this fix works.** `main.ts` has no unit test coverage; no file under `__tests__/` imports it. The suite covers the extracted pure modules (`auto-sync.ts`, `session-expiry.ts`, `plaud-token.ts`, `refresh-schedule.ts`, `reconnect-routing.ts`), none of which this diff touches. So the suite is a regression check on untouched code. Stating this explicitly because 0.35.0 shipped capturing nothing with the whole suite green.

**Live verification: NOT YET DONE.** It needs a signed-in session, so it is recorded here rather than claimed. Steps, in `obs-test-vault` (already configured: `signInMethod: "window"`, auto-sync on at 15 min, debug on):

1. Cause an auto-sync tick to fail with an auth category.
2. Confirm the sticky "Plaud auto-sync paused: your session expired." prompt appears and does not self-dismiss.
3. Run **Debug: refresh the session now**, which mints a fresh credential from the partition cookies and calls `resumeAutoSyncIfPaused()`.
4. **Expected: the prompt disappears** and auto-sync resumes. Before this change it stays up. This is the exact scenario in the issue.
5. Confirm the Reconnect click path still works, and that no prompt survives a plugin reload.

## Review notes

Codex pre-commit was skipped by explicit instruction for this batch, not by oversight. The staged diff was reviewed against all six recurring defect classes from the commit gate; the two that had real work were exit paths (which is what this fixes) and prose drift (README, CHANGELOG, and CONTRIBUTING grepped for pause and reconnect-prompt wording; no stale claims, CHANGELOG entry added in this commit).
