### PR TITLE
chore: correct the CodeRabbit release-gate comment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,9 @@
 # Review once when a PR opens; do not re-review on every push. Batch fixes,
 # then comment `@coderabbitai full review` to request the final pass.
 # Release/metadata PRs (titled "Release ...") are skipped: they only bump the
-# version + CHANGELOG, and the release workflow (attestation + scan) is their gate.
+# version + CHANGELOG and are still gated by the required CI check like any PR.
+# (The tag-push release workflow then adds SLSA attestation; its VirusTotal step
+# is best-effort and non-blocking, so it is not itself a gate.)
 reviews:
   auto_review:
     enabled: true


### PR DESCRIPTION
The comment said the release workflow's attestation + scan gate skipped
Release-titled PRs, but the VirusTotal step is continue-on-error (non-blocking).
Point it at the required CI check, the actual gate, and note the workflow adds
SLSA attestation on tag push. Matches the template and the rest of the fleet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release validation: CI remains the required gate.
  * Noted that SLSA attestation is generated during tag-based releases.
  * Clarified that VirusTotal scanning is best-effort and does not block releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->