### PR TITLE
Extract the capture store out of main.ts

### DIFF
--- a/__tests__/main-capture-atomicity.test.ts
+++ b/__tests__/main-capture-atomicity.test.ts
@@ -89,6 +89,13 @@ interface Harness {
 	failSave: Error | null;
 	/** Set to make the CAPTURED-id credential write throw, recording nothing. */
 	failSecret: Error | null;
+	/**
+	 * Set to make the LEGACY-id blank throw. A separate switch from failSecret
+	 * because the two happen on opposite sides of the commit: the credential
+	 * write can still undo a capture, the legacy blank is bookkeeping after one
+	 * has already succeeded and must not be able to fail it.
+	 */
+	failLegacySecret: Error | null;
 	/** Runs during the settings write, while the commit is still in flight. */
 	duringSave: (() => void) | null;
 	/**
@@ -123,6 +130,7 @@ function makeHarness(settings: Partial<HarnessSettings> = {}): Harness {
 		secrets,
 		failSave: null,
 		failSecret: null,
+		failLegacySecret: null,
 		duringSave: null,
 		shortLifetimeNotices: 0,
 	};
@@ -142,6 +150,12 @@ function makeHarness(settings: Partial<HarnessSettings> = {}): Harness {
 			if (id === CAPTURED_SECRET_ID && harness.failSecret !== null) {
 				// A backend that refused the write recorded nothing.
 				throw harness.failSecret;
+			}
+			if (
+				id === LEGACY_REFRESH_SECRET_ID &&
+				harness.failLegacySecret !== null
+			) {
+				throw harness.failLegacySecret;
 			}
 			calls.push(`setSecret:${id}`);
 			secrets.set(id, secret);
@@ -409,6 +423,58 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			);
 			expect(h.calls).toContain('reconcileRefresh');
 			expect(h.calls).toContain('settingsRefresh');
+		});
+
+		it('does not fail a stored capture when blanking the legacy token throws', async () => {
+			// The legacy blank writes a secret, and setSecret is throwable. On the
+			// plugin this call was a private method that swallowed its own errors,
+			// so it could sit outside the guard; behind the host interface it is an
+			// arbitrary callback, and a throwing one would reject a store whose
+			// credential is already durably written. The bookkeeping after it must
+			// still run: a stored window credential without its renewal timer stops
+			// renewing silently.
+			const h = makeHarness();
+			h.failLegacySecret = new Error('secret backing store unavailable');
+			h.host.settingsRefresh = () => h.calls.push('settingsRefresh');
+			const token = usableToken();
+
+			const result = await h.store.storeAccessToken(token, 'window');
+
+			expect(result).toEqual({ outcome: 'stored' });
+			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(token);
+			expect(h.host.settings.secretId).toBe(CAPTURED_SECRET_ID);
+			expect(consoleError).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'legacy refresh-token blank after a stored capture failed',
+				),
+				expect.any(Error),
+			);
+			expect(h.calls).toContain('reconcileExpiry');
+			expect(h.calls).toContain('reconcileRefresh');
+			expect(h.calls).toContain('settingsRefresh');
+		});
+
+		it('does not fail a stored capture when clearing the refresh failure throws', async () => {
+			// Same reasoning as the legacy blank. On the plugin this was a bare
+			// field assignment that could not throw; through the host it is a
+			// callback like any other.
+			const h = makeHarness();
+			h.host.clearRefreshFailure = (): void => {
+				throw new Error('refresh-failure clear blew up');
+			};
+			const token = usableToken();
+
+			const result = await h.store.storeAccessToken(token, 'window');
+
+			expect(result).toEqual({ outcome: 'stored' });
+			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(token);
+			expect(consoleError).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'refresh-failure clear after a stored capture failed',
+				),
+				expect.any(Error),
+			);
+			expect(h.calls).toContain('reconcileRefresh');
 		});
 	});
 

--- a/__tests__/main-capture-atomicity.test.ts
+++ b/__tests__/main-capture-atomicity.test.ts
@@ -13,10 +13,17 @@
  * makes the settings write the commit point and runs it FIRST, so a failure has
  * nothing to unwind.
  *
- * Built with `Object.create(prototype)` like the other main.ts suites: the store
- * is one method and constructing a real plugin would drag in the whole onload.
+ * This suite used to build its subject with
+ * `Object.create(PlaudImporterPlugin.prototype)`, because the store was five
+ * methods on the plugin class and constructing a real plugin would have dragged
+ * in the whole onload. `Object.create` runs no field initializers, so every
+ * field the store touched had to be seeded by hand, and a field added later was
+ * silently `undefined` rather than a failure. The store now lives in
+ * capture-store.ts with a constructor and an explicit host, so the subject
+ * below is a real `new CaptureStore(...)` over an ordinary stub.
  */
-import PlaudImporterPlugin from '../main';
+import { CaptureStore, type CaptureStoreHost } from '../capture-store';
+import type { SignInMethod } from '../reconnect-routing';
 
 // Build a minimal unsigned JWT. The capture guard reads unverified claims only,
 // so an unsigned token with a dummy signature segment is a faithful fixture.
@@ -43,38 +50,38 @@ function usableToken(clientId = 'web'): string {
 	});
 }
 
+// Written out rather than imported from the source. These ids address secrets
+// that already exist in every user's vault, so a change to either is a breaking
+// change; a literal here fails when one moves, an import would follow it.
 const CAPTURED_SECRET_ID = 'plaud-importer-token';
 const LEGACY_REFRESH_SECRET_ID = 'plaud-importer-refresh-token';
 
-type StoreOutcome =
-	| { outcome: 'stored' }
-	| { outcome: 'unusable' }
-	| { outcome: 'superseded' }
-	| { outcome: 'save-failed'; error: unknown }
-	| { outcome: 'torn'; error: unknown };
+/** Settings shaped like the plugin's, plus one unrelated field to watch. */
+interface HarnessSettings {
+	secretId: string;
+	apiBaseUrl: string;
+	signInMethod: SignInMethod;
+	/** Unrelated to auth, used to prove a concurrent edit is not reverted. */
+	autoSyncEnabled: boolean;
+	[key: string]: unknown;
+}
 
-/** The subset of the plugin the store touches. Private members need the cast. */
-interface StoreHost {
-	settings: Record<string, unknown>;
-	app: { secretStorage: { setSecret(id: string, secret: string): void } };
-	saveData(data: unknown): Promise<void>;
-	/** Tail of the capture queue. Seeded by hand: see the note in makeHarness. */
-	captureStoreChain: Promise<unknown>;
+/**
+ * Stands in for the plugin. It is the object main.ts builds inline, with the
+ * plugin state the store mutates hoisted onto it so the assertions can read it
+ * back, and with the hooks the tests override left as plain properties.
+ */
+interface HostStub extends CaptureStoreHost<HarnessSettings> {
+	settings: HarnessSettings;
+	/** Cleared by a successful store, exactly as on the plugin. */
 	sessionRefreshFailed: boolean;
-	settingsRefresh?: () => void;
-	reconcileSessionExpiryWarning(): void;
-	reconcileSessionRefresh(): void;
-	storeAccessToken(
-		rawToken: string,
-		signInMethod?: string,
-		apiBaseUrl?: string,
-		background?: boolean,
-		stillOwns?: () => boolean,
-	): Promise<StoreOutcome>;
+	/** Null when no settings tab is mounted, exactly as on the plugin. */
+	settingsRefresh: (() => void) | null;
 }
 
 interface Harness {
-	plugin: StoreHost;
+	store: CaptureStore<HarnessSettings>;
+	host: HostStub;
 	/** Every mutation in the order it happened, so ordering is assertable. */
 	calls: string[];
 	secrets: Map<string, string>;
@@ -84,6 +91,14 @@ interface Harness {
 	failSecret: Error | null;
 	/** Runs during the settings write, while the commit is still in flight. */
 	duringSave: (() => void) | null;
+	/**
+	 * How many times the short-lifetime heads-up hook was invoked. Counted
+	 * rather than pushed into `calls`, because the real method is advisory and
+	 * silent for the iat-less fixtures above: recording it as a mutation would
+	 * put an event in the ordering assertions that a real capture of these
+	 * tokens never produces.
+	 */
+	shortLifetimeNotices: number;
 }
 
 /** What a vault that will not take the write looks like out of saveData. */
@@ -91,71 +106,91 @@ function vaultWriteError(): Error {
 	return new Error("EROFS: read-only file system, open 'data.json'");
 }
 
-function makeHarness(settings: Record<string, unknown> = {}): Harness {
-	const plugin = Object.create(PlaudImporterPlugin.prototype) as StoreHost;
+function makeHarness(settings: Partial<HarnessSettings> = {}): Harness {
+	const secrets = new Map<string, string>();
+	const calls: string[] = [];
+	// Seed the credential a previous sign-in left, so "nothing was written" can
+	// be checked as "the old value is still there" rather than merely "absent".
+	secrets.set(CAPTURED_SECRET_ID, 'previous-token');
+	secrets.set(LEGACY_REFRESH_SECRET_ID, 'previous-refresh-token');
+
 	const harness: Harness = {
-		plugin,
-		calls: [],
-		secrets: new Map<string, string>(),
+		// Both filled in below; the host closes over `harness`, so it cannot be
+		// built before the object exists.
+		store: null as unknown as CaptureStore<HarnessSettings>,
+		host: null as unknown as HostStub,
+		calls,
+		secrets,
 		failSave: null,
 		failSecret: null,
 		duringSave: null,
+		shortLifetimeNotices: 0,
 	};
 
-	// `Object.create` builds the prototype chain but runs no field initializers,
-	// so every class field the store reads has to be seeded here. This one is
-	// load-bearing rather than cosmetic: the queue chains onto it, and leaving it
-	// undefined fails at the first store rather than in some later assertion.
-	plugin.captureStoreChain = Promise.resolve();
-	plugin.settings = {
-		secretId: 'some-other-secret',
-		apiBaseUrl: 'https://api.plaud.ai',
-		signInMethod: 'browser',
-		// An unrelated setting, used to prove a concurrent edit is not reverted.
-		autoSyncEnabled: false,
-		...settings,
-	};
-	// Seed the credential a previous sign-in left, so "nothing was written" can
-	// be checked as "the old value is still there" rather than merely "absent".
-	harness.secrets.set(CAPTURED_SECRET_ID, 'previous-token');
-	harness.secrets.set(LEGACY_REFRESH_SECRET_ID, 'previous-refresh-token');
-
-	plugin.app = {
-		secretStorage: {
-			setSecret: (id: string, secret: string): void => {
-				if (id === CAPTURED_SECRET_ID && harness.failSecret !== null) {
-					// A backend that refused the write recorded nothing.
-					throw harness.failSecret;
-				}
-				harness.calls.push(`setSecret:${id}`);
-				harness.secrets.set(id, secret);
-			},
+	const host: HostStub = {
+		settings: {
+			secretId: 'some-other-secret',
+			apiBaseUrl: 'https://api.plaud.ai',
+			signInMethod: 'browser',
+			autoSyncEnabled: false,
+			...settings,
+		},
+		sessionRefreshFailed: true,
+		settingsRefresh: null,
+		getSettings: () => host.settings,
+		setSecret: (id: string, secret: string): void => {
+			if (id === CAPTURED_SECRET_ID && harness.failSecret !== null) {
+				// A backend that refused the write recorded nothing.
+				throw harness.failSecret;
+			}
+			calls.push(`setSecret:${id}`);
+			secrets.set(id, secret);
+		},
+		saveData: async (data: HarnessSettings): Promise<void> => {
+			calls.push('saveData');
+			harness.duringSave?.();
+			// A real settings write is not synchronous. Yielding here is what makes
+			// "the credential lands only after the write resolves" a real assertion
+			// rather than an artifact of everything running in one tick.
+			await Promise.resolve();
+			if (harness.failSave !== null) {
+				throw harness.failSave;
+			}
+			calls.push('saveData:ok');
+			// Whatever reached disk, so a failed save can be checked as "nothing".
+			secrets.set('__data.json__', JSON.stringify(data));
+		},
+		isDisposed: () => false,
+		// Mirrors the plugin's one-liner rather than recording a bare call, so the
+		// "does not blank the legacy refresh token" assertions keep measuring a
+		// secret value instead of a spy.
+		clearStoredRefreshToken: (): void => {
+			host.setSecret(LEGACY_REFRESH_SECRET_ID, '');
+		},
+		clearRefreshFailure: (): void => {
+			host.sessionRefreshFailed = false;
+		},
+		noteShortLifetimeOnCapture: (): void => {
+			harness.shortLifetimeNotices += 1;
+		},
+		reconcileSessionExpiryWarning: (): void => {
+			calls.push('reconcileExpiry');
+		},
+		reconcileSessionRefresh: (): void => {
+			calls.push('reconcileRefresh');
+		},
+		redrawSettings: (): void => host.settingsRefresh?.(),
+		probeCandidate: (): Promise<void> => {
+			// storeAccessToken never probes; only storeFirstWorkingCandidate does,
+			// and this suite does not exercise it. Fail loudly if that changes.
+			throw new Error('probeCandidate is not part of this suite');
 		},
 	};
-	plugin.saveData = async (data: unknown): Promise<void> => {
-		harness.calls.push('saveData');
-		harness.duringSave?.();
-		// A real settings write is not synchronous. Yielding here is what makes
-		// "the credential lands only after the write resolves" a real assertion
-		// rather than an artifact of everything running in one tick.
-		await Promise.resolve();
-		if (harness.failSave !== null) {
-			throw harness.failSave;
-		}
-		harness.calls.push('saveData:ok');
-		// Whatever reached disk, so a failed save can be checked as "nothing".
-		harness.secrets.set('__data.json__', JSON.stringify(data));
-	};
-	plugin.sessionRefreshFailed = true;
-	plugin.reconcileSessionExpiryWarning = (): void => {
-		harness.calls.push('reconcileExpiry');
-	};
-	plugin.reconcileSessionRefresh = (): void => {
-		harness.calls.push('reconcileRefresh');
-	};
+
+	harness.host = host;
+	harness.store = new CaptureStore<HarnessSettings>(host);
 	return harness;
 }
-
 describe('storing a capture is all-or-nothing (issue #86)', () => {
 	let consoleError: jest.SpyInstance;
 
@@ -176,7 +211,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.calls).not.toContain(`setSecret:${CAPTURED_SECRET_ID}`);
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe('previous-token');
@@ -188,15 +223,15 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
 
-			await h.plugin.storeAccessToken(
+			await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 				'https://api-eu.plaud.ai',
 			);
 
-			expect(h.plugin.settings.secretId).toBe('some-other-secret');
-			expect(h.plugin.settings.signInMethod).toBe('browser');
-			expect(h.plugin.settings.apiBaseUrl).toBe('https://api.plaud.ai');
+			expect(h.host.settings.secretId).toBe('some-other-secret');
+			expect(h.host.settings.signInMethod).toBe('browser');
+			expect(h.host.settings.apiBaseUrl).toBe('https://api.plaud.ai');
 		});
 
 		it('reports the failure as its own outcome, carrying the cause', async () => {
@@ -206,7 +241,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const cause = vaultWriteError();
 			h.failSave = cause;
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 			);
@@ -225,7 +260,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.secrets.get(LEGACY_REFRESH_SECRET_ID)).toBe(
 				'previous-refresh-token',
@@ -239,7 +274,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.calls).not.toContain('reconcileExpiry');
 			expect(h.calls).not.toContain('reconcileRefresh');
@@ -251,17 +286,17 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
-			expect(h.plugin.sessionRefreshFailed).toBe(true);
+			expect(h.host.sessionRefreshFailed).toBe(true);
 		});
 
 		it('does not redraw the settings tab', async () => {
 			const h = makeHarness();
 			h.failSave = vaultWriteError();
-			h.plugin.settingsRefresh = () => h.calls.push('settingsRefresh');
+			h.host.settingsRefresh = () => h.calls.push('settingsRefresh');
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.calls).not.toContain('settingsRefresh');
 		});
@@ -273,7 +308,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// leave the credential behind with nothing describing it.
 			const h = makeHarness();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.calls.indexOf('saveData:ok')).toBeLessThan(
 				h.calls.indexOf(`setSecret:${CAPTURED_SECRET_ID}`),
@@ -284,7 +319,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			const token = usableToken();
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				token,
 				'window',
 				'https://api-eu.plaud.ai',
@@ -292,11 +327,9 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 
 			expect(result).toEqual({ outcome: 'stored' });
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(token);
-			expect(h.plugin.settings.secretId).toBe(CAPTURED_SECRET_ID);
-			expect(h.plugin.settings.signInMethod).toBe('window');
-			expect(h.plugin.settings.apiBaseUrl).toBe(
-				'https://api-eu.plaud.ai',
-			);
+			expect(h.host.settings.secretId).toBe(CAPTURED_SECRET_ID);
+			expect(h.host.settings.signInMethod).toBe('window');
+			expect(h.host.settings.apiBaseUrl).toBe('https://api-eu.plaud.ai');
 		});
 
 		it('persists the same pairing it applied in memory', async () => {
@@ -304,7 +337,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// and applied another would just move the tear.
 			const h = makeHarness();
 
-			await h.plugin.storeAccessToken(
+			await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 				'https://api-eu.plaud.ai',
@@ -321,9 +354,9 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 		it('keeps the configured region when the capture found none', async () => {
 			const h = makeHarness();
 
-			await h.plugin.storeAccessToken(usableToken(), 'browser');
+			await h.store.storeAccessToken(usableToken(), 'browser');
 
-			expect(h.plugin.settings.apiBaseUrl).toBe('https://api.plaud.ai');
+			expect(h.host.settings.apiBaseUrl).toBe('https://api.plaud.ai');
 		});
 
 		it('does not revert an unrelated setting changed while the write was in flight', async () => {
@@ -332,22 +365,22 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// write. Only the fields this capture owns are applied.
 			const h = makeHarness();
 			h.duringSave = () => {
-				h.plugin.settings.autoSyncEnabled = true;
+				h.host.settings.autoSyncEnabled = true;
 			};
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
-			expect(h.plugin.settings.autoSyncEnabled).toBe(true);
-			expect(h.plugin.settings.secretId).toBe(CAPTURED_SECRET_ID);
+			expect(h.host.settings.autoSyncEnabled).toBe(true);
+			expect(h.host.settings.secretId).toBe(CAPTURED_SECRET_ID);
 		});
 
 		it('blanks the legacy refresh token and reconciles the session', async () => {
 			const h = makeHarness();
 
-			await h.plugin.storeAccessToken(usableToken(), 'window');
+			await h.store.storeAccessToken(usableToken(), 'window');
 
 			expect(h.secrets.get(LEGACY_REFRESH_SECRET_ID)).toBe('');
-			expect(h.plugin.sessionRefreshFailed).toBe(false);
+			expect(h.host.sessionRefreshFailed).toBe(false);
 			expect(h.calls).toContain('reconcileExpiry');
 			expect(h.calls).toContain('reconcileRefresh');
 		});
@@ -360,13 +393,13 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// failing must not skip the rest: a stored window credential still
 			// arms its renewal timer and the tab still redraws.
 			const h = makeHarness();
-			h.plugin.reconcileSessionExpiryWarning = (): void => {
+			h.host.reconcileSessionExpiryWarning = (): void => {
 				throw new Error('expiry reconcile blew up');
 			};
-			h.plugin.settingsRefresh = () => h.calls.push('settingsRefresh');
+			h.host.settingsRefresh = () => h.calls.push('settingsRefresh');
 			const token = usableToken();
 
-			const result = await h.plugin.storeAccessToken(token, 'window');
+			const result = await h.store.storeAccessToken(token, 'window');
 
 			expect(result).toEqual({ outcome: 'stored' });
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(token);
@@ -390,7 +423,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const cause = new Error('secret backing store unavailable');
 			h.failSecret = cause;
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 				'https://api-eu.plaud.ai',
@@ -404,7 +437,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			expect(onDisk.secretId).toBe('some-other-secret');
 			expect(onDisk.signInMethod).toBe('browser');
 			expect(onDisk.apiBaseUrl).toBe('https://api.plaud.ai');
-			expect(h.plugin.settings.secretId).toBe('some-other-secret');
+			expect(h.host.settings.secretId).toBe('some-other-secret');
 			expect(h.calls).not.toContain('reconcileRefresh');
 			expect(consoleError).toHaveBeenCalledWith(
 				expect.stringContaining(
@@ -424,15 +457,16 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			h.failSecret = cause;
 			// The restore write is the second save this store makes; refuse
 			// exactly that one via the harness's own failure switch.
+			const restoreFailure = vaultWriteError();
 			let saves = 0;
 			h.duringSave = () => {
 				saves += 1;
 				if (saves === 2) {
-					h.failSave = vaultWriteError();
+					h.failSave = restoreFailure;
 				}
 			};
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 			);
@@ -445,8 +479,24 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			) as Record<string, unknown>;
 			expect(onDisk.secretId).toBe(CAPTURED_SECRET_ID);
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe('previous-token');
-			expect(h.plugin.settings.secretId).toBe('some-other-secret');
+			expect(h.host.settings.secretId).toBe('some-other-secret');
 			expect(h.calls).not.toContain('reconcileRefresh');
+			// BOTH causes have to reach the log. The torn notice tells the user
+			// to sign in again and says nothing about why, so the console is the
+			// only place the two failures behind it are recorded; losing either
+			// leaves the rarest path in the store undiagnosable from a report.
+			expect(consoleError).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'could not store the captured credential',
+				),
+				cause,
+			);
+			expect(consoleError).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'could not restore settings after the credential write failed',
+				),
+				restoreFailure,
+			);
 		});
 	});
 
@@ -469,7 +519,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const slowFirstSave = new Promise<void>((resolve) => {
 				releaseFirst = resolve;
 			});
-			h.plugin.saveData = async (): Promise<void> => {
+			h.host.saveData = async (): Promise<void> => {
 				if (!sawFirst) {
 					sawFirst = true;
 					h.calls.push('saveData:slow');
@@ -482,15 +532,15 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 				h.calls.push('saveData:fast:ok');
 			};
 
-			const a = h.plugin.storeAccessToken(first, 'window');
-			const b = h.plugin.storeAccessToken(second, 'browser');
+			const a = h.store.storeAccessToken(first, 'window');
+			const b = h.store.storeAccessToken(second, 'browser');
 			await Promise.resolve();
 			await Promise.resolve();
 			releaseFirst();
 			await Promise.all([a, b]);
 
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(second);
-			expect(h.plugin.settings.signInMethod).toBe('browser');
+			expect(h.host.settings.signInMethod).toBe('browser');
 		});
 
 		it("never runs one store's commit inside another's", async () => {
@@ -500,8 +550,8 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 
 			await Promise.all([
-				h.plugin.storeAccessToken(usableToken('a'), 'window'),
-				h.plugin.storeAccessToken(usableToken('b'), 'browser'),
+				h.store.storeAccessToken(usableToken('a'), 'window'),
+				h.store.storeAccessToken(usableToken('b'), 'browser'),
 			]);
 
 			const oneStore = [
@@ -522,11 +572,11 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// the write happens.
 			const h = makeHarness();
 			const first = usableToken('first');
-			const a = h.plugin.storeAccessToken(first, 'window');
+			const a = h.store.storeAccessToken(first, 'window');
 			// Holds the same guard the background refresh holds: "the credential I
 			// measured is still the live one". It passes at call time, because the
 			// first store has not reached its setSecret yet.
-			const b = h.plugin.storeAccessToken(
+			const b = h.store.storeAccessToken(
 				usableToken('stale'),
 				'browser',
 				undefined,
@@ -537,13 +587,13 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			await expect(a).resolves.toEqual({ outcome: 'stored' });
 			await expect(b).resolves.toEqual({ outcome: 'superseded' });
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe(first);
-			expect(h.plugin.settings.signInMethod).toBe('window');
+			expect(h.host.settings.signInMethod).toBe('window');
 		});
 
 		it('writes nothing at all when it finds itself superseded', async () => {
 			const h = makeHarness();
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				usableToken(),
 				'window',
 				'https://api-eu.plaud.ai',
@@ -554,8 +604,8 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			expect(result).toEqual({ outcome: 'superseded' });
 			expect(h.calls).toHaveLength(0);
 			expect(h.secrets.get(CAPTURED_SECRET_ID)).toBe('previous-token');
-			expect(h.plugin.settings.secretId).toBe('some-other-secret');
-			expect(h.plugin.settings.apiBaseUrl).toBe('https://api.plaud.ai');
+			expect(h.host.settings.secretId).toBe('some-other-secret');
+			expect(h.host.settings.apiBaseUrl).toBe('https://api.plaud.ai');
 		});
 
 		it('does not strand later captures behind one that threw', async () => {
@@ -566,7 +616,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			const h = makeHarness();
 			const survivor = usableToken('survivor');
 
-			const first = h.plugin.storeAccessToken(
+			const first = h.store.storeAccessToken(
 				usableToken('doomed'),
 				'window',
 				undefined,
@@ -575,7 +625,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 					throw new Error('guard blew up');
 				},
 			);
-			const second = h.plugin.storeAccessToken(survivor, 'browser');
+			const second = h.store.storeAccessToken(survivor, 'browser');
 
 			await expect(first).rejects.toThrow('guard blew up');
 			await expect(second).resolves.toEqual({ outcome: 'stored' });
@@ -589,7 +639,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 			// this one IS fixed by signing in again.
 			const h = makeHarness();
 
-			const result = await h.plugin.storeAccessToken(
+			const result = await h.store.storeAccessToken(
 				'not-a-jwt',
 				'window',
 			);
@@ -606,7 +656,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 				exp: Math.floor(Date.now() / 1000) - 60,
 			});
 
-			const result = await h.plugin.storeAccessToken(expired, 'window');
+			const result = await h.store.storeAccessToken(expired, 'window');
 
 			expect(result).toEqual({ outcome: 'unusable' });
 			expect(h.calls).toHaveLength(0);
@@ -619,7 +669,7 @@ describe('storing a capture is all-or-nothing (issue #86)', () => {
 		const h = makeHarness();
 		const token = usableToken();
 
-		const result = await h.plugin.storeAccessToken(
+		const result = await h.store.storeAccessToken(
 			`Bearer ${token}`,
 			'window',
 		);

--- a/capture-store.ts
+++ b/capture-store.ts
@@ -383,20 +383,23 @@ export class CaptureStore<S extends CaptureSettings> {
 		if (apiBaseUrl !== undefined) {
 			live.apiBaseUrl = apiBaseUrl;
 		}
-		// Blank any legacy WRT from a previous session so it cannot shadow the
-		// recorded method. After the commit, like the credential: a capture that
-		// never stored must not clear the session it failed to replace.
-		this.host.clearStoredRefreshToken();
-		// A newly stored credential clears any prior refresh failure: whatever
-		// was wrong, the user just replaced the thing that was failing.
-		this.host.clearRefreshFailure();
-		// Everything below is bookkeeping about a store that has already
-		// succeeded. A throw in it must not escape, or the caller reports a
-		// save failure for a credential that is durably linked; the redraw
-		// guard this generalizes existed for exactly that reason. Each call is
-		// guarded ALONE, because they are independent: one failing must not
-		// skip the rest, or a stored credential is left without its renewal
+		// EVERY host call below this line is bookkeeping about a store that has
+		// already succeeded. A throw in one must not escape, or the caller
+		// reports a save failure for a credential that is durably linked; the
+		// redraw guard this generalizes existed for exactly that reason. Each
+		// call is guarded ALONE, because they are independent: one failing must
+		// not skip the rest, or a stored credential is left without its renewal
 		// timer or with a stale settings tab.
+		//
+		// The guard covers the two clears as well, which it did not have to when
+		// this lived on the plugin: there `clearStoredRefreshToken` was a private
+		// method with its own try/catch and the refresh-failure clear was a bare
+		// field assignment, so neither could throw and the guard could start
+		// below them. Behind an interface they are arbitrary host callbacks, and
+		// `setSecret` (which the plugin's implementation calls) is documented
+		// throwable. Relying on a host to swallow its own errors would make an
+		// undocumented precondition load-bearing on the plugin's most delicate
+		// path.
 		const guarded = (what: string, run: () => void): void => {
 			try {
 				run();
@@ -407,6 +410,15 @@ export class CaptureStore<S extends CaptureSettings> {
 				);
 			}
 		};
+		// Blank any legacy WRT from a previous session so it cannot shadow the
+		// recorded method. After the commit, like the credential: a capture that
+		// never stored must not clear the session it failed to replace.
+		guarded('legacy refresh-token blank', () =>
+			this.host.clearStoredRefreshToken(),
+		);
+		// A newly stored credential clears any prior refresh failure: whatever
+		// was wrong, the user just replaced the thing that was failing.
+		guarded('refresh-failure clear', () => this.host.clearRefreshFailure());
 		if (!background) {
 			guarded('short-lifetime notice', () =>
 				this.host.noteShortLifetimeOnCapture(token, signInMethod),

--- a/capture-store.ts
+++ b/capture-store.ts
@@ -1,0 +1,576 @@
+/**
+ * The capture store: everything that turns a candidate credential into a stored
+ * one. Extracted verbatim from main.ts, where it was five methods on the plugin
+ * class reachable only through `Object.create(PlaudImporterPlugin.prototype)`.
+ *
+ * The store reaches its surroundings through CaptureStoreHost and nothing else,
+ * so it can be built with `new` in a test. That is the point of the extraction:
+ * the atomicity rules below are the plugin's most delicate code and they were
+ * the hardest thing in the repo to exercise.
+ */
+import { Notice } from 'obsidian';
+import { isUsableUserToken } from './plaud-token';
+import { selectWorkingCandidate } from './token-candidates';
+import type { SignInMethod } from './reconnect-routing';
+
+// Stable SecretStorage id for a token captured by the in-app sign-in flow.
+// Re-running sign-in overwrites it, mirroring "replace my token".
+export const CAPTURED_SECRET_ID = 'plaud-importer-token';
+
+// Deep-link result notices. Held in consts because the strings are shown from
+// two code paths (during a browser reconnect and standalone) and must stay
+// identical; built as variables so the sentence-case lint, which only inspects
+// literals at the call site, accepts the product name mid-sentence.
+const DEEP_LINK_SAVED_NOTICE =
+	'Plaud token received from your browser and saved.';
+const DEEP_LINK_BAD_TOKEN_NOTICE =
+	'Plaud sign-in link did not carry a usable token. In your browser, sign in to Plaud before clicking the bookmarklet, then try again.';
+// Every candidate the browser sent was rejected by Plaud itself, so the
+// browser session is signed out or revoked rather than the link being wrong
+// (issue #78: rogerfsh's 300-day token still decodes cleanly but is revoked).
+const DEEP_LINK_ALL_REJECTED_NOTICE =
+	'Plaud rejected every sign-in token from your browser, so that session looks signed out or revoked. Sign in to Plaud in your browser again, then click the bookmark.';
+// One candidate, and Plaud could not be reached to check it. Storing it
+// unverified matches the pre-0.35.0 behavior and keeps an offline reconnect
+// working; the user finds out from the next import if it was already dead.
+const DEEP_LINK_UNVERIFIED_NOTICE =
+	'Plaud token received from your browser and saved, but Plaud could not be reached to check it. Run Test connection once you are back online.';
+// Shown while several candidates are probed. A const like its siblings so the
+// sentence-case lint, which only inspects literals at the call site, accepts
+// the product name mid-sentence.
+const DEEP_LINK_PROBING_NOTICE = 'Checking which Plaud sign-in still works…';
+// A capture that failed while being SAVED, rather than one the token was wrong
+// for. Every notice above means the credential was the problem; this one means
+// it may well have been fine, so repeating the sign-in is not the fix. The
+// wording names the likely cause as something to check rather than as a
+// diagnosis: the capture path throws opaquely (a settings write is the common
+// source, but not the only one), so asserting "the vault is not writable" would
+// be the same over-claiming this notice exists to stop. Telling the two apart
+// properly needs the result union tracked in issue #86.
+export const CAPTURE_SAVE_FAILED_NOTICE =
+	'Plaud: could not save the token. If this keeps happening, check that this vault is writable and has free space.';
+// The one failure that cannot promise "nothing changed": the settings commit
+// landed, the credential write then threw, and writing the old settings back
+// failed too. Signing in again rewrites both halves, so that is the instruction.
+const CAPTURE_TORN_NOTICE =
+	'Plaud: the sign-in was recorded but its credential could not be stored, so the previous session is still in use. Sign in again to finish reconnecting.';
+// Several candidates and no way to ask which one works. Picking blind would
+// store the wrong credential (a revoked long-lived token outranks a live short
+// one on every claim we can read), so store nothing and let the user retry.
+const DEEP_LINK_UNREACHABLE_NOTICE =
+	'Could not reach Plaud to check which sign-in token to use, so nothing was saved. Check your connection, then click the bookmark again.';
+
+/**
+ * What storing a captured credential did (issue #86). A boolean could not carry
+ * the distinction the issue asks for: a credential the plugin REJECTED is fixed
+ * by signing in again, and one it never got to WRITE is not. The second used to
+ * arrive only as an opaque throw, so no surface could tell them apart.
+ *
+ * No outcome here means "partly applied and unreported". "torn" exists for the
+ * one sequence that can still half-apply (commit landed, credential write
+ * threw, restore write failed too), so even that arrives as a value a surface
+ * can explain rather than as an opaque rejection.
+ */
+export type CaptureStoreResult =
+	/** Failed the pre-write capture guard. Nothing was written. */
+	| { outcome: 'unusable' }
+	/**
+	 * Something took over the credential while this store waited its turn.
+	 * Nothing was written, and nothing should be said: whatever superseded this
+	 * is what the user is holding.
+	 */
+	| { outcome: 'superseded' }
+	/**
+	 * The settings write rejected (read-only vault, full disk, a sync client
+	 * holding the file), or the credential write threw and the settings were
+	 * rolled back. Either way nothing is changed. Carries the cause for
+	 * logging; surfaces show CAPTURE_SAVE_FAILED_NOTICE rather than the raw
+	 * error.
+	 */
+	| { outcome: 'save-failed'; error: unknown }
+	/**
+	 * The settings commit landed, the credential write then threw, and writing
+	 * the previous settings back failed too. data.json names this capture
+	 * while the secret still holds the previous credential; the previous
+	 * session keeps working in memory. Signing in again rewrites both sides,
+	 * so surfaces show CAPTURE_TORN_NOTICE, which says exactly that. Carries
+	 * the credential write's cause.
+	 */
+	| { outcome: 'torn'; error: unknown }
+	| { outcome: 'stored' };
+
+/** The settings fields the store itself reads and writes. */
+export interface CaptureSettings {
+	secretId: string;
+	signInMethod: SignInMethod;
+	apiBaseUrl: string;
+}
+
+/**
+ * Everything the store needs from the plugin around it, named one call at a
+ * time rather than as `plugin: PlaudImporterPlugin`. Passing the plugin would
+ * have moved the lines and kept the coupling, which is the part worth removing.
+ *
+ * Generic over the full settings type because the store persists the WHOLE
+ * settings object (it spreads it into the commit) while only reading and
+ * writing the three fields in CaptureSettings.
+ */
+export interface CaptureStoreHost<S extends CaptureSettings> {
+	/**
+	 * The LIVE settings object, re-read on every use. A method rather than a
+	 * property because loadSettings REPLACES the object, so a reference taken
+	 * once at construction would go stale on the next load. Callers mutate what
+	 * this returns; see the note at the end of commitCapturedToken for why the
+	 * commit applies its own fields to the live object instead of adopting the
+	 * snapshot it took before the await.
+	 */
+	getSettings(): S;
+	/** Throwable, and treated as such: SecretStorage.setSecret returns void. */
+	setSecret(id: string, secret: string): void;
+	saveData(data: S): Promise<void>;
+	/** True once the plugin has unloaded. Nothing may be stored onto it after. */
+	isDisposed(): boolean;
+	/** Blank the legacy pre-0.32.0 refresh token so it cannot shadow this one. */
+	clearStoredRefreshToken(): void;
+	/** A fresh credential clears any prior refresh failure. */
+	clearRefreshFailure(): void;
+	/** One-time short-session heads-up (issue #78). Suppressed for background stores. */
+	noteShortLifetimeOnCapture(token: string, signInMethod: SignInMethod): void;
+	reconcileSessionExpiryWarning(): void;
+	reconcileSessionRefresh(): void;
+	/** Redraw the settings tab's status line and secret picker, if it is open. */
+	redrawSettings(): void;
+	/**
+	 * One authenticated round-trip against `baseUrl` using `token`, resolving on
+	 * acceptance and rejecting on refusal. A host call rather than a client the
+	 * store constructs itself, so the store carries no transport dependency and
+	 * its tests need no client mock. `onBaseUrlChanged` reports a region
+	 * redirect followed during the probe.
+	 */
+	probeCandidate(
+		token: string,
+		baseUrl: string,
+		onBaseUrlChanged: (url: string) => void,
+	): Promise<void>;
+}
+
+export class CaptureStore<S extends CaptureSettings> {
+	/**
+	 * Tail of the capture queue. Owned by the store now; it used to be a plugin
+	 * field that every test had to seed by hand because `Object.create` runs no
+	 * field initializers.
+	 */
+	private captureStoreChain: Promise<unknown> = Promise.resolve();
+
+	constructor(private readonly host: CaptureStoreHost<S>) {}
+
+	// Validates a raw token value (the long-lived user token, optionally bearer-
+	// prefixed) and, if valid, stores it in the captured-token secret and links
+	// it. Overwrites the same secret each time, so replacing a token never
+	// requires creating or deleting a secret. Returns false without changing
+	// anything when the value fails the capture guard (payload must carry a
+	// client_id and a still-future exp). Shared by the browser deep-link handler
+	// and the clipboard-paste button.
+	async storeAccessToken(
+		rawToken: string,
+		// Which surface captured this credential. Reconnect reopens the same one,
+		// so the embedded window must record "window" even though it now shares
+		// the browser path's probe-and-select machinery.
+		signInMethod: SignInMethod = 'browser',
+		// The API origin this credential belongs to, when the capture surface
+		// discovered one. Applied HERE, in the same mutation batch as the token,
+		// rather than by the caller beforehand: a host written ahead of the
+		// store outlives a store that then fails, leaving the new region paired
+		// with the old credential. A token and the region it is valid for move
+		// together or not at all.
+		apiBaseUrl?: string,
+		// True when this store came from the unattended refresh rather than a
+		// user action. Suppresses the capture-time notices: the short-lifetime
+		// heads-up is written for someone who just finished signing in, and on
+		// the ~22 hour refresh cycle it would pop a 12 second notice saying the
+		// plugin will ask them to sign in again, which is both noisy and, for a
+		// refresh that just succeeded, wrong. A silent path that announces
+		// itself every cycle is not silent.
+		background = false,
+		// Re-checked immediately before the commit, for callers whose right to
+		// store can lapse while they wait: a cancelled reconnect flow, or a
+		// background refresh whose credential the user has since replaced. Their
+		// own checks run BEFORE this call, and this method now has an await ahead
+		// of the credential write, so a check made out there is not binding by the
+		// time the write happens. Callers with nothing to go stale keep the
+		// default.
+		stillOwns: () => boolean = () => true,
+	): Promise<CaptureStoreResult> {
+		const token = rawToken.trim().replace(/^bearer\s+/i, '');
+		if (token.length === 0 || !isUsableUserToken(token)) {
+			return { outcome: 'unusable' };
+		}
+		// Serialized, and ONLY this method is. The old store wrote the secret with
+		// a synchronous setSecret before its await, so credentials landed in CALL
+		// order however the saves interleaved. Committing settings first puts an
+		// await between a caller's decision and its credential write, so without
+		// this a store that STARTED earlier could FINISH later and overwrite a
+		// newer one: a background refresh mid-save when the user pastes a token.
+		// The queue exists to restore the ordering this reorder breaks, nothing
+		// more, so it is scoped to captures rather than to settings writes at
+		// large.
+		return this.serializeCaptureStore(() =>
+			this.commitCapturedToken(
+				token,
+				signInMethod,
+				apiBaseUrl,
+				background,
+				stillOwns,
+			),
+		);
+	}
+
+	/** Runs capture stores one at a time, in the order they were called. */
+	private serializeCaptureStore(
+		work: () => Promise<CaptureStoreResult>,
+	): Promise<CaptureStoreResult> {
+		// Both handlers run `work`: a predecessor that failed still had its turn,
+		// and a queue that stopped on the first failure would strand every later
+		// capture behind it.
+		const run = this.captureStoreChain.then(work, work);
+		// The chain must never carry a rejection forward, or one throwing store
+		// would reject every store queued after it. Successors wait for this one to
+		// FINISH, not to succeed; the result still reaches its own caller.
+		this.captureStoreChain = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	}
+
+	/**
+	 * The store itself, always run through the queue above. `token` has already
+	 * passed the capture guard and been trimmed.
+	 */
+	private async commitCapturedToken(
+		token: string,
+		signInMethod: SignInMethod,
+		apiBaseUrl: string | undefined,
+		background: boolean,
+		stillOwns: () => boolean,
+	): Promise<CaptureStoreResult> {
+		// The queue guarantees order, not relevance. This caller may have waited
+		// while a newer capture took over, and its own guard was evaluated before
+		// it joined. Re-ask now, with nothing yet written.
+		if (!stillOwns()) {
+			return { outcome: 'superseded' };
+		}
+		// THE SETTINGS WRITE IS THE COMMIT POINT, AND IT RUNS FIRST (issue #86).
+		//
+		// It used to run last, after `setSecret` had already put the credential on
+		// disk. `setSecret` is a synchronous void call (obsidian.d.ts: `setSecret(
+		// id: string, secret: string): void`), so it persists the moment it is
+		// called and there is no promise to fail. The awaited settings save right
+		// after it CAN fail, for ordinary reasons: a vault on read-only storage, a
+		// full disk, a sync client holding data.json. When it did, the new
+		// credential was already durably stored under the same id the old one used
+		// while data.json still named the old region and sign-in method, and that
+		// mismatch survived a restart.
+		//
+		// Unwinding the secret afterwards is the obvious fix and it is the wrong
+		// one. Three attempts were each faulted correctly, the last because the
+		// capture surfaces are not serialized against each other, so an unwind can
+		// undo whichever capture finished last: the one the user is holding.
+		//
+		// Doing the failable write first removes the unwind instead of trying to
+		// make one safe. Until `saveData` resolves nothing is mutated: not the
+		// secret, not the live settings, not the file. A rejection is a clean
+		// no-op, which is what lets CAPTURE_SAVE_FAILED_NOTICE promise nothing
+		// changed.
+		//
+		// KNOWN, ACCEPTED RESIDUAL, and the one thing this reorder makes worse
+		// rather than better. Everything below hangs on one fact: the live
+		// settings still hold the OLD auth fields until the commit resolves,
+		// because they are applied only after it. So during that window:
+		//
+		// - Clear sign-in or the token picker can run. This method then resumes
+		//   and re-links its own credential, undoing a sign-out the user asked
+		//   for. The old synchronous store had already written by then, so the
+		//   sign-out won.
+		// - An ordinary saveSettings() from any settings control writes the stale
+		//   auth fields. If it lands after this commit, disk names the old sign-in
+		//   while the secret holds the new token, which is this bug's own shape
+		//   arriving from the other side.
+		//
+		// The queue above covers captures against each other and nothing else, on
+		// purpose. Closing these two needs every settings write and credential
+		// mutation to share one ordering protocol, which is a change to the whole
+		// plugin rather than to this method, with a much wider blast radius than
+		// the defect being fixed. It belongs in its own issue and its own review.
+		//
+		// The trade, stated so it can be argued with: both windows are the
+		// duration of one file write, both need a competing action inside those
+		// few milliseconds, and both are recoverable by repeating the action. What
+		// they buy is the removal of a failure that anyone on a read-only or full
+		// vault hit every single time, silently, and permanently.
+		//
+		// Residual, stated plainly: a crash between the commit and `setSecret`
+		// leaves data.json naming the new region and method with the previous
+		// token. Closing that needs a fresh secret id per capture and a pointer
+		// swap; rejected because SecretStorage has no delete (see clearSignIn) and
+		// the settings token picker lists every id, so each orphan is permanent
+		// and user-visible. A crash window one synchronous step wide, worst case a
+		// one-generation-stale credential and a reconnect prompt, against a
+		// failure reproducible on any read-only vault whose worst case was silent,
+		// restart-surviving corruption. A THROWN credential write is not part of
+		// this residual: it is caught below, the settings are written back, and
+		// only when even that restore fails does it surface, as a reported
+		// `torn` outcome rather than silence. What remains is the hard crash.
+		const settings = this.host.getSettings();
+		const next: S = {
+			...settings,
+			secretId: CAPTURED_SECRET_ID,
+			// A pasted/deep-linked token came through the browser flow. Record that
+			// so Reconnect routes there.
+			signInMethod,
+		};
+		if (apiBaseUrl !== undefined) {
+			next.apiBaseUrl = apiBaseUrl;
+		}
+		try {
+			await this.host.saveData(next);
+		} catch (err) {
+			console.error(
+				'Plaud importer: could not save the captured sign-in',
+				err,
+			);
+			return { outcome: 'save-failed', error: err };
+		}
+		// The credential write CAN THROW: this plugin treats setSecret as
+		// throwable everywhere else it writes one (clearSignIn,
+		// clearStoredRefreshToken). Left bare here, a backing store that refused
+		// the write would recreate the tear this method exists to prevent, from
+		// the other side: data.json naming a sign-in whose credential never
+		// landed. It runs BEFORE the in-memory fields are applied, so on failure
+		// memory still describes the credential that survives.
+		try {
+			this.host.setSecret(CAPTURED_SECRET_ID, token);
+		} catch (err) {
+			console.error(
+				'Plaud importer: could not store the captured credential',
+				err,
+			);
+			// The commit above already landed, so write the previous settings
+			// back. A rollback is safe HERE and nowhere else: this store holds
+			// the capture queue, so no other capture can interleave with it,
+			// which is exactly what faulted the three pre-#97 rollback attempts.
+			// The live settings are untouched at this point and still describe
+			// the surviving credential, concurrent non-capture edits included.
+			try {
+				await this.host.saveData({ ...this.host.getSettings() });
+			} catch (restoreErr) {
+				console.error(
+					'Plaud importer: could not restore settings after the credential write failed',
+					restoreErr,
+				);
+				return { outcome: 'torn', error: err };
+			}
+			return { outcome: 'save-failed', error: err };
+		}
+		// Committed. Apply the fields this capture owns to the live settings object
+		// rather than swapping in `next` wholesale: `next` was snapshotted before
+		// the await, so adopting it would silently revert an unrelated setting the
+		// user changed while the write was in flight. Re-read rather than reusing
+		// the reference taken above, for the same reason.
+		const live = this.host.getSettings();
+		live.secretId = next.secretId;
+		live.signInMethod = next.signInMethod;
+		if (apiBaseUrl !== undefined) {
+			live.apiBaseUrl = apiBaseUrl;
+		}
+		// Blank any legacy WRT from a previous session so it cannot shadow the
+		// recorded method. After the commit, like the credential: a capture that
+		// never stored must not clear the session it failed to replace.
+		this.host.clearStoredRefreshToken();
+		// A newly stored credential clears any prior refresh failure: whatever
+		// was wrong, the user just replaced the thing that was failing.
+		this.host.clearRefreshFailure();
+		// Everything below is bookkeeping about a store that has already
+		// succeeded. A throw in it must not escape, or the caller reports a
+		// save failure for a credential that is durably linked; the redraw
+		// guard this generalizes existed for exactly that reason. Each call is
+		// guarded ALONE, because they are independent: one failing must not
+		// skip the rest, or a stored credential is left without its renewal
+		// timer or with a stale settings tab.
+		const guarded = (what: string, run: () => void): void => {
+			try {
+				run();
+			} catch (err) {
+				console.error(
+					`Plaud importer: ${what} after a stored capture failed`,
+					err,
+				);
+			}
+		};
+		if (!background) {
+			guarded('short-lifetime notice', () =>
+				this.host.noteShortLifetimeOnCapture(token, signInMethod),
+			);
+		}
+		guarded('expiry-warning reconcile', () =>
+			this.host.reconcileSessionExpiryWarning(),
+		);
+		guarded('session-refresh reconcile', () =>
+			this.host.reconcileSessionRefresh(),
+		);
+		// A deep link can land while the settings tab is open, which is exactly
+		// what the one-click bookmark encourages: launch sign-in from settings,
+		// click the bookmark, come back. Redraw the status line and secret
+		// picker so the tab does not keep saying "not connected yet". Read at
+		// call time, so a tab closed during the await above is simply null.
+		guarded('settings redraw', () => this.host.redrawSettings());
+		return { outcome: 'stored' };
+	}
+
+	/**
+	 * Renders a store outcome as the {stored, message} pair the capture surfaces
+	 * show, so a save failure cannot be reported as a bad token on one path and
+	 * correctly on another. `savedNotice` differs per path (a probed capture and
+	 * an unverified one say different things), so it is passed in.
+	 */
+	private describeCaptureOutcome(
+		result: CaptureStoreResult,
+		savedNotice: string,
+	): { stored: boolean; message: string } {
+		switch (result.outcome) {
+			case 'stored':
+				return { stored: true, message: savedNotice };
+			case 'save-failed':
+				return { stored: false, message: CAPTURE_SAVE_FAILED_NOTICE };
+			case 'torn':
+				// NOT the save-failed notice: that one promises nothing changed,
+				// which is untrue on this path. This one says what did.
+				return { stored: false, message: CAPTURE_TORN_NOTICE };
+			case 'superseded':
+				// The established "say nothing" signal on this path, already used
+				// when the plugin unloads or a newer sign-in owns the credential.
+				return { stored: false, message: '' };
+			case 'unusable':
+				return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
+		}
+	}
+
+	// Probes candidate tokens against Plaud and stores the first one Plaud
+	// accepts (issue #78, 0.35.0). Each probe runs on a THROWAWAY client built
+	// around a closure returning that one candidate: the real client reads
+	// secretStorage, and nothing may be written to storage before it is
+	// validated. The probe is a real API call because Plaud answers auth
+	// failures with HTTP 200 and a negative in-band status, so only the
+	// client's in-band handling can tell acceptance from rejection.
+	//
+	// Returns the Notice text to show, plus whether a token was stored.
+	async storeFirstWorkingCandidate(
+		candidates: readonly string[],
+		// Re-checked immediately before the store, never only before the probe.
+		// Probing is several round-trips, so it reopens the exact window PR #76
+		// closed: a delivery whose flow was cancelled while it ran must not
+		// overwrite a newer sign-in's token. Callers with no such window keep
+		// the default.
+		canStore: () => boolean = () => true,
+		signInMethod: SignInMethod = 'browser',
+		// Region the capture surface already discovered, when it found one. Used
+		// to aim the probes and handed on to the store; deliberately NOT written
+		// to settings on the way in, so a capture that never stores leaves the
+		// configured host untouched.
+		discoveredBaseUrl?: string,
+	): Promise<{ stored: boolean; message: string }> {
+		const probeBaseUrl =
+			discoveredBaseUrl ?? this.host.getSettings().apiBaseUrl;
+		// The region redirect a probe may follow is captured locally instead of
+		// being persisted by the client's own callback: an unvalidated
+		// candidate must not rewrite the configured API host. It is handed to
+		// the store below only for the candidate that is actually stored. Held
+		// on an object so the value written inside the probe closure is read
+		// back correctly after the await.
+		const detected: { baseUrl: string | null } = { baseUrl: null };
+		// Probing several candidates is several round-trips, and the user has
+		// just switched from the browser to Obsidian expecting something to
+		// happen. Say what is happening rather than sitting silent. Given a
+		// finite duration as well as an explicit hide, so an unload mid-probe
+		// cannot strand it.
+		const progress =
+			candidates.length > 1
+				? new Notice(DEEP_LINK_PROBING_NOTICE, 15000)
+				: null;
+		let selection;
+		try {
+			selection = await selectWorkingCandidate(
+				candidates,
+				async (candidate) => {
+					detected.baseUrl = null;
+					await this.host.probeCandidate(
+						candidate,
+						probeBaseUrl,
+						(url) => {
+							detected.baseUrl = url;
+						},
+					);
+				},
+			);
+		} finally {
+			progress?.hide();
+		}
+		// An empty message means "say nothing": the plugin unloaded, or a newer
+		// sign-in owns the credential and this delivery is stale.
+		// Checked here to skip the store entirely, and handed to the store as well,
+		// which re-asks immediately before its commit. This check alone stopped
+		// being binding once the store had an await ahead of its credential write.
+		const stillOwns = (): boolean => !this.host.isDisposed() && canStore();
+		if (!stillOwns()) {
+			return { stored: false, message: '' };
+		}
+		if (selection.outcome === 'none-usable') {
+			return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
+		}
+		if (selection.outcome === 'all-rejected') {
+			return { stored: false, message: DEEP_LINK_ALL_REJECTED_NOTICE };
+		}
+		if (selection.outcome === 'unreachable') {
+			// With several candidates the whole point is choosing between them,
+			// and no claim distinguishes a revoked token from a live one, so a
+			// blind pick would store the wrong credential. With exactly one
+			// there is nothing to choose: store it unverified, which is what
+			// every release before 0.35.0 did, so an offline reconnect still
+			// works.
+			if (selection.usable.length !== 1) {
+				return { stored: false, message: DEEP_LINK_UNREACHABLE_NOTICE };
+			}
+			// Unreachable means nothing was proven, so no redirect was observed
+			// either; the surface's own discovered region is the best available.
+			return this.describeCaptureOutcome(
+				await this.storeAccessToken(
+					selection.usable[0],
+					signInMethod,
+					discoveredBaseUrl,
+					false,
+					stillOwns,
+				),
+				DEEP_LINK_UNVERIFIED_NOTICE,
+			);
+		}
+		// Selected. A 'selected' outcome always carries a token; fail closed
+		// rather than assert it.
+		const token = selection.token;
+		if (token === null) {
+			return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
+		}
+		// Hand the store the regional host this candidate was actually proven
+		// against, so the token and its region are written in one batch. A
+		// redirect followed during probing outranks the surface's own guess.
+		return this.describeCaptureOutcome(
+			await this.storeAccessToken(
+				token,
+				signInMethod,
+				detected.baseUrl ?? discoveredBaseUrl,
+				false,
+				stillOwns,
+			),
+			DEEP_LINK_SAVED_NOTICE,
+		);
+	}
+}

--- a/main.ts
+++ b/main.ts
@@ -42,7 +42,6 @@ import {
 	escapeHtmlAttribute,
 	parseClipboardTokens,
 	parseTokenCandidates,
-	selectWorkingCandidate,
 	buildSignInBookmarklet,
 } from './token-candidates';
 import {
@@ -98,10 +97,12 @@ import {
 	preferWindowForReconnect,
 	type SignInMethod,
 } from './reconnect-routing';
-
-// Stable SecretStorage id for a token captured by the in-app sign-in flow.
-// Re-running sign-in overwrites it, mirroring "replace my token".
-const CAPTURED_SECRET_ID = 'plaud-importer-token';
+import {
+	CaptureStore,
+	CAPTURED_SECRET_ID,
+	CAPTURE_SAVE_FAILED_NOTICE,
+	type CaptureStoreResult,
+} from './capture-store';
 
 // Legacy secret id for the paired refresh token (typ WRT) that pre-0.32.0
 // email sign-ins stored. The refresh subsystem is gone; the secret is only
@@ -112,91 +113,6 @@ const LEGACY_REFRESH_SECRET_ID = 'plaud-importer-refresh-token';
 // Plaud web app, opened in the system browser for the browser-based sign-in
 // flow (where Google/Apple SSO work, unlike an embedded webview).
 const PLAUD_WEB_URL = 'https://web.plaud.ai';
-
-// Explanatory note shown under the "Sign in" heading. Held in a const so it can
-// name Plaud/Google/Apple plainly: the sentence-case lint only inspects string
-// literals written directly at a setText/createEl call, not a referenced const.
-// Deep-link result notices. Held in consts because the strings are shown from
-// two code paths (during a browser reconnect and standalone) and must stay
-// identical; built as variables so the sentence-case lint, which only inspects
-// literals at the call site, accepts the product name mid-sentence.
-const DEEP_LINK_SAVED_NOTICE =
-	'Plaud token received from your browser and saved.';
-const DEEP_LINK_BAD_TOKEN_NOTICE =
-	'Plaud sign-in link did not carry a usable token. In your browser, sign in to Plaud before clicking the bookmarklet, then try again.';
-// Every candidate the browser sent was rejected by Plaud itself, so the
-// browser session is signed out or revoked rather than the link being wrong
-// (issue #78: rogerfsh's 300-day token still decodes cleanly but is revoked).
-const DEEP_LINK_ALL_REJECTED_NOTICE =
-	'Plaud rejected every sign-in token from your browser, so that session looks signed out or revoked. Sign in to Plaud in your browser again, then click the bookmark.';
-// One candidate, and Plaud could not be reached to check it. Storing it
-// unverified matches the pre-0.35.0 behavior and keeps an offline reconnect
-// working; the user finds out from the next import if it was already dead.
-const DEEP_LINK_UNVERIFIED_NOTICE =
-	'Plaud token received from your browser and saved, but Plaud could not be reached to check it. Run Test connection once you are back online.';
-// Shown while several candidates are probed. A const like its siblings so the
-// sentence-case lint, which only inspects literals at the call site, accepts
-// the product name mid-sentence.
-const DEEP_LINK_PROBING_NOTICE = 'Checking which Plaud sign-in still works…';
-// A capture that failed while being SAVED, rather than one the token was wrong
-// for. Every notice above means the credential was the problem; this one means
-// it may well have been fine, so repeating the sign-in is not the fix. The
-// wording names the likely cause as something to check rather than as a
-// diagnosis: the capture path throws opaquely (a settings write is the common
-// source, but not the only one), so asserting "the vault is not writable" would
-// be the same over-claiming this notice exists to stop. Telling the two apart
-// properly needs the result union tracked in issue #86.
-const CAPTURE_SAVE_FAILED_NOTICE =
-	'Plaud: could not save the token. If this keeps happening, check that this vault is writable and has free space.';
-// The one failure that cannot promise "nothing changed": the settings commit
-// landed, the credential write then threw, and writing the old settings back
-// failed too. Signing in again rewrites both halves, so that is the instruction.
-const CAPTURE_TORN_NOTICE =
-	'Plaud: the sign-in was recorded but its credential could not be stored, so the previous session is still in use. Sign in again to finish reconnecting.';
-// Several candidates and no way to ask which one works. Picking blind would
-// store the wrong credential (a revoked long-lived token outranks a live short
-// one on every claim we can read), so store nothing and let the user retry.
-const DEEP_LINK_UNREACHABLE_NOTICE =
-	'Could not reach Plaud to check which sign-in token to use, so nothing was saved. Check your connection, then click the bookmark again.';
-
-/**
- * What storing a captured credential did (issue #86). A boolean could not carry
- * the distinction the issue asks for: a credential the plugin REJECTED is fixed
- * by signing in again, and one it never got to WRITE is not. The second used to
- * arrive only as an opaque throw, so no surface could tell them apart.
- *
- * No outcome here means "partly applied and unreported". "torn" exists for the
- * one sequence that can still half-apply (commit landed, credential write
- * threw, restore write failed too), so even that arrives as a value a surface
- * can explain rather than as an opaque rejection.
- */
-type CaptureStoreResult =
-	/** Failed the pre-write capture guard. Nothing was written. */
-	| { outcome: 'unusable' }
-	/**
-	 * Something took over the credential while this store waited its turn.
-	 * Nothing was written, and nothing should be said: whatever superseded this
-	 * is what the user is holding.
-	 */
-	| { outcome: 'superseded' }
-	/**
-	 * The settings write rejected (read-only vault, full disk, a sync client
-	 * holding the file), or the credential write threw and the settings were
-	 * rolled back. Either way nothing is changed. Carries the cause for
-	 * logging; surfaces show CAPTURE_SAVE_FAILED_NOTICE rather than the raw
-	 * error.
-	 */
-	| { outcome: 'save-failed'; error: unknown }
-	/**
-	 * The settings commit landed, the credential write then threw, and writing
-	 * the previous settings back failed too. data.json names this capture
-	 * while the secret still holds the previous credential; the previous
-	 * session keeps working in memory. Signing in again rewrites both sides,
-	 * so surfaces show CAPTURE_TORN_NOTICE, which says exactly that. Carries
-	 * the credential write's cause.
-	 */
-	| { outcome: 'torn'; error: unknown }
-	| { outcome: 'stored' };
 
 /**
  * What a re-authentication attempt did. Needed because turning a save failure
@@ -886,10 +802,44 @@ export default class PlaudImporterPlugin extends Plugin {
 	// entry point (settings, the auth-pause notice, the backfill retry), so
 	// stacked stale notices cannot launch clobbering capture sessions.
 	private reauthInFlight = false;
-	// Tail of the capture-store queue. Scoped to captures only: it exists to
-	// restore the call ordering that committing settings before the credential
-	// would otherwise break, not to serialize settings writes generally (#86).
-	private captureStoreChain: Promise<unknown> = Promise.resolve();
+	// Turns a candidate credential into a stored one, and owns the capture queue
+	// that keeps concurrent captures in call order (#86). Built here rather than
+	// in onload so it exists before any deep link can arrive; every dependency
+	// below is read at call time, so none of them need to be ready yet.
+	private readonly captureStore = new CaptureStore<PlaudImporterSettings>({
+		// Re-read on every use: loadSettings REPLACES the settings object, so a
+		// reference taken here would be the pre-load default forever after.
+		getSettings: () => this.settings,
+		setSecret: (id, secret) => this.app.secretStorage.setSecret(id, secret),
+		saveData: (data) => this.saveData(data),
+		isDisposed: () => this.disposed,
+		clearStoredRefreshToken: () => this.clearStoredRefreshToken(),
+		clearRefreshFailure: () => {
+			this.sessionRefreshFailed = false;
+		},
+		noteShortLifetimeOnCapture: (token, signInMethod) =>
+			this.noteShortLifetimeOnCapture(token, signInMethod),
+		reconcileSessionExpiryWarning: () =>
+			this.reconcileSessionExpiryWarning(),
+		reconcileSessionRefresh: () => this.reconcileSessionRefresh(),
+		// Read at call time, so a tab closed mid-store is simply null.
+		redrawSettings: () => this.settingsRefresh?.(),
+		// A THROWAWAY client per probe, built around a closure returning that one
+		// candidate: the real client reads secretStorage, and nothing may be
+		// written to storage before it is validated.
+		probeCandidate: async (token, baseUrl, onBaseUrlChanged) => {
+			const probe = new ReverseEngineeredPlaudClient(
+				() => token,
+				obsidianFetcher,
+				{
+					debugLogger: this.debugLogger,
+					baseUrl,
+					onBaseUrlChanged,
+				},
+			);
+			await probe.listRecordings({ limit: 1 });
+		},
+	});
 	// Redraws the open settings tab's sign-in status and secret picker. Set by
 	// the tab's display() (the pre-1.13 imperative path; 1.13+ renders
 	// declaratively and re-reads on its own) and cleared by its hide(), so it
@@ -1565,7 +1515,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			// there is cheaper than queueing and then discarding.
 			let stored: CaptureStoreResult;
 			try {
-				stored = await this.storeAccessToken(
+				stored = await this.captureStore.storeAccessToken(
 					result.token,
 					'window',
 					result.apiBaseUrl ?? undefined,
@@ -3504,7 +3454,7 @@ export default class PlaudImporterPlugin extends Plugin {
 			// probing. Passing it down means the host lands in settings only
 			// alongside a credential that actually stored, so there is no window
 			// to unwind and nothing to race.
-			const outcome = await this.storeFirstWorkingCandidate(
+			const outcome = await this.captureStore.storeFirstWorkingCandidate(
 				result.tokens,
 				() => !this.disposed,
 				'window',
@@ -3566,7 +3516,7 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 		// The same guard again, because the probe between here and the store is
 		// a second, longer chance for this paste to go stale.
-		const result = await this.storeFirstWorkingCandidate(
+		const result = await this.captureStore.storeFirstWorkingCandidate(
 			candidates,
 			canStore,
 		);
@@ -3631,416 +3581,6 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 	}
 
-	// Validates a raw token value (the long-lived user token, optionally bearer-
-	// prefixed) and, if valid, stores it in the captured-token secret and links
-	// it. Overwrites the same secret each time, so replacing a token never
-	// requires creating or deleting a secret. Returns false without changing
-	// anything when the value fails the capture guard (payload must carry a
-	// client_id and a still-future exp). Shared by the browser deep-link handler
-	// and the clipboard-paste button.
-	async storeAccessToken(
-		rawToken: string,
-		// Which surface captured this credential. Reconnect reopens the same one,
-		// so the embedded window must record "window" even though it now shares
-		// the browser path's probe-and-select machinery.
-		signInMethod: SignInMethod = 'browser',
-		// The API origin this credential belongs to, when the capture surface
-		// discovered one. Applied HERE, in the same mutation batch as the token,
-		// rather than by the caller beforehand: a host written ahead of the
-		// store outlives a store that then fails, leaving the new region paired
-		// with the old credential. A token and the region it is valid for move
-		// together or not at all.
-		apiBaseUrl?: string,
-		// True when this store came from the unattended refresh rather than a
-		// user action. Suppresses the capture-time notices: the short-lifetime
-		// heads-up is written for someone who just finished signing in, and on
-		// the ~22 hour refresh cycle it would pop a 12 second notice saying the
-		// plugin will ask them to sign in again, which is both noisy and, for a
-		// refresh that just succeeded, wrong. A silent path that announces
-		// itself every cycle is not silent.
-		background = false,
-		// Re-checked immediately before the commit, for callers whose right to
-		// store can lapse while they wait: a cancelled reconnect flow, or a
-		// background refresh whose credential the user has since replaced. Their
-		// own checks run BEFORE this call, and this method now has an await ahead
-		// of the credential write, so a check made out there is not binding by the
-		// time the write happens. Callers with nothing to go stale keep the
-		// default.
-		stillOwns: () => boolean = () => true,
-	): Promise<CaptureStoreResult> {
-		const token = rawToken.trim().replace(/^bearer\s+/i, '');
-		if (token.length === 0 || !isUsableUserToken(token)) {
-			return { outcome: 'unusable' };
-		}
-		// Serialized, and ONLY this method is. The old store wrote the secret with
-		// a synchronous setSecret before its await, so credentials landed in CALL
-		// order however the saves interleaved. Committing settings first puts an
-		// await between a caller's decision and its credential write, so without
-		// this a store that STARTED earlier could FINISH later and overwrite a
-		// newer one: a background refresh mid-save when the user pastes a token.
-		// The queue exists to restore the ordering this reorder breaks, nothing
-		// more, so it is scoped to captures rather than to settings writes at
-		// large.
-		return this.serializeCaptureStore(() =>
-			this.commitCapturedToken(
-				token,
-				signInMethod,
-				apiBaseUrl,
-				background,
-				stillOwns,
-			),
-		);
-	}
-
-	/** Runs capture stores one at a time, in the order they were called. */
-	private serializeCaptureStore(
-		work: () => Promise<CaptureStoreResult>,
-	): Promise<CaptureStoreResult> {
-		// Both handlers run `work`: a predecessor that failed still had its turn,
-		// and a queue that stopped on the first failure would strand every later
-		// capture behind it.
-		const run = this.captureStoreChain.then(work, work);
-		// The chain must never carry a rejection forward, or one throwing store
-		// would reject every store queued after it. Successors wait for this one to
-		// FINISH, not to succeed; the result still reaches its own caller.
-		this.captureStoreChain = run.then(
-			() => undefined,
-			() => undefined,
-		);
-		return run;
-	}
-
-	/**
-	 * The store itself, always run through the queue above. `token` has already
-	 * passed the capture guard and been trimmed.
-	 */
-	private async commitCapturedToken(
-		token: string,
-		signInMethod: SignInMethod,
-		apiBaseUrl: string | undefined,
-		background: boolean,
-		stillOwns: () => boolean,
-	): Promise<CaptureStoreResult> {
-		// The queue guarantees order, not relevance. This caller may have waited
-		// while a newer capture took over, and its own guard was evaluated before
-		// it joined. Re-ask now, with nothing yet written.
-		if (!stillOwns()) {
-			return { outcome: 'superseded' };
-		}
-		// THE SETTINGS WRITE IS THE COMMIT POINT, AND IT RUNS FIRST (issue #86).
-		//
-		// It used to run last, after `setSecret` had already put the credential on
-		// disk. `setSecret` is a synchronous void call (obsidian.d.ts: `setSecret(
-		// id: string, secret: string): void`), so it persists the moment it is
-		// called and there is no promise to fail. The awaited settings save right
-		// after it CAN fail, for ordinary reasons: a vault on read-only storage, a
-		// full disk, a sync client holding data.json. When it did, the new
-		// credential was already durably stored under the same id the old one used
-		// while data.json still named the old region and sign-in method, and that
-		// mismatch survived a restart.
-		//
-		// Unwinding the secret afterwards is the obvious fix and it is the wrong
-		// one. Three attempts were each faulted correctly, the last because the
-		// capture surfaces are not serialized against each other, so an unwind can
-		// undo whichever capture finished last: the one the user is holding.
-		//
-		// Doing the failable write first removes the unwind instead of trying to
-		// make one safe. Until `saveData` resolves nothing is mutated: not the
-		// secret, not `this.settings`, not the file. A rejection is a clean no-op,
-		// which is what lets CAPTURE_SAVE_FAILED_NOTICE promise nothing changed.
-		//
-		// KNOWN, ACCEPTED RESIDUAL, and the one thing this reorder makes worse
-		// rather than better. Everything below hangs on one fact: `this.settings`
-		// still holds the OLD auth fields until the commit resolves, because they
-		// are applied only after it. So during that window:
-		//
-		// - Clear sign-in or the token picker can run. This method then resumes
-		//   and re-links its own credential, undoing a sign-out the user asked
-		//   for. The old synchronous store had already written by then, so the
-		//   sign-out won.
-		// - An ordinary saveSettings() from any settings control writes the stale
-		//   auth fields. If it lands after this commit, disk names the old sign-in
-		//   while the secret holds the new token, which is this bug's own shape
-		//   arriving from the other side.
-		//
-		// The queue above covers captures against each other and nothing else, on
-		// purpose. Closing these two needs every settings write and credential
-		// mutation to share one ordering protocol, which is a change to the whole
-		// plugin rather than to this method, with a much wider blast radius than
-		// the defect being fixed. It belongs in its own issue and its own review.
-		//
-		// The trade, stated so it can be argued with: both windows are the
-		// duration of one file write, both need a competing action inside those
-		// few milliseconds, and both are recoverable by repeating the action. What
-		// they buy is the removal of a failure that anyone on a read-only or full
-		// vault hit every single time, silently, and permanently.
-		//
-		// Residual, stated plainly: a crash between the commit and `setSecret`
-		// leaves data.json naming the new region and method with the previous
-		// token. Closing that needs a fresh secret id per capture and a pointer
-		// swap; rejected because SecretStorage has no delete (see clearSignIn) and
-		// the settings token picker lists every id, so each orphan is permanent
-		// and user-visible. A crash window one synchronous step wide, worst case a
-		// one-generation-stale credential and a reconnect prompt, against a
-		// failure reproducible on any read-only vault whose worst case was silent,
-		// restart-surviving corruption. A THROWN credential write is not part of
-		// this residual: it is caught below, the settings are written back, and
-		// only when even that restore fails does it surface, as a reported
-		// `torn` outcome rather than silence. What remains is the hard crash.
-		const next: PlaudImporterSettings = {
-			...this.settings,
-			secretId: CAPTURED_SECRET_ID,
-			// A pasted/deep-linked token came through the browser flow. Record that
-			// so Reconnect routes there.
-			signInMethod,
-		};
-		if (apiBaseUrl !== undefined) {
-			next.apiBaseUrl = apiBaseUrl;
-		}
-		try {
-			await this.saveData(next);
-		} catch (err) {
-			console.error(
-				'Plaud importer: could not save the captured sign-in',
-				err,
-			);
-			return { outcome: 'save-failed', error: err };
-		}
-		// The credential write CAN THROW: this file treats setSecret as throwable
-		// everywhere else it writes one (clearSignIn, clearStoredRefreshToken).
-		// Left bare here, a backing store that refused the write would recreate
-		// the tear this method exists to prevent, from the other side: data.json
-		// naming a sign-in whose credential never landed. It runs BEFORE the
-		// in-memory fields are applied, so on failure memory still describes the
-		// credential that survives.
-		try {
-			this.app.secretStorage.setSecret(CAPTURED_SECRET_ID, token);
-		} catch (err) {
-			console.error(
-				'Plaud importer: could not store the captured credential',
-				err,
-			);
-			// The commit above already landed, so write the previous settings
-			// back. A rollback is safe HERE and nowhere else: this store holds
-			// the capture queue, so no other capture can interleave with it,
-			// which is exactly what faulted the three pre-#97 rollback attempts.
-			// `this.settings` is untouched at this point and still describes the
-			// surviving credential, concurrent non-capture edits included.
-			try {
-				await this.saveData({ ...this.settings });
-			} catch (restoreErr) {
-				console.error(
-					'Plaud importer: could not restore settings after the credential write failed',
-					restoreErr,
-				);
-				return { outcome: 'torn', error: err };
-			}
-			return { outcome: 'save-failed', error: err };
-		}
-		// Committed. Apply the fields this capture owns to the live settings object
-		// rather than swapping in `next` wholesale: `next` was snapshotted before
-		// the await, so adopting it would silently revert an unrelated setting the
-		// user changed while the write was in flight.
-		this.settings.secretId = next.secretId;
-		this.settings.signInMethod = next.signInMethod;
-		if (apiBaseUrl !== undefined) {
-			this.settings.apiBaseUrl = apiBaseUrl;
-		}
-		// Blank any legacy WRT from a previous session so it cannot shadow the
-		// recorded method. After the commit, like the credential: a capture that
-		// never stored must not clear the session it failed to replace.
-		this.clearStoredRefreshToken();
-		// A newly stored credential clears any prior refresh failure: whatever
-		// was wrong, the user just replaced the thing that was failing.
-		this.sessionRefreshFailed = false;
-		// Everything below is bookkeeping about a store that has already
-		// succeeded. A throw in it must not escape, or the caller reports a
-		// save failure for a credential that is durably linked; the redraw
-		// guard this generalizes existed for exactly that reason. Each call is
-		// guarded ALONE, because they are independent: one failing must not
-		// skip the rest, or a stored credential is left without its renewal
-		// timer or with a stale settings tab.
-		const guarded = (what: string, run: () => void): void => {
-			try {
-				run();
-			} catch (err) {
-				console.error(
-					`Plaud importer: ${what} after a stored capture failed`,
-					err,
-				);
-			}
-		};
-		if (!background) {
-			guarded('short-lifetime notice', () =>
-				this.noteShortLifetimeOnCapture(token, signInMethod),
-			);
-		}
-		guarded('expiry-warning reconcile', () =>
-			this.reconcileSessionExpiryWarning(),
-		);
-		guarded('session-refresh reconcile', () =>
-			this.reconcileSessionRefresh(),
-		);
-		// A deep link can land while the settings tab is open, which is exactly
-		// what the one-click bookmark encourages: launch sign-in from settings,
-		// click the bookmark, come back. Redraw the status line and secret
-		// picker so the tab does not keep saying "not connected yet". Read at
-		// call time, so a tab closed during the await above is simply null.
-		guarded('settings redraw', () => this.settingsRefresh?.());
-		return { outcome: 'stored' };
-	}
-
-	/**
-	 * Renders a store outcome as the {stored, message} pair the capture surfaces
-	 * show, so a save failure cannot be reported as a bad token on one path and
-	 * correctly on another. `savedNotice` differs per path (a probed capture and
-	 * an unverified one say different things), so it is passed in.
-	 */
-	private describeCaptureOutcome(
-		result: CaptureStoreResult,
-		savedNotice: string,
-	): { stored: boolean; message: string } {
-		switch (result.outcome) {
-			case 'stored':
-				return { stored: true, message: savedNotice };
-			case 'save-failed':
-				return { stored: false, message: CAPTURE_SAVE_FAILED_NOTICE };
-			case 'torn':
-				// NOT the save-failed notice: that one promises nothing changed,
-				// which is untrue on this path. This one says what did.
-				return { stored: false, message: CAPTURE_TORN_NOTICE };
-			case 'superseded':
-				// The established "say nothing" signal on this path, already used
-				// when the plugin unloads or a newer sign-in owns the credential.
-				return { stored: false, message: '' };
-			case 'unusable':
-				return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
-		}
-	}
-
-	// Probes candidate tokens against Plaud and stores the first one Plaud
-	// accepts (issue #78, 0.35.0). Each probe runs on a THROWAWAY client built
-	// around a closure returning that one candidate: the real client reads
-	// secretStorage, and nothing may be written to storage before it is
-	// validated. The probe is a real API call because Plaud answers auth
-	// failures with HTTP 200 and a negative in-band status, so only the
-	// client's in-band handling can tell acceptance from rejection.
-	//
-	// Returns the Notice text to show, plus whether a token was stored.
-	private async storeFirstWorkingCandidate(
-		candidates: readonly string[],
-		// Re-checked immediately before the store, never only before the probe.
-		// Probing is several round-trips, so it reopens the exact window PR #76
-		// closed: a delivery whose flow was cancelled while it ran must not
-		// overwrite a newer sign-in's token. Callers with no such window keep
-		// the default.
-		canStore: () => boolean = () => true,
-		signInMethod: SignInMethod = 'browser',
-		// Region the capture surface already discovered, when it found one. Used
-		// to aim the probes and handed on to the store; deliberately NOT written
-		// to settings on the way in, so a capture that never stores leaves the
-		// configured host untouched.
-		discoveredBaseUrl?: string,
-	): Promise<{ stored: boolean; message: string }> {
-		const probeBaseUrl = discoveredBaseUrl ?? this.settings.apiBaseUrl;
-		// The region redirect a probe may follow is captured locally instead of
-		// being persisted by the client's own callback: an unvalidated
-		// candidate must not rewrite the configured API host. It is handed to
-		// the store below only for the candidate that is actually stored. Held
-		// on an object so the value written inside the probe closure is read
-		// back correctly after the await.
-		const detected: { baseUrl: string | null } = { baseUrl: null };
-		// Probing several candidates is several round-trips, and the user has
-		// just switched from the browser to Obsidian expecting something to
-		// happen. Say what is happening rather than sitting silent. Given a
-		// finite duration as well as an explicit hide, so an unload mid-probe
-		// cannot strand it.
-		const progress =
-			candidates.length > 1
-				? new Notice(DEEP_LINK_PROBING_NOTICE, 15000)
-				: null;
-		let selection;
-		try {
-			selection = await selectWorkingCandidate(
-				candidates,
-				async (candidate) => {
-					detected.baseUrl = null;
-					const probe = new ReverseEngineeredPlaudClient(
-						() => candidate,
-						obsidianFetcher,
-						{
-							debugLogger: this.debugLogger,
-							baseUrl: probeBaseUrl,
-							onBaseUrlChanged: (url) => {
-								detected.baseUrl = url;
-							},
-						},
-					);
-					await probe.listRecordings({ limit: 1 });
-				},
-			);
-		} finally {
-			progress?.hide();
-		}
-		// An empty message means "say nothing": the plugin unloaded, or a newer
-		// sign-in owns the credential and this delivery is stale.
-		// Checked here to skip the store entirely, and handed to the store as well,
-		// which re-asks immediately before its commit. This check alone stopped
-		// being binding once the store had an await ahead of its credential write.
-		const stillOwns = (): boolean => !this.disposed && canStore();
-		if (!stillOwns()) {
-			return { stored: false, message: '' };
-		}
-		if (selection.outcome === 'none-usable') {
-			return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
-		}
-		if (selection.outcome === 'all-rejected') {
-			return { stored: false, message: DEEP_LINK_ALL_REJECTED_NOTICE };
-		}
-		if (selection.outcome === 'unreachable') {
-			// With several candidates the whole point is choosing between them,
-			// and no claim distinguishes a revoked token from a live one, so a
-			// blind pick would store the wrong credential. With exactly one
-			// there is nothing to choose: store it unverified, which is what
-			// every release before 0.35.0 did, so an offline reconnect still
-			// works.
-			if (selection.usable.length !== 1) {
-				return { stored: false, message: DEEP_LINK_UNREACHABLE_NOTICE };
-			}
-			// Unreachable means nothing was proven, so no redirect was observed
-			// either; the surface's own discovered region is the best available.
-			return this.describeCaptureOutcome(
-				await this.storeAccessToken(
-					selection.usable[0],
-					signInMethod,
-					discoveredBaseUrl,
-					false,
-					stillOwns,
-				),
-				DEEP_LINK_UNVERIFIED_NOTICE,
-			);
-		}
-		// Selected. A 'selected' outcome always carries a token; fail closed
-		// rather than assert it.
-		const token = selection.token;
-		if (token === null) {
-			return { stored: false, message: DEEP_LINK_BAD_TOKEN_NOTICE };
-		}
-		// Hand the store the regional host this candidate was actually proven
-		// against, so the token and its region are written in one batch. A
-		// redirect followed during probing outranks the surface's own guess.
-		return this.describeCaptureOutcome(
-			await this.storeAccessToken(
-				token,
-				signInMethod,
-				detected.baseUrl ?? discoveredBaseUrl,
-				false,
-				stillOwns,
-			),
-			DEEP_LINK_SAVED_NOTICE,
-		);
-	}
-
 	// Handles obsidian://plaud-importer-token deep links from the browser
 	// sign-in bookmarklet. Reads the 0.35.0 `tokens` candidate list and the
 	// legacy single `token` parameter, so a bookmark the user has not re-added
@@ -4075,7 +3615,7 @@ export default class PlaudImporterPlugin extends Plugin {
 				// was merely cancelled (nothing owns sign-in now) still stores,
 				// which is the behavior every release before 0.35.0 had: the
 				// user did just sign in, and the fall-through below reports it.
-				result = await this.storeFirstWorkingCandidate(
+				result = await this.captureStore.storeFirstWorkingCandidate(
 					candidates,
 					() =>
 						this.browserReconnect === null ||
@@ -4104,7 +3644,8 @@ export default class PlaudImporterPlugin extends Plugin {
 			new Notice(result.message);
 			return;
 		}
-		const result = await this.storeFirstWorkingCandidate(candidates);
+		const result =
+			await this.captureStore.storeFirstWorkingCandidate(candidates);
 		if (result.stored) {
 			// Outside the reconnect flow a fresh token still means the session
 			// is back; a paused auto-sync should not wait for its next trigger.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"package:brat": "npm run build && node package-brat.mjs",
-		"lint": "eslint main.ts plaud-client.ts plaud-client-re.ts plaud-login.ts plaud-partition.ts plaud-refresh-net.ts refresh-schedule.ts reconnect-routing.ts plaud-token.ts session-expiry.ts token-candidates.ts import-core.ts import-modal.ts import-runner.ts attachment-importer.ts note-writer.ts folder-catalog.ts debug-logger.ts vault-index.ts __tests__/plaud-client-re.test.ts __tests__/plaud-token.test.ts __tests__/plaud-login-origin.test.ts __tests__/plaud-login-probe.test.ts __tests__/plaud-partition.test.ts __tests__/plaud-refresh-net.test.ts __tests__/refresh-schedule.test.ts __tests__/reconnect-routing.test.ts __tests__/session-expiry.test.ts __tests__/token-candidates.test.ts __tests__/summary-metadata.test.ts __tests__/import-modal.test.ts __tests__/import-runner.test.ts __tests__/note-writer.test.ts __tests__/folder-catalog.test.ts __tests__/attachment-importer.test.ts __tests__/debug-logger.test.ts __tests__/vault-index.test.ts __tests__/main-notice-lifecycle.test.ts __tests__/main-capture-save-failure.test.ts __tests__/main-capture-atomicity.test.ts __tests__/__mocks__/obsidian.ts --max-warnings 0 && prettier --check \"*.ts\" \"__tests__/**/*.ts\" && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
+		"lint": "eslint . --max-warnings 0 && prettier --check \"**/*.ts\" && node scripts/check-submission.mjs && node scripts/check-icons.mjs",
 		"test": "jest --passWithNoTests",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},


### PR DESCRIPTION
First extraction in the `main.ts` split agreed after the 0.37.0 quality review. Design note: `dev-docs/plaud-importer/2026-08-02-main-ts-split-design.md` (private workspace).

`main.ts` was 6,143 lines and is the plugin's one structural debt. This PR moves the capture store out of it: the five methods that turn a candidate credential into a stored one.

## What moved

`storeAccessToken`, `serializeCaptureStore`, `commitCapturedToken`, `describeCaptureOutcome` and `storeFirstWorkingCandidate` go to `capture-store.ts`, with `CaptureStoreResult`, `CAPTURED_SECRET_ID` and the capture notice strings. Code and comments move verbatim: those comments record the settled outcome of #86 and three rejected rollback designs.

`main.ts`: 6,143 -> 5,684 lines.

The capture SURFACES stay behind for now (`reauthenticate`, `pasteTokenFromClipboard`, `handleTokenDeepLink`, `clearSignIn`). They each also touch the reconnect flow, auto-sync and the modal stack, so they are their own PR.

## The seam

The store reaches the plugin only through `CaptureStoreHost`, named one call at a time rather than as `plugin: PlaudImporterPlugin`. Passing the plugin would have moved the lines and kept the coupling. Two points worth review attention:

- **`getSettings()` is a method, not a property.** `loadSettings` REPLACES the settings object, so a reference captured at construction would be the pre-load default forever. Every read is live, which is what the commit's "apply to the live object, not the pre-await snapshot" rule depends on.
- **`probeCandidate` is a host call.** The store carries no transport dependency and its tests need no client mock.

## Why it is worth doing

`main-capture-atomicity.test.ts` built its subject with `Object.create(PlaudImporterPlugin.prototype)`, which builds the prototype chain but runs no field initializers. Every field the store touched had to be hand-seeded, and a field added later read as `undefined` rather than failing. The suite now constructs a real `CaptureStore` over a stub host. Same 24 tests, same assertions.

Also folds in CodeRabbit's PR #97 nit: the torn path asserts both `console.error` calls. That path shows a notice that says nothing about why, so the log is the only record of the two failures behind it.

## Second commit

`chore: lint every file, not a hand-kept list`. The lint script enumerated its inputs by hand, so five files had never been linted: `auto-sync.ts`, `auto-sync-runner.ts`, and the auto-sync, auto-sync-runner and import-core test suites. They were clean, but nothing was checking. `eslint .` plus the config's own ignores now covers 47 files, up from 42. Done first so extracted modules are covered the moment they exist.

## Verification

- No behavior change. Verified by normalizing the moved methods against their originals at `HEAD`: every difference is comment rewording, the generic type parameter, the host seam, or Prettier wrapping.
- 1,209 tests pass, unchanged count.
- `npm run lint`, `npm run build` green.

## NOT verified, and out of scope here

0.37.0's live sign-in verification is still outstanding, and this PR refactors that path. The two do not share a build: the released 0.37.0 is what gets verified and is unaffected by this branch. But **0.38.0 must not be cut off this refactor until that verification happens.**