### PR TITLE
Add the Discord link and a funding link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Plaud Importer will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **A Discord link in the settings footer and the README.** Questions, ideas, and general discussion now have somewhere to go that is not a GitHub issue. The invite never expires. A GitHub issue is still the better home for anything that needs tracking.
+- **A funding link.** Obsidian shows it beside the plugin in Community plugins for anyone who wants to support the work. Entirely optional and it changes nothing about how the plugin behaves.
+
+### Fixed
+
+- **Template names with stray braces no longer misbehave.** A note-name or folder template containing an unmatched `{`, for example `{{{{YYYY}}`, was read starting from the first brace, so the plugin fed the date formatter a nonsense pattern and put garbage in your filename. It now reads the well-formed `{{YYYY}}` and leaves the stray braces as the plain text they are. A template with a long run of `{` characters could also make the plugin hang for seconds while it worked through them; that is now instant.
+- **The description of "Keep AI keywords as note property" is the same on every Obsidian version.** The settings tab renders through two different code paths depending on your Obsidian version, and the one used by 1.12 was missing the sentence explaining why the toggle is off by default. Both now show the full description.
+- **The links in the settings footer no longer run together.** The separators between them depended on plain whitespace, which the layout dropped, so the row could read `GitHub|Report issues`. They are spaced by the layout now.
+
 ## [0.37.0] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ See [PRIVACY.md](./PRIVACY.md) for the full privacy policy and liability disclai
 - **Import silently "skipped"** — your duplicate handling was set to Skip and the note already existed. Switch to **Ask each time** (default since 0.2.0) or **Overwrite**.
 - **A brand-new recording will not import yet.** A recording does not become available to import until you have opened Plaud (web or app) and its cloud has finished finalizing the recording. Until then the plugin cannot see it. Open Plaud, let it finish processing, then run the import again. This is a Plaud-side step, not a plugin limitation.
 
+## Community
+
+Questions, ideas, and general discussion happen on [Discord](https://discord.gg/gd6tKJDPj4). For anything that needs tracking, a GitHub issue is still the better home.
+
 ## Support and issues
 
 Please report bugs and feature requests at [github.com/ckelsoe/obsidian-plaud-importer/issues](https://github.com/ckelsoe/obsidian-plaud-importer/issues). Include:

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
 	"description": "Import meeting summaries, transcripts, and attachments from Plaud.AI into your vault.",
 	"author": "Charles Kelsoe (ckelsoe)",
 	"authorUrl": "https://github.com/ckelsoe",
+	"fundingUrl": "https://buymeacoffee.com/ckelsoe",
 	"isDesktopOnly": true
 }

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -355,6 +355,12 @@ const DATETIME_TEMPLATE_FOOTNOTE =
 const CLEAR_SIGN_IN_DESC =
 	'Sign out of the embedded Plaud browser for this vault and wipe the stored token so the next sign-in starts completely fresh. Other vaults keep their own sign-ins. This also removes the older shared sign-in left over from before each vault had its own. Use this to reach the sign-in screen when it keeps signing you in automatically. Obsidian has no way to delete the secret entry, so an emptied one may stay in the token picker, but it holds no token.';
 
+// Community discussion for this plugin. This must stay a never-expiring
+// discord.gg invite. A discord.com/channels/... deep link only resolves for
+// accounts already in the server, so it cannot get anyone in, and a default
+// invite expires after 7 days and would rot in a shipped release.
+const DISCORD_URL = 'https://discord.gg/gd6tKJDPj4';
+
 // Same reason as the const above, and this one had ALREADY drifted: the
 // imperative path was missing the sentence explaining why the toggle is off by
 // default, so an Obsidian 1.12 user read a shorter description than a 1.13 one
@@ -2149,26 +2155,38 @@ export class PlaudImporterSettingsTab extends PluginSettingTab {
 		el.empty();
 		el.addClass('plaud-importer-settings-footer');
 
+		// Everything goes in one inner container. settingEl is a flex row, and a
+		// flex item drops the whitespace at its own edges, which is what
+		// collapsed the separators into "GitHub|Report issues". Spacing is a gap
+		// now, so it no longer depends on text nodes surviving layout. Same fix
+		// and same markup as the reference plugin's footer.
+		const inner = el.createDiv({ cls: 'plaud-importer-footer-inner' });
+
 		const manifestVersion = this.plugin.manifest.version || '0.0.0';
-		el.createSpan({ text: `Version ${manifestVersion} | ` });
+		inner.createSpan({ text: `Version ${manifestVersion}` });
 
 		const createExternalLink = (
 			text: string,
 			url: string,
-		): HTMLAnchorElement =>
-			el.createEl('a', {
+		): HTMLAnchorElement => {
+			inner.createSpan({
+				cls: 'plaud-importer-footer-separator',
+				text: '|',
+			});
+			return inner.createEl('a', {
 				text,
 				href: url,
 				attr: { target: '_blank', rel: 'noopener' },
 			});
+		};
 
 		createExternalLink(
 			'GitHub',
 			'https://github.com/ckelsoe/obsidian-plaud-importer',
 		);
-		el.createSpan({ text: ' | ' });
+		createExternalLink('Discord', DISCORD_URL);
 		createExternalLink(
-			'Report Issues',
+			'Report issues',
 			'https://github.com/ckelsoe/obsidian-plaud-importer/issues',
 		);
 	}

--- a/styles.css
+++ b/styles.css
@@ -168,8 +168,24 @@
 }
 
 .plaud-importer-settings-footer {
+	justify-content: center;
 	text-align: center;
 	opacity: 0.8;
+}
+
+/* The separators are a flex gap, not whitespace in text nodes: settingEl is a
+   flex row and a flex item drops the whitespace at its own edges, which
+   collapsed "GitHub | Discord" into "GitHub|Discord". */
+.plaud-importer-footer-inner {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: var(--size-4-2);
+}
+
+.plaud-importer-footer-separator {
+	color: var(--text-faint);
 }
 
 .plaud-importer-meta {


### PR DESCRIPTION
Three user-facing gaps, all in the settings footer area.

> Stacked on #102. Retarget to `main` once that merges.

## Discord

The plugin had no Discord link anywhere — not the footer, not the README, nowhere in the source. The reference plugin (`obsidian-shell-path-copy`) has had one since 2.9.0. Same invite, same wording.

**It must stay a `discord.gg` invite that never expires.** A `discord.com/channels/...` deep link only resolves for accounts already in the server, so it cannot get anyone in, and a default invite expires after 7 days and would rot in a shipped release. That reasoning is in a comment above the const so nobody "tidies" it later.

## Funding

`manifest.json` had no `fundingUrl`, so Obsidian showed no support link beside the plugin. Five of the eight public plugins already carry `buymeacoffee.com/ckelsoe`; this is one of the three that did not.

## The footer separators were broken

Pre-existing, and visible: separators were plain text nodes (`' | '`). `settingEl` is a flex row, and a flex item drops the whitespace at its own edges, so the row could render as `GitHub|Report issues`. The reference plugin hit this and fixed it with an inner flex container and a `gap`; same markup and CSS adopted here.

## Verification

1,211 tests pass, lint and build green. `CHANGELOG.md` and `README.md` updated in the same commit rather than deferred to release time.

## Follow-up

Discord is going to **all** public plugins, and `fundingUrl` to the two others missing it (`obsidian-developer-cookbook`, `obsidian-developer-toolbox`), plus the standard template so new plugins get both. That is separate work per repo.