### PR TITLE
Fix dev-dependency security advisories and drop the obsolete OSV suppression

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,7 +1,11 @@
 # OSV-Scanner suppressions. Every entry must document why the advisory is
 # accepted and what would let us drop it. Revisit whenever the dependency tree
 # changes (a new lockfile may remove the transitive path entirely).
-
-[[IgnoredVulns]]
-id = "GHSA-mh99-v99m-4gvg"
-reason = "brace-expansion unbounded-expansion DoS (vulnerable <= 5.0.7, first patched in 5.0.8, with no backport on the 1.x or 2.x lines). Reaches this repo only through DEV tooling: eslint's minimatch 3.x pulls a 1.x brace-expansion, and jest / typescript-eslint / glob pull 2.x and 5.x lines via newer minimatch. It is never in the shipped main.js (esbuild bundles runtime deps only; npm ls --omit=dev shows brace-expansion absent from the production tree) and only expands our own lint/test glob patterns, not attacker-controlled input. No non-breaking fix exists: forcing brace-expansion 5.0.8 everywhere breaks eslint's minimatch 3.x, which does require('brace-expansion') expecting a function and gets 5.x's object export (TypeError: expand is not a function). Drop this entry once eslint ships a minimatch that consumes fixed brace-expansion, or the 1.x/2.x path leaves the tree. To check: run npm ls brace-expansion and if no instance is <= 5.0.7, remove this entry."
+#
+# There are currently NO suppressions. The brace-expansion advisories
+# (GHSA-mh99 and its bypass GHSA-rgw5), fast-uri (GHSA-7p8r), and js-yaml
+# (GHSA-5p4m) that once needed one were all resolved by patched transitive
+# versions on 2026-08-10; a plain `npm audit fix` cleared them without breaking
+# the toolchain, so nothing needs ignoring. Add an entry below only for an
+# advisory that is genuinely unfixable without breaking a build (dev-only, not
+# reachable, no non-breaking upgrade), and say what would let us remove it.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -3,9 +3,10 @@
 # changes (a new lockfile may remove the transitive path entirely).
 #
 # There are currently NO suppressions. The brace-expansion advisories
-# (GHSA-mh99 and its bypass GHSA-rgw5), fast-uri (GHSA-7p8r), and js-yaml
-# (GHSA-5p4m) that once needed one were all resolved by patched transitive
-# versions on 2026-08-10; a plain `npm audit fix` cleared them without breaking
-# the toolchain, so nothing needs ignoring. Add an entry below only for an
-# advisory that is genuinely unfixable without breaking a build (dev-only, not
-# reachable, no non-breaking upgrade), and say what would let us remove it.
+# (GHSA-mh99-v99m-4gvg and its bypass GHSA-rgw5-rvv9-x895), fast-uri
+# (GHSA-7p8r-x3mc-p8w7), and js-yaml (GHSA-5p4m-2wfm-xmqj) that once needed one
+# were all resolved by patched transitive versions on 2026-08-10; a plain
+# `npm audit fix` cleared them without breaking the toolchain, so nothing needs
+# ignoring. Add an entry below only for an advisory that is genuinely unfixable
+# without breaking a build (dev-only, not reachable, no non-breaking upgrade),
+# and say what would let us remove it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,9 +1119,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1200,9 +1200,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3481,16 +3481,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/browserslist": {
@@ -4643,9 +4643,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4753,9 +4753,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4836,9 +4836,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5036,9 +5036,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5117,9 +5117,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5358,9 +5358,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5715,9 +5715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7163,9 +7163,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8309,9 +8309,9 @@
 			"license": "MIT"
 		},
 		"node_modules/readdir-glob/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9228,9 +9228,9 @@
 			"license": "MIT"
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## What

`npm audit fix` (non-breaking, patch-level) to clear three advisories that OSV started flagging against versions already in the lockfile, plus removal of the now-obsolete `GHSA-mh99` suppression.

| package | before | after | advisory cleared |
|---|---|---|---|
| brace-expansion | 1.1.16 / 2.1.2 / 5.0.7 | 1.1.18 / 2.1.4 / 5.0.9 | GHSA-rgw5 (bypass of CVE-2026-14257) |
| fast-uri | 3.1.4 | 3.1.5 | GHSA-7p8r |
| js-yaml | 4.3.0 | 4.3.1 | GHSA-5p4m |

All three are **dev-tooling only** (eslint / typescript-eslint / ts-jest / bestzip): absent from the production tree (`npm ls --omit=dev` is empty) and never referenced in the shipped `main.js`.

## Why the OSV ignore is removed, not extended

The same patched versions also resolve the older brace-expansion `GHSA-mh99` on the 1.x/2.x lines (the maintainers backported it), which previously had no non-breaking fix and so was suppressed in `osv-scanner.toml`. Running the OSV scanner locally with an empty config now reports **no issues**, so that suppression is dead weight. The repo now carries **zero** OSV suppressions.

## Verification

- `osv-scanner --lockfile=package-lock.json` → No issues found
- `npm audit` → found 0 vulnerabilities
- `npm run lint`, `npm test` (1213), `npm run build` → all green

`package.json` is unchanged; only transitive lockfile versions moved.