### PR TITLE
Link the issue tracker from the Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ See [PRIVACY.md](./PRIVACY.md) for the full privacy policy and liability disclai
 
 ## Community
 
-Questions, ideas, and general discussion happen on [Discord](https://discord.gg/gd6tKJDPj4). For anything that needs tracking, a GitHub issue is still the better home.
+Questions, ideas, and general discussion happen on [Discord](https://discord.gg/gd6tKJDPj4). For anything that needs tracking, a [GitHub issue](https://github.com/ckelsoe/obsidian-plaud-importer/issues) is still the better home.
 
 ## Support and issues
 


### PR DESCRIPTION
Follow-up to #103, which shipped in 0.38.0. CodeRabbit caught this on the same rollout in another repo: the Community section recommends a GitHub issue for anything trackable, and that was the one destination in the sentence you could not click.

One line, README only, so it rides the next release rather than earning one. The same fix has gone into the standard template so new plugins get it right.