### PR TITLE
Fix the template-token ReDoS in note-writer

### DIFF
--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -646,6 +646,33 @@ describe('formatNoteName', () => {
 			'Notes {{draft}}',
 		);
 	});
+
+	// CodeQL js/polynomial-redos, two highs. The token regex used to exclude
+	// only `}` from its inner class, so a run of `{` made the engine start a
+	// match at every one of them and scan to the end before failing: quadratic
+	// in the template's length. Templates are user settings, so the input
+	// arrives from data.json.
+	it('does not degrade quadratically on a template of many open braces', () => {
+		// 40k braces. Under the old pattern this is ~800M character
+		// comparisons and takes seconds; under the new one it is linear.
+		// The assertion is the wall clock, so the threshold is loose enough
+		// not to flake on a loaded CI box but far below the old behavior.
+		const hostile = '{'.repeat(40000);
+		const started = Date.now();
+		expect(() => formatNoteName(hostile, d, 'X')).not.toThrow();
+		expect(Date.now() - started).toBeLessThan(1000);
+	});
+
+	it('reads a doubled brace as the literal it is, not as part of the token', () => {
+		// Excluding `{` from the token body changed this, for the better. The
+		// old pattern matched from the FIRST brace with an inner value of
+		// "{{YYYY", which Moment rendered as garbage. The token is now the
+		// well-formed pair and the strays stay literal.
+		expect(formatNoteName('{{{{YYYY}}', d, 'X')).toBe('{{2026');
+		// A brace inside an otherwise well-formed token means the token is not
+		// well-formed, so none of it is substituted.
+		expect(formatNoteName('{{YY{YY}}', d, 'X')).toBe('{{YY{YY}}');
+	});
 });
 
 // isValidNoteNameTemplate ---------------------------------------------------

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -520,6 +520,33 @@ function formatDateYmd(d: Date): string {
 }
 
 /**
+ * One `{{token}}`. Four places in this file used to spell this out separately,
+ * as `/\{\{([^}]*)\}\}/`; one definition now, so a change to what counts as a
+ * token cannot land in three of them.
+ *
+ * The inner class excludes `{` as well as `}`, which is what closes two CodeQL
+ * `js/polynomial-redos` highs. With only `}` excluded, a template of many `{`
+ * makes the engine start a match attempt at every one of them, scan the rest of
+ * the string, and fail: quadratic in the template's length. Templates are user
+ * settings, so the input is attacker-controlled in the sense the rule means (a
+ * pasted or synced `data.json`), even if the attacker is usually just a typo.
+ *
+ * Excluding `{` also fixes what a malformed template did. `{{{{YYYY}}` used to
+ * match from the first brace with an inner value of `{{YYYY`, which Moment
+ * formatted as garbage; it now matches `{{YYYY}}` at offset 2 and leaves the
+ * stray braces as the literal text they are. No well-formed template changes:
+ * the token body is a Moment format string, and Moment escapes literals with
+ * `[square brackets]`, never braces.
+ *
+ * A factory rather than a shared `RegExp`, so no call site can be affected by
+ * another's `lastIndex`.
+ */
+const TEMPLATE_TOKEN_PATTERN = '\\{\\{([^{}]*)\\}\\}';
+function templateTokenRe(flags = 'g'): RegExp {
+	return new RegExp(TEMPLATE_TOKEN_PATTERN, flags);
+}
+
+/**
  * Expand a `{{...}}` template against a date using real Moment.js formatting.
  * The content INSIDE each `{{}}` is a Moment format string, so a single pair can
  * hold a whole date layout (`{{YYYY-MM-DD - dddd}}`) or several tokens with their
@@ -558,7 +585,7 @@ function expandDateTemplate(
 	// off no-unnecessary-type-assertion.
 	const m = (moment as typeof import('moment'))(date).locale('en');
 	return template.replace(
-		/\{\{([^}]*)\}\}/g,
+		templateTokenRe(),
 		(_match, raw: string): string => {
 			const inner = raw.trim();
 			if (title !== undefined && inner === 'title') {
@@ -681,7 +708,7 @@ export function resolveSubfolder(
 		return '';
 	}
 	const dateValid = date instanceof Date && !Number.isNaN(date.getTime());
-	if (!dateValid && /\{\{[^}]*\}\}/.test(template)) {
+	if (!dateValid && templateTokenRe('').test(template)) {
 		return '_undated';
 	}
 	// {{title}} support (issue #30 follow-up): strip a leading date from the title
@@ -943,13 +970,10 @@ const LEGACY_TOKEN_MIGRATION: ReadonlyMap<string, string> = new Map([
  * never throws, so a hand-edited bad template cannot block settings load.
  */
 export function migrateLegacyDateTemplate(template: string): string {
-	return template.replace(
-		/\{\{([^}]*)\}\}/g,
-		(match, raw: string): string => {
-			const mapped = LEGACY_TOKEN_MIGRATION.get(raw.trim());
-			return mapped === undefined ? match : `{{${mapped}}}`;
-		},
-	);
+	return template.replace(templateTokenRe(), (match, raw: string): string => {
+		const mapped = LEGACY_TOKEN_MIGRATION.get(raw.trim());
+		return mapped === undefined ? match : `{{${mapped}}}`;
+	});
 }
 
 /**
@@ -1363,7 +1387,7 @@ export function expandCustomFrontmatterValue(
 	// the Moment date engine. The moment cast mirrors expandDateTemplate: it pins
 	// the factory to moment's own type at the marketplace type-check boundary.
 	const m = (moment as typeof import('moment'))(ctx.date).locale('en');
-	return value.replace(/\{\{([^}]*)\}\}/g, (_match, raw: string): string => {
+	return value.replace(templateTokenRe(), (_match, raw: string): string => {
 		const inner = raw.trim();
 		if (Object.prototype.hasOwnProperty.call(content, inner)) {
 			return content[inner];


### PR DESCRIPTION
Closes both open CodeQL `js/polynomial-redos` highs.

## The bug

The template-token regex excluded only `}` from the token body:

```js
/\{\{([^}]*)\}\}/g
```

A template of many `{` makes the engine start a match attempt at every one of them, scan the rest of the string, and fail. Quadratic in the template's length.

Measured on 40,000 open braces:

| pattern | time |
|---|---|
| `[^}]` (old) | **2,567 ms** |
| `[^{}]` (new) | **0 ms** |

Templates are user settings read from `data.json`, which is the sense in which CodeQL calls the input attacker-controlled, even when the attacker is a typo or a bad sync.

## The other half of the fix

Excluding `{` also corrects what malformed templates did. `{{{{YYYY}}` used to match from the *first* brace with an inner value of `{{YYYY`, which Moment rendered as garbage. It now matches the well-formed `{{YYYY}}` and leaves the strays as the literal text they are.

**No well-formed template changes.** A token body is a Moment format string, and Moment escapes literals with `[square brackets]`, never braces.

## Four copies, one definition

The same regex was spelled out in four places, which is exactly how a fix like this lands in three of them. Collapsed to one factory with the reasoning in one place. A factory rather than a shared `RegExp` so no call site can be affected by another's `lastIndex`.

## Tests

Two added:

- The hostile input under a wall-clock bound. **Verified non-vacuous** — it fails against the old pattern.
- The malformed-template behavior, pinning the improvement rather than leaving it undocumented.

1,213 tests pass. Lint, type-check and build green.