### PR TITLE
Add a recording-source import filter (issue #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Plaud Importer will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Import only from the Plaud devices you choose.** A new "Recording sources" section in settings lets you load the devices paired to your Plaud account and uncheck any whose recordings you do not want in your vault, plus a separate choice for recordings made in the Plaud app or imported. It applies to both manual import and background auto-sync, so a device you keep for personal recordings (for example a NotePin) stops being pulled in automatically. Off by default, and a device you pair later is included until you change it here.
+
 ## [0.39.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Plaud does not offer an official API yet, so this plugin works by using Plaud's 
 - **Optionally sync a rename back to Plaud (off by default).** When you rename a recording in Obsidian, the plugin can update that recording's title in Plaud so the two stay in sync. This is opt-in and the only thing the plugin ever writes back to Plaud; with it off, renames stay entirely local. See [Renaming recordings](#renaming-recordings).
 - **"Imported" and "Update available" badges in the recording list.** Each row whose `plaud-id` already exists in your output folder shows an Imported pill; click it to open the existing note. If that recording changed in Plaud since you imported it, the row shows an Update available badge instead, so you can spot and re-import a stale note by hand. Re-importing is still possible and honors your duplicate-handling setting.
 - **Filter the import list, and ignore recordings you never want.** A filter bar at the top of the import dialog hides recordings you have already imported (on by default), so the list shows what is left to import instead of everything. Separate toggles also hide update-available, ignored, and trashed recordings. Each row has an eye button to **ignore** a recording (a junk or personal clip): ignored recordings drop out of the list and are skipped by background auto-sync, and ignoring works even on recordings you never imported. Recordings in Plaud's trash show a **Trashed** badge when you choose to show them.
+- **Import only from selected recording sources.** Choose which of your paired Plaud devices to import from, and whether to include recordings made in the Plaud app or imported, so a device you keep for personal recordings stays out of your vault. Applies to manual import and background auto-sync alike, off by default. See [Recording sources](#recording-sources).
 - **Resume an interrupted import.** If your Plaud session expires partway through a multi-select import, the run stops at the first recording that fails to authenticate, keeps what it already imported, and lets you sign in again right there; a **Resume remaining** button then finishes the recordings that were left.
 - **Duplicate handling** is configurable — Skip, Overwrite, or Ask each time. "Ask each time" prompts per file with an explicit warning that the existing note body AND its `-assets` folder will be replaced; in a multi-select import you can escalate to "Overwrite all remaining" / "Skip all remaining" or cancel the batch.
 - **Transcript folding** — imported notes open with the transcript section collapsed by default so the summary is what you see first. Toggleable in settings.
@@ -259,6 +260,15 @@ It also re-imports recordings you changed in Plaud since importing them (an edit
 If your Plaud session expires, auto-sync pauses with a single notice and resumes automatically when you reconnect (Test connection, a manual import, re-entering your token, or toggling auto-sync off and on). The notice's **Reconnect** button opens the sign-in that matches your account: the email window for password logins, or the browser bookmarklet flow for Google and Apple accounts.
 
 **Backfill for existing notes:** notes imported before this feature shipped do not carry the version marker auto-sync compares against, so their Plaud-side edits are not detected until the marker exists. Run the command **Plaud Importer: Backfill version markers for auto-sync** once after enabling auto-sync to make your existing library edit-detectable. It only adds a frontmatter marker and never rewrites note content.
+
+### Recording sources
+
+Optional filter, **off by default**, that limits import to the sources you choose. Useful when one of your Plaud devices records things you do not want in your vault, so background auto-sync stops pulling them in.
+
+- **Only import from selected sources.** The master switch. Off means every recording is imported (the original behavior).
+- **Sources.** Click **Load devices** to fetch the devices paired to your Plaud account, then uncheck any whose recordings you want to skip. A separate **App, desktop and imported recordings** checkbox covers recordings made in the Plaud app or imported, which have no device.
+
+The filter applies to both manual import and auto-sync. It uses blocklist behavior: a source is imported unless you uncheck it, so a device you pair later is included by default until you change it here.
 
 ### Tags and keywords
 

--- a/__tests__/auto-sync.test.ts
+++ b/__tests__/auto-sync.test.ts
@@ -9,6 +9,7 @@ import {
 	isUpdateAvailable,
 	INITIAL_AUTO_SYNC_STATE,
 } from '../auto-sync';
+import { buildSourceFilter } from '../import-core';
 
 function rec(
 	overrides: Partial<Omit<Recording, 'id'>> & { id: string },
@@ -27,6 +28,7 @@ function rec(
 		tags: overrides.tags,
 		versionMs: overrides.versionMs,
 		waitPull: overrides.waitPull,
+		source: overrides.source,
 	};
 }
 
@@ -307,6 +309,79 @@ describe('selectAutoSyncCandidates', () => {
 		);
 		expect(candidates).toEqual([]);
 		expect(reachedUpToDate).toBe(false);
+	});
+
+	// Source filter (issue #110): a blocked-source recording behaves exactly like
+	// an ignored one -- never a candidate, and never the frontier.
+	it('drops a source-blocked recording but still reaches a candidate below it', () => {
+		const filter = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NOTEPIN'],
+			blockAppRecordings: false,
+		});
+		const page = [
+			rec({
+				id: 'blocked',
+				versionMs: 900,
+				source: { kind: 'device', serial: 'NOTEPIN' },
+			}),
+			rec({
+				id: 'wanted',
+				versionMs: 800,
+				source: { kind: 'device', serial: 'NOTE' },
+			}),
+		];
+		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(
+			page,
+			idx([]),
+			undefined,
+			filter,
+		);
+		expect(candidates.map((c) => c.recording.id)).toEqual(['wanted']);
+		expect(reachedUpToDate).toBe(false);
+	});
+
+	it('a page of only source-blocked recordings is not a frontier', () => {
+		const filter = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NOTEPIN'],
+			blockAppRecordings: false,
+		});
+		const index = idx([['synced', { path: 's', versionMs: 500 }]]);
+		const page = [
+			rec({
+				id: 'blocked',
+				versionMs: 900,
+				source: { kind: 'device', serial: 'NOTEPIN' },
+			}),
+			// An up-to-date recording that WOULD be a frontier on its own, but the
+			// blocked row above keeps the page from proving the frontier.
+			rec({
+				id: 'synced',
+				versionMs: 500,
+				source: { kind: 'device', serial: 'NOTE' },
+			}),
+		];
+		const { candidates, reachedUpToDate } = selectAutoSyncCandidates(
+			page,
+			index,
+			undefined,
+			filter,
+		);
+		expect(candidates).toEqual([]);
+		expect(reachedUpToDate).toBe(false);
+	});
+
+	it('applies no source filtering when the filter is omitted', () => {
+		const page = [
+			rec({
+				id: 'np',
+				versionMs: 900,
+				source: { kind: 'device', serial: 'NOTEPIN' },
+			}),
+		];
+		const { candidates } = selectAutoSyncCandidates(page, idx([]));
+		expect(candidates.map((c) => c.recording.id)).toEqual(['np']);
 	});
 });
 

--- a/__tests__/import-core.test.ts
+++ b/__tests__/import-core.test.ts
@@ -1,6 +1,12 @@
 import type { PlaudRecordingId, Recording } from '../plaud-client';
 import type { ImportedRecord } from '../vault-index';
-import { filterListView, type ListViewFilter } from '../import-core';
+import {
+	buildSourceFilter,
+	filterListView,
+	isRecordingSourceAllowed,
+	type ListViewFilter,
+	type SourceFilterSettings,
+} from '../import-core';
 
 function rec(
 	overrides: Partial<Omit<Recording, 'id'>> & { id: string },
@@ -19,6 +25,7 @@ function rec(
 		tags: overrides.tags,
 		versionMs: overrides.versionMs,
 		waitPull: overrides.waitPull,
+		source: overrides.source,
 	};
 }
 
@@ -40,6 +47,7 @@ function filter(over: Partial<ListViewFilter>): ListViewFilter {
 		hideIgnored: over.hideIgnored ?? false,
 		index: over.index ?? idx([]),
 		ignoredIds: over.ignoredIds ?? ignored([]),
+		sourceFilter: over.sourceFilter,
 	};
 }
 
@@ -235,5 +243,108 @@ describe('filterListView', () => {
 				),
 			),
 		).toEqual([]);
+	});
+});
+
+describe('filterListView source filter', () => {
+	it('hides a recording from a blocked source, keeps allowed ones', () => {
+		const page = [
+			rec({ id: 'np', source: { kind: 'device', serial: 'NOTEPIN' } }),
+			rec({ id: 'note', source: { kind: 'device', serial: 'NOTE' } }),
+			rec({ id: 'app', source: { kind: 'app' } }),
+		];
+		const sourceFilter = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NOTEPIN'],
+			blockAppRecordings: false,
+		});
+		expect(ids(filterListView(page, filter({ sourceFilter })))).toEqual([
+			'note',
+			'app',
+		]);
+	});
+
+	it('does not filter by source when no source filter is supplied', () => {
+		const page = [
+			rec({ id: 'np', source: { kind: 'device', serial: 'NOTEPIN' } }),
+		];
+		expect(ids(filterListView(page, filter({})))).toEqual(['np']);
+	});
+});
+
+describe('buildSourceFilter', () => {
+	const settings = (
+		over: Partial<SourceFilterSettings>,
+	): SourceFilterSettings => ({
+		sourceFilterEnabled: over.sourceFilterEnabled ?? false,
+		blockedDeviceSerials: over.blockedDeviceSerials ?? [],
+		blockAppRecordings: over.blockAppRecordings ?? false,
+	});
+
+	it('maps settings fields onto the resolved filter', () => {
+		const f = buildSourceFilter(
+			settings({
+				sourceFilterEnabled: true,
+				blockedDeviceSerials: ['A', 'B'],
+				blockAppRecordings: true,
+			}),
+		);
+		expect(f.enabled).toBe(true);
+		expect(f.blockApp).toBe(true);
+		expect([...f.blockedDeviceSerials].sort()).toEqual(['A', 'B']);
+	});
+});
+
+describe('isRecordingSourceAllowed', () => {
+	const device = (serial: string): Recording =>
+		rec({ id: `dev-${serial}`, source: { kind: 'device', serial } });
+	const app = rec({ id: 'app', source: { kind: 'app' } });
+
+	it('allows everything when the filter is disabled', () => {
+		const f = buildSourceFilter({
+			sourceFilterEnabled: false,
+			blockedDeviceSerials: ['NP'],
+			blockAppRecordings: true,
+		});
+		expect(isRecordingSourceAllowed(device('NP'), f)).toBe(true);
+		expect(isRecordingSourceAllowed(app, f)).toBe(true);
+	});
+
+	it('blocks a device whose serial is in the blocklist, allows others', () => {
+		const f = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NP'],
+			blockAppRecordings: false,
+		});
+		expect(isRecordingSourceAllowed(device('NP'), f)).toBe(false);
+		expect(isRecordingSourceAllowed(device('NOTE'), f)).toBe(true);
+	});
+
+	it('allows a never-configured device by default (blocklist semantics)', () => {
+		const f = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NP'],
+			blockAppRecordings: false,
+		});
+		expect(isRecordingSourceAllowed(device('BRAND-NEW'), f)).toBe(true);
+	});
+
+	it('honors the app bucket independently of device serials', () => {
+		const f = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: [],
+			blockAppRecordings: true,
+		});
+		expect(isRecordingSourceAllowed(app, f)).toBe(false);
+		expect(isRecordingSourceAllowed(device('NOTE'), f)).toBe(true);
+	});
+
+	it('never hides a recording with no classified source', () => {
+		const f = buildSourceFilter({
+			sourceFilterEnabled: true,
+			blockedDeviceSerials: ['NP'],
+			blockAppRecordings: true,
+		});
+		expect(isRecordingSourceAllowed(rec({ id: 'none' }), f)).toBe(true);
 	});
 });

--- a/__tests__/plaud-client-re.test.ts
+++ b/__tests__/plaud-client-re.test.ts
@@ -1131,7 +1131,7 @@ describe('listRecordings filter validation', () => {
 // getTranscriptAndSummary — POST /ai/transsumm/{id}
 // =============================================================================
 
-import type { PlaudRecordingId } from '../plaud-client';
+import type { PlaudRecordingId, Recording } from '../plaud-client';
 
 function transsummEnvelope(
 	overrides: Record<string, unknown> = {},
@@ -4488,6 +4488,136 @@ describe('getFolderCatalog', () => {
 		await expect(client.getFolderCatalog()).rejects.toBeInstanceOf(
 			PlaudParseError,
 		);
+	});
+});
+
+// getDeviceCatalog (issue #110): fetch + cache the paired-device list.
+describe('getDeviceCatalog', () => {
+	const deviceEnvelope = (items: unknown[]): Record<string, unknown> => ({
+		status: 0,
+		msg: 'success',
+		data_devices: items,
+	});
+
+	it('parses {sn,name,model,version_number} and calls GET /device/list', async () => {
+		const { fetcher, lastRequest } = captureFetcher(
+			ok(
+				deviceEnvelope([
+					{
+						sn: '8800040111486696',
+						name: 'CK PLAUD NotePin',
+						model: '880',
+						version_number: 131335,
+					},
+				]),
+			),
+		);
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		const devices = await client.getDeviceCatalog();
+		expect(devices).toEqual([
+			{
+				sn: '8800040111486696',
+				name: 'CK PLAUD NotePin',
+				model: '880',
+				versionNumber: 131335,
+			},
+		]);
+		expect(lastRequest()?.url).toContain('/device/list');
+		expect(lastRequest()?.method).toBe('GET');
+	});
+
+	it('coerces a numeric model to a string and tolerates a missing name', async () => {
+		const { fetcher } = captureFetcher(
+			ok(deviceEnvelope([{ sn: 'S1', model: 888 }])),
+		);
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		const devices = await client.getDeviceCatalog();
+		expect(devices[0]).toEqual({
+			sn: 'S1',
+			name: '',
+			model: '888',
+			versionNumber: undefined,
+		});
+	});
+
+	it('caches per session: a second call does not refetch', async () => {
+		const { fetcher, allRequests } = captureFetcher(
+			ok(deviceEnvelope([{ sn: 'S1', name: 'A', model: '880' }])),
+		);
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		await client.getDeviceCatalog();
+		await client.getDeviceCatalog();
+		expect(allRequests().length).toBe(1);
+	});
+
+	it('skips malformed entries instead of failing the whole list', async () => {
+		const { fetcher } = captureFetcher(
+			ok(
+				deviceEnvelope([
+					{ sn: 'S1', name: 'A', model: '880' },
+					{ name: 'no sn' }, // missing sn
+					{ sn: '' }, // empty sn
+					{ sn: 'S2', name: 'B', model: '888' },
+				]),
+			),
+		);
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		const devices = await client.getDeviceCatalog();
+		expect(devices.map((d) => d.sn)).toEqual(['S1', 'S2']);
+	});
+
+	it('throws a parse error when data_devices is missing', async () => {
+		const { fetcher } = captureFetcher(ok({ status: 0, msg: 'x' }));
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		await expect(client.getDeviceCatalog()).rejects.toBeInstanceOf(
+			PlaudParseError,
+		);
+	});
+});
+
+// Recording capture-source derivation (issue #110): scene + serial_number ->
+// { kind: 'device', serial } | { kind: 'app' }.
+describe('parseRecording source derivation', () => {
+	const firstRecording = async (
+		overrides: Record<string, unknown>,
+	): Promise<Recording> => {
+		const { fetcher } = captureFetcher(
+			ok(listEnvelope([record(overrides)])),
+		);
+		const client = new ReverseEngineeredPlaudClient(() => 'tok', fetcher);
+		const recordings = await client.listRecordings();
+		return recordings[0];
+	};
+
+	it('classifies scene 1 with a serial as a device capture', async () => {
+		const r = await firstRecording({ scene: 1, serial_number: 'DEV-1' });
+		expect(r.source).toEqual({ kind: 'device', serial: 'DEV-1' });
+	});
+
+	it('classifies scene 7 with a serial as a device capture', async () => {
+		const r = await firstRecording({ scene: 7, serial_number: 'DEV-7' });
+		expect(r.source).toEqual({ kind: 'device', serial: 'DEV-7' });
+	});
+
+	it('classifies scene 102 as a non-device (app) capture', async () => {
+		const r = await firstRecording({
+			scene: 102,
+			serial_number: '1787255948336',
+		});
+		expect(r.source).toEqual({ kind: 'app' });
+	});
+
+	it('treats a device scene with an empty serial as app', async () => {
+		const r = await firstRecording({ scene: 1, serial_number: '' });
+		expect(r.source).toEqual({ kind: 'app' });
+	});
+
+	it('treats a missing scene as app even with a serial present', async () => {
+		const r = await firstRecording({
+			scene: undefined,
+			serial_number: 'S',
+		});
+		expect(r.source).toEqual({ kind: 'app' });
 	});
 });
 

--- a/auto-sync-runner.ts
+++ b/auto-sync-runner.ts
@@ -12,6 +12,7 @@
 import type { PlaudRecordingId, Recording } from './plaud-client';
 import type { ImportedRecord } from './vault-index';
 import { selectAutoSyncCandidates } from './auto-sync';
+import type { SourceFilter } from './import-core';
 
 export interface AutoSyncTickDeps {
 	/** One page of the list, edit-time descending (sort_by=edit_time). */
@@ -36,6 +37,12 @@ export interface AutoSyncTickDeps {
 	 * selection so auto-sync never pulls them. Omitted -> nothing ignored.
 	 */
 	readonly ignoredIds?: ReadonlySet<PlaudRecordingId>;
+	/**
+	 * Recording-source filter (issue #110). A recording from a blocked source is
+	 * skipped exactly like an ignored one. Rebuilt from settings each tick so a
+	 * change takes effect on the next run. Omitted -> nothing filtered.
+	 */
+	readonly sourceFilter?: SourceFilter;
 	log?(message: string, payload?: unknown): void;
 }
 
@@ -76,7 +83,12 @@ export async function runAutoSyncTick(
 			break;
 		}
 		const { candidates, reachedUpToDate: hitBoundary } =
-			selectAutoSyncCandidates(page, index, deps.ignoredIds);
+			selectAutoSyncCandidates(
+				page,
+				index,
+				deps.ignoredIds,
+				deps.sourceFilter,
+			);
 		for (const candidate of candidates) {
 			if (newRecs.length + changedRecs.length >= deps.maxImportsPerTick) {
 				cappedByImports = true;

--- a/auto-sync.ts
+++ b/auto-sync.ts
@@ -18,7 +18,9 @@ import type { ImportedRecord } from './vault-index';
 import {
 	categoryAllowsReauth,
 	filterVisibleRecordings,
+	isRecordingSourceAllowed,
 	type ErrorCategory,
+	type SourceFilter,
 } from './import-core';
 
 // isUpdateAvailable moved to import-core.ts (the acyclic pure base) so the list-
@@ -116,9 +118,9 @@ export interface SelectCandidatesResult {
 	 * `version_ms` <= stored). That is the real synced frontier, so the
 	 * scheduler stops paging. A page is deliberately NOT a frontier when it
 	 * still holds any candidate, any `up-to-date-current` (legacy note with no
-	 * marker, per the migration rule), or any `skipped-wait-pull` row: an
-	 * importable recording can sort below those on a later page, so paging must
-	 * continue. This replaces both the old "first up-to-date recording" break
+	 * marker, per the migration rule), any `skipped-wait-pull` row, or any
+	 * source-blocked row (issue #110): an importable recording can sort below
+	 * those on a later page, so paging must continue. This replaces both the old "first up-to-date recording" break
 	 * (stranded new recordings below it) and the interim "zero candidates" stop
 	 * (stranded ready recordings below an all-legacy or all-wait_pull page).
 	 */
@@ -142,18 +144,30 @@ export function selectAutoSyncCandidates(
 	page: readonly Recording[],
 	index: ReadonlyMap<PlaudRecordingId, ImportedRecord>,
 	ignoredIds: ReadonlySet<PlaudRecordingId> = NO_IGNORED_IDS,
+	sourceFilter?: SourceFilter,
 ): SelectCandidatesResult {
 	// Never import trash. filterVisibleRecordings preserves order.
 	const visible = filterVisibleRecordings(page, false);
 	const candidates: AutoSyncCandidate[] = [];
 	// The frontier is reached only if the page has at least one recording and
 	// every one of them is an `up-to-date-boundary`. Any candidate, legacy
-	// (`up-to-date-current`), pending (`skipped-wait-pull`), or `ignored` row
-	// means an importable recording could still be below, so we must keep paging.
+	// (`up-to-date-current`), pending (`skipped-wait-pull`), `ignored`, or
+	// source-blocked row means an importable recording could still be below, so
+	// we must keep paging.
 	let sawRecording = false;
 	let allProvenUpToDate = true;
 	for (const recording of visible) {
 		sawRecording = true;
+		// A source-blocked recording (for example a device the user chose to skip)
+		// is treated exactly like an ignored one: never imported, and NOT a
+		// frontier, so an allowed recording sorted below it is still reached.
+		if (
+			sourceFilter !== undefined &&
+			!isRecordingSourceAllowed(recording, sourceFilter)
+		) {
+			allProvenUpToDate = false;
+			continue;
+		}
 		const classification = classifyRecording(recording, index, ignoredIds);
 		if (classification === 'new' || classification === 'changed') {
 			candidates.push({ recording, kind: classification });

--- a/import-core.ts
+++ b/import-core.ts
@@ -114,6 +114,12 @@ export interface ImportModalOptions extends NoteWriterOptions {
 	 * perspective; the host owns save-error handling.
 	 */
 	readonly onViewStateChange?: (patch: ImportViewStatePatch) => void;
+	/**
+	 * Recording-source filter (issue #110), prebuilt from settings by the host.
+	 * The modal applies it to its list view so a source the user chose to skip is
+	 * hidden from manual import too, matching auto-sync. Omitted -> no filtering.
+	 */
+	readonly sourceFilter?: SourceFilter;
 	readonly defaultIncludeSummary?: boolean;
 	readonly defaultIncludeAttachments?: boolean;
 	readonly defaultIncludeMindmap?: boolean;
@@ -641,6 +647,70 @@ export function filterVisibleRecordings(
 	return recordings.filter((r) => !r.isTrashed);
 }
 
+// -----------------------------------------------------------------------------
+// Recording-source filter (issue #110). Lets a user keep a chosen capture
+// source out of import, most importantly out of unattended auto-sync (a personal
+// NotePin the user does not want in the vault). The signal is a recording's
+// `source` (derived from `scene` + `serial_number` at parse time), so the filter
+// is catalog-free and the headless path never needs a network call to apply it.
+//
+// Blocklist semantics on purpose: a recording is allowed unless its source is
+// explicitly blocked. A device the user has never configured (a brand-new
+// device) is therefore imported by default rather than silently dropped.
+// -----------------------------------------------------------------------------
+
+/** Resolved recording-source filter, built from settings by `buildSourceFilter`. */
+export interface SourceFilter {
+	/** Master switch. When false the filter allows everything (no-op). */
+	readonly enabled: boolean;
+	/** Hardware serials whose device recordings the user chose to skip. */
+	readonly blockedDeviceSerials: ReadonlySet<string>;
+	/** When true, skip non-device (app / desktop / imported) recordings. */
+	readonly blockApp: boolean;
+}
+
+/** The settings fields `buildSourceFilter` reads. A structural subset of the plugin settings. */
+export interface SourceFilterSettings {
+	readonly sourceFilterEnabled: boolean;
+	readonly blockedDeviceSerials: readonly string[];
+	readonly blockAppRecordings: boolean;
+}
+
+/** Build the resolved `SourceFilter` from the relevant settings fields. */
+export function buildSourceFilter(
+	settings: SourceFilterSettings,
+): SourceFilter {
+	return {
+		enabled: settings.sourceFilterEnabled,
+		blockedDeviceSerials: new Set(settings.blockedDeviceSerials),
+		blockApp: settings.blockAppRecordings,
+	};
+}
+
+/**
+ * True when a recording is allowed past the source filter. Pure and exported so
+ * both auto-sync candidate selection and the import view can share one rule. A
+ * disabled filter, or a recording with no classified source, always passes.
+ */
+export function isRecordingSourceAllowed(
+	recording: Recording,
+	filter: SourceFilter,
+): boolean {
+	if (!filter.enabled) {
+		return true;
+	}
+	const source = recording.source;
+	// Only synthetic/legacy Recording values reach here without a source (the
+	// live parser always sets one); never hide something we cannot classify.
+	if (source === undefined) {
+		return true;
+	}
+	if (source.kind === 'device') {
+		return !filter.blockedDeviceSerials.has(source.serial);
+	}
+	return !filter.blockApp;
+}
+
 /**
  * True when an already-imported recording has changed in Plaud since import:
  * both the listed and the stored `version_ms` are known and the listed one is
@@ -701,6 +771,13 @@ export interface ListViewFilter {
 	readonly index: ReadonlyMap<PlaudRecordingId, ImportedRecord>;
 	/** Ignored recording ids. */
 	readonly ignoredIds: ReadonlySet<PlaudRecordingId>;
+	/**
+	 * Recording-source filter (issue #110). When present and enabled, recordings
+	 * from a blocked source are hidden from the dialog, matching the same filter
+	 * auto-sync applies, so a device the user chose to skip does not clutter the
+	 * manual import list either. Omitted -> no source filtering in the view.
+	 */
+	readonly sourceFilter?: SourceFilter;
 }
 
 /**
@@ -728,6 +805,12 @@ export function filterListView(
 			return false;
 		}
 		if (filter.hideIgnored && filter.ignoredIds.has(r.id)) {
+			return false;
+		}
+		if (
+			filter.sourceFilter !== undefined &&
+			!isRecordingSourceAllowed(r, filter.sourceFilter)
+		) {
 			return false;
 		}
 		const existing = filter.index.get(r.id);

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -1105,6 +1105,10 @@ export class ImportModal extends Modal {
 			hideIgnored: this.hideIgnored,
 			index: this.importedIndex,
 			ignoredIds: this.ignoredIds,
+			// Recording-source filter (issue #110): a static snapshot from the
+			// host, not a filter-bar toggle, so a blocked source is hidden here the
+			// same way it is skipped by auto-sync.
+			sourceFilter: this.noteWriterOptions.sourceFilter,
 		};
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -51,12 +51,18 @@ import {
 import { runImport } from './import-runner';
 import {
 	PAGE_SIZE,
+	buildSourceFilter,
 	categoryAllowsReauth,
 	type ArtifactSelection,
 	type ImportModalOptions,
 	type ImportViewStatePatch,
 } from './import-core';
-import type { PlaudClient, PlaudRecordingId, Recording } from './plaud-client';
+import type {
+	PlaudClient,
+	PlaudDevice,
+	PlaudRecordingId,
+	Recording,
+} from './plaud-client';
 import { runAutoSyncTick } from './auto-sync-runner';
 import {
 	coerceIntervalMinutes,
@@ -79,6 +85,7 @@ import {
 	DEFAULT_SETTINGS,
 	resolveRibbonIconId,
 	type PlaudImporterSettings,
+	type StoredDevice,
 } from './settings-types';
 import { PlaudImporterSettingsTab } from './settings-tab';
 import { SessionRenewal, type RefreshOutcome } from './session-renewal';
@@ -768,6 +775,34 @@ export default class PlaudImporterPlugin extends Plugin {
 		}
 	}
 
+	/**
+	 * Fetch the account's paired devices and remember them for the recording-
+	 * source filter UI (issue #110). Persists the list to `knownDevices` so the
+	 * settings checkboxes can label each device by name. Throws a user-facing
+	 * Error when no client is ready or the fetch fails; the settings control
+	 * catches it and shows the message.
+	 */
+	async loadPlaudDevices(): Promise<readonly StoredDevice[]> {
+		const client = this.client;
+		if (client === undefined) {
+			throw new Error('Sign in to Plaud first, then load your devices.');
+		}
+		let devices: readonly PlaudDevice[];
+		try {
+			devices = await client.getDeviceCatalog();
+		} catch (err) {
+			throw new Error(classifyError(err).message);
+		}
+		const stored: StoredDevice[] = devices.map((d) => ({
+			sn: d.sn,
+			name: d.name,
+			model: d.model,
+		}));
+		this.settings.knownDevices = stored;
+		await this.saveSettings();
+		return stored;
+	}
+
 	// ---- Auto-sync (issue #5) -------------------------------------------
 
 	private logAutoSync(message: string, payload?: unknown): void {
@@ -823,6 +858,10 @@ export default class PlaudImporterPlugin extends Plugin {
 			ignoredRecordingIds: this.settings.ignoredRecordingIds.map(
 				(id) => id as PlaudRecordingId,
 			),
+			// Recording-source filter (issue #110): the same filter auto-sync
+			// applies, so a blocked source is hidden from the manual import list
+			// too. Built here so the modal needs no settings access of its own.
+			sourceFilter: buildSourceFilter(this.settings),
 			debugLogger: this.debugLogger,
 			getAuthToken: () =>
 				this.settings.secretId.length > 0
@@ -1465,6 +1504,10 @@ export default class PlaudImporterPlugin extends Plugin {
 						(id) => id as PlaudRecordingId,
 					),
 				),
+				// Honor the recording-source filter in the background. Rebuilt each
+				// tick from settings so a device blocked/unblocked mid-session takes
+				// effect on the next run, matching the ignore set above.
+				sourceFilter: buildSourceFilter(this.settings),
 				listPage: (skip, limit) =>
 					client.listRecordings({ sortBy: 'edit_time', skip, limit }),
 				buildIndex: () => index,

--- a/plaud-client-re.ts
+++ b/plaud-client-re.ts
@@ -13,10 +13,12 @@ import type {
 	Chapter,
 	ConsumerNote,
 	PlaudClient,
+	PlaudDevice,
 	PlaudFolder,
 	PlaudRecordingId,
 	Recording,
 	RecordingFilter,
+	RecordingSource,
 	Summary,
 	Transcript,
 	TranscriptAndSummary,
@@ -150,6 +152,11 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 	// plugin reloads (a fresh client instance clears the cache). undefined means
 	// "not yet fetched"; an empty array is a valid cached "no folders" result.
 	private folderCatalogCache: readonly PlaudFolder[] | undefined;
+	// Per-session cache of the paired-device list (`GET /device/list`), same
+	// rationale as the folder catalog: it changes rarely, so one fetch per plugin
+	// session is enough and a reload clears it. undefined = not yet fetched; an
+	// empty array is a valid cached "no devices" result.
+	private deviceCatalogCache: readonly PlaudDevice[] | undefined;
 
 	constructor(
 		tokenProvider: PlaudTokenProvider,
@@ -263,6 +270,28 @@ export class ReverseEngineeredPlaudClient implements PlaudClient {
 			});
 		}
 		return catalog;
+	}
+
+	async getDeviceCatalog(): Promise<readonly PlaudDevice[]> {
+		if (this.deviceCatalogCache !== undefined) {
+			return this.deviceCatalogCache;
+		}
+		const endpoint = '/device/list';
+		const url = `${this.baseUrl}${endpoint}`;
+		const raw = await this.fetchJson(url, endpoint);
+		const { devices, skipped } = parseDeviceCatalog(raw, endpoint);
+		this.deviceCatalogCache = devices;
+		if (this.debugLogger?.enabled === true) {
+			this.debugLogger.log({
+				kind: 'parsed',
+				endpoint,
+				message: `parsed ${devices.length} devices${
+					skipped > 0 ? ` (skipped ${skipped} malformed)` : ''
+				}`,
+				payload: { count: devices.length, skipped },
+			});
+		}
+		return devices;
 	}
 
 	async getTranscriptAndSummary(
@@ -1308,6 +1337,16 @@ interface RawRecording {
 	readonly version_ms?: number;
 	// 1 while the recording is still syncing from the capture device.
 	readonly wait_pull?: number;
+	// Capture-context enum (issue #110, verified live 2026-08-21): 1 and 7 are
+	// physical-device captures, 102/101/1000 are the non-device app/desktop/import
+	// path. Present on 100% of the live account; optional so an older payload
+	// without it still parses (source then falls back to 'app').
+	readonly scene?: number;
+	// The capturing device's hardware serial on a device capture (joins to a
+	// PlaudDevice.sn); a synthetic timestamp/uuid/random string on the non-device
+	// path. Present on 100% of the live account; optional and loosely typed
+	// because a malformed value must not fail the whole recording.
+	readonly serial_number?: string;
 }
 
 function parseListResponse(
@@ -1402,6 +1441,71 @@ function parseFolderCatalog(
 		});
 	}
 	return { catalog, skipped };
+}
+
+// Wire shape of one `GET /device/list` entry (`data_devices[]`). `sn` is the
+// join key to a recording's serial_number and must be a non-empty string;
+// `name` is the user-assigned label (may be empty on the wire); `model` is
+// Plaud's class code, seen as a string ("880") but accepted as a number too,
+// defensively.
+interface RawDevice {
+	readonly sn: string;
+	readonly name?: string;
+	readonly model?: string | number;
+	readonly version_number?: number;
+}
+
+function isRawDevice(value: unknown): value is RawDevice {
+	return (
+		isRecord(value) &&
+		typeof value.sn === 'string' &&
+		value.sn.length > 0 &&
+		(value.name === undefined || typeof value.name === 'string') &&
+		(value.model === undefined ||
+			typeof value.model === 'string' ||
+			typeof value.model === 'number') &&
+		(value.version_number === undefined ||
+			typeof value.version_number === 'number')
+	);
+}
+
+// Parse the paired-device list envelope (`GET /device/list` → data_devices[]).
+// Like parseFolderCatalog, a single malformed entry is skipped and counted
+// rather than aborting the whole parse: the device list is best-effort filter
+// enrichment, so one bad device must not cost the rest their names. Only a
+// structurally-wrong envelope (missing/!array `data_devices`) throws.
+function parseDeviceCatalog(
+	raw: unknown,
+	endpoint: string,
+): { devices: readonly PlaudDevice[]; skipped: number } {
+	if (!isRecord(raw)) {
+		throw new PlaudParseError('Response body is not an object', endpoint);
+	}
+	const list = raw.data_devices;
+	if (!Array.isArray(list)) {
+		throw new PlaudParseError(
+			'Response is missing data_devices array',
+			endpoint,
+		);
+	}
+	const devices: PlaudDevice[] = [];
+	let skipped = 0;
+	for (const item of list) {
+		if (!isRawDevice(item)) {
+			skipped++;
+			continue;
+		}
+		devices.push({
+			sn: item.sn,
+			name: typeof item.name === 'string' ? item.name : '',
+			model: item.model === undefined ? '' : String(item.model),
+			versionNumber:
+				typeof item.version_number === 'number'
+					? item.version_number
+					: undefined,
+		});
+	}
+	return { devices, skipped };
 }
 
 // Plausibility bounds for a Plaud recording's start_time, which is a unix
@@ -1522,12 +1626,26 @@ function parseRecording(raw: RawRecording, endpoint: string): Recording {
 		}
 	}
 
+	// Capture source (issue #110). A physical-device capture is `scene` 1 or 7
+	// carrying the device's hardware serial; everything else (scenes 102/101/1000,
+	// or a missing/empty serial) is the non-device app/desktop/import path. Keep
+	// this derivation catalog-free so the headless auto-sync filter never needs a
+	// network call to classify a recording.
+	const isDeviceScene = raw.scene === 1 || raw.scene === 7;
+	const serial =
+		typeof raw.serial_number === 'string' ? raw.serial_number : '';
+	const source: RecordingSource =
+		isDeviceScene && serial.length > 0
+			? { kind: 'device', serial }
+			: { kind: 'app' };
+
 	return {
 		id: raw.id as PlaudRecordingId,
 		title: raw.filename,
 		createdAt: new Date(raw.start_time),
 		endsAt: new Date(endMs),
 		captureOffsetMinutes,
+		source,
 		// Convert ms → seconds at the trust boundary so every downstream
 		// consumer (NoteWriter, ImportModal display, Dataview queries)
 		// sees seconds. Matches the segment-timestamp treatment at

--- a/plaud-client.ts
+++ b/plaud-client.ts
@@ -146,8 +146,45 @@ export interface PlaudFolder {
 	readonly color?: string;
 }
 
+/**
+ * One paired device from the account (`GET /device/list` → `data_devices[]`).
+ * `sn` is the hardware serial that a device-captured recording carries in its
+ * `serial_number` field, so it is the join key between a recording and the
+ * device that made it (verified live 2026-08-21, issue #110). `name` is the
+ * user-assigned device name shown in the Plaud app; `model` is Plaud's numeric
+ * class code (see `deviceModelLabel`).
+ */
+export interface PlaudDevice {
+	readonly sn: string;
+	readonly name: string;
+	readonly model: string;
+	readonly versionNumber?: number;
+}
+
+// Plaud's numeric device-class codes, observed live 2026-08-21. Unknown codes
+// fall back to a generic label rather than guessing, so a future device model
+// still renders a sensible name.
+const DEVICE_MODEL_LABELS: Readonly<Record<string, string>> = {
+	'880': 'NotePin',
+	'881': 'Note Pro',
+	'888': 'Note',
+};
+
+/** Human-readable class name for a device `model` code, e.g. `880` → "NotePin". */
+export function deviceModelLabel(model: string): string {
+	return DEVICE_MODEL_LABELS[model] ?? 'Plaud device';
+}
+
 export interface PlaudClient {
 	listRecordings(filter?: RecordingFilter): Promise<readonly Recording[]>;
+	/**
+	 * Fetch the account's paired devices (`GET /device/list`) so the import-
+	 * source filter can list them by name and match a recording's
+	 * `serial_number` to the device that captured it. Implementations should
+	 * cache per session; the device list changes rarely. Best-effort at the call
+	 * site: a failed fetch degrades to "no devices known", never fails a sync.
+	 */
+	getDeviceCatalog(): Promise<readonly PlaudDevice[]>;
 	getTranscriptAndSummary(
 		id: PlaudRecordingId,
 	): Promise<TranscriptAndSummary>;
@@ -202,6 +239,19 @@ export interface RecordingFilter {
 	 */
 	readonly sortBy?: 'start_time' | 'edit_time';
 }
+
+/**
+ * Where a recording was captured, derived from the list payload's `scene` and
+ * `serial_number`. Verified live 2026-08-21 (issue #110): `scene` 1 and 7 are
+ * physical-device captures whose `serial_number` is the capturing device's
+ * hardware serial (it joins to a `PlaudDevice.sn`); every other scene, or a
+ * synthetic/empty serial, is the non-device app/desktop/import path. The
+ * recording-source import filter uses this to keep a chosen device (for example
+ * a personal NotePin) out of auto-sync.
+ */
+export type RecordingSource =
+	| { readonly kind: 'device'; readonly serial: string }
+	| { readonly kind: 'app' };
 
 export interface Recording {
 	readonly id: PlaudRecordingId;
@@ -261,6 +311,14 @@ export interface Recording {
 	 * absent.
 	 */
 	readonly waitPull?: boolean;
+	/**
+	 * Where the recording was captured (`{ kind: 'device', serial }` for a
+	 * physical Plaud device, `{ kind: 'app' }` for the desktop/phone/import path).
+	 * Derived by the parser from `scene` + `serial_number`. Optional only so
+	 * legacy/synthetic Recording values without it still type-check; the live
+	 * parser always sets it. Consumed by the recording-source import filter.
+	 */
+	readonly source?: RecordingSource;
 }
 
 export interface Transcript {

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -21,6 +21,7 @@ import {
 	setIcon,
 } from 'obsidian';
 import { describeTokenLifetime, readTokenLifetime } from './plaud-token';
+import { deviceModelLabel } from './plaud-client';
 import {
 	DEFAULT_NOTE_NAME_TEMPLATE,
 	isValidNoteNameTemplate,
@@ -47,6 +48,7 @@ import {
 	RIBBON_ICON_CHOICES,
 	resolveRibbonIconId,
 	type PlaudImporterSettings,
+	type StoredDevice,
 } from './settings-types';
 import type { SignInMethod } from './reconnect-routing';
 import type { BufferedDebugLogger } from './debug-logger';
@@ -70,6 +72,7 @@ export interface SettingsTabHost extends Plugin {
 	saveSettings(): Promise<void>;
 	readStoredTokenValue(): string;
 	testPlaudConnection(): Promise<{ ok: boolean; message: string }>;
+	loadPlaudDevices(): Promise<readonly StoredDevice[]>;
 	reauthenticate(): Promise<ReauthOutcome>;
 	pasteTokenFromClipboard(canStore?: () => boolean): Promise<boolean>;
 	clearSignIn(): Promise<{ sessionCleared: boolean }>;
@@ -97,6 +100,12 @@ const SIGN_IN_NOTE =
 // lifetime.
 const AUTO_SYNC_DESC =
 	"Off by default. Runs a background import on a schedule, unattended and never prompting. It uses your default import options: new recordings are imported, and a recording you changed in Plaud (edited speaker names, corrected transcript, or finished processing) is re-imported. IMPORTANT: a re-import OVERWRITES that note and its downloaded artifacts with Plaud's current version, so edits you made to a synced note or its attachment files are lost on the next change. Only recordings that actually changed are touched; unchanged notes are never modified. Desktop only. The background sync runs between sign-ins for as long as your Plaud session lasts (set by Plaud and shown in the status line under Plaud token), pausing for a one-click reconnection when the session expires.";
+
+const RECORDING_SOURCES_DESC =
+	'Off by default, so every recording is imported. Turn on to import only the sources you pick below, for both manual import and automatic sync. Useful when one of your Plaud devices records things you do not want in your vault (for example a personal NotePin), so automatic sync stops pulling them in.';
+
+const RECORDING_SOURCES_CONTROL_DESC =
+	'Load your devices, then uncheck any whose recordings you do not want imported. A source stays imported unless you uncheck it, so a device you add later is included by default until you change it here. Only applies when the setting above is on.';
 
 // Subfolder template documentation, shared by the declarative settings
 // (1.13+) and the imperative display() fallback (1.12) so both render the
@@ -683,6 +692,21 @@ export class PlaudImporterSettingsTab extends PluginSettingTab {
 			},
 		);
 
+		new Setting(containerEl).setName('Recording sources').setHeading();
+		this.addToggleRow(
+			containerEl,
+			'Only import from selected sources',
+			RECORDING_SOURCES_DESC,
+			'sourceFilterEnabled',
+		);
+		this.renderRecordingSourcesControl(
+			this.makeSetting(
+				containerEl,
+				'Sources',
+				RECORDING_SOURCES_CONTROL_DESC,
+			),
+		);
+
 		new Setting(containerEl).setName('Transcript rendering').setHeading();
 		this.addToggleRow(
 			containerEl,
@@ -967,6 +991,144 @@ export class PlaudImporterSettingsTab extends PluginSettingTab {
 				}
 			}),
 		);
+	}
+
+	// Recording-source filter control (issue #110): a "Load devices" action, a
+	// status line, then a checkbox per device plus the non-device bucket. A ticked
+	// box means "import from this source"; unticking a device adds its serial to
+	// the blocklist. Rendered once and shared by both the imperative display() and
+	// the declarative getSettingDefinitions() paths.
+	private renderRecordingSourcesControl(setting: Setting): void {
+		setting.settingEl.addClass('plaud-importer-stacked-row');
+
+		// The button is added first so it sits above the status and list; the
+		// status and list divs are created after so they stack below it.
+		setting.addButton((btn) =>
+			btn.setButtonText('Load devices').onClick(async () => {
+				btn.setDisabled(true);
+				statusEl.setText('Loading devices…');
+				try {
+					const devices = await this.plugin.loadPlaudDevices();
+					statusEl.setText(
+						devices.length === 1
+							? 'Loaded 1 device.'
+							: `Loaded ${devices.length} devices.`,
+					);
+					renderList();
+				} catch (err) {
+					statusEl.setText(
+						err instanceof Error
+							? err.message
+							: 'Could not load devices.',
+					);
+				} finally {
+					btn.setDisabled(false);
+				}
+			}),
+		);
+
+		const statusEl = setting.controlEl.createDiv({
+			cls: 'plaud-importer-sources-status',
+		});
+		const listEl = setting.controlEl.createDiv({
+			cls: 'plaud-importer-sources-list',
+		});
+
+		// One checkbox row. `imported` is the checked state; onToggle is called
+		// with the new checked (imported) state.
+		const addSourceRow = (
+			name: string,
+			sublabel: string,
+			imported: boolean,
+			ariaLabel: string,
+			onToggle: (imported: boolean) => void,
+		): void => {
+			const row = listEl.createEl('label', {
+				cls: 'plaud-importer-source-row',
+			});
+			const checkbox = row.createEl('input', {
+				attr: { type: 'checkbox', 'aria-label': ariaLabel },
+			});
+			checkbox.checked = imported;
+			const textEl = row.createDiv({
+				cls: 'plaud-importer-source-text',
+			});
+			textEl.createDiv({
+				cls: 'plaud-importer-source-name',
+				text: name,
+			});
+			if (sublabel.length > 0) {
+				textEl.createDiv({
+					cls: 'plaud-importer-source-sub',
+					text: sublabel,
+				});
+			}
+			checkbox.addEventListener('change', () =>
+				onToggle(checkbox.checked),
+			);
+		};
+
+		const renderList = (): void => {
+			listEl.empty();
+			const blocked = new Set(this.plugin.settings.blockedDeviceSerials);
+
+			// Show the remembered devices, plus any blocked serial we have no
+			// remembered name for, so a block is always visible and reversible even
+			// before the device list is loaded.
+			const devices: StoredDevice[] = [
+				...this.plugin.settings.knownDevices,
+			];
+			const knownSerials = new Set(devices.map((d) => d.sn));
+			for (const sn of blocked) {
+				if (!knownSerials.has(sn)) {
+					devices.push({ sn, name: sn, model: '' });
+				}
+			}
+
+			if (devices.length === 0) {
+				listEl.createDiv({
+					cls: 'plaud-importer-sources-empty',
+					text: 'No devices loaded yet. Click Load devices to fetch the devices paired to your Plaud account.',
+				});
+			}
+
+			for (const device of devices) {
+				const name = device.name.length > 0 ? device.name : device.sn;
+				addSourceRow(
+					name,
+					deviceModelLabel(device.model),
+					!blocked.has(device.sn),
+					`Import recordings from ${name}`,
+					(imported) => {
+						const next = new Set(
+							this.plugin.settings.blockedDeviceSerials,
+						);
+						if (imported) {
+							next.delete(device.sn);
+						} else {
+							next.add(device.sn);
+						}
+						this.plugin.settings.blockedDeviceSerials = [...next];
+						void this.plugin.saveSettings();
+					},
+				);
+			}
+
+			// The non-device bucket (Plaud app / desktop / imported audio), always
+			// shown since it needs no device list.
+			addSourceRow(
+				'App, desktop and imported recordings',
+				'Recordings made in the Plaud app or imported, with no device',
+				!this.plugin.settings.blockAppRecordings,
+				'Import app, desktop and imported recordings',
+				(imported) => {
+					this.plugin.settings.blockAppRecordings = !imported;
+					void this.plugin.saveSettings();
+				},
+			);
+		};
+
+		renderList();
 	}
 
 	private renderClearSignInControl(setting: Setting): void {
@@ -2008,6 +2170,29 @@ export class PlaudImporterSettingsTab extends PluginSettingTab {
 								'1440': 'Once a day',
 							},
 						},
+					},
+				],
+			},
+			{
+				type: 'group',
+				heading: 'Recording sources',
+				items: [
+					{
+						name: 'Only import from selected sources',
+						desc: RECORDING_SOURCES_DESC,
+						control: {
+							type: 'toggle',
+							key: 'sourceFilterEnabled',
+						},
+					},
+					{
+						name: 'Sources',
+						desc: RECORDING_SOURCES_CONTROL_DESC,
+						// Dynamic checkbox list backed by a network device fetch, so
+						// it is rendered imperatively and is not search-indexable.
+						searchable: false,
+						render: (setting: Setting) =>
+							this.renderRecordingSourcesControl(setting),
 					},
 				],
 			},

--- a/settings-types.ts
+++ b/settings-types.ts
@@ -49,6 +49,19 @@ export function resolveRibbonIconId(stored: string | undefined): string {
 		: DEFAULT_RIBBON_ICON;
 }
 
+/**
+ * A paired Plaud device remembered for the recording-source filter (issue #110).
+ * Snapshotted from `GET /device/list` when the user refreshes the device list in
+ * settings, so the settings UI can label a device by name even offline, and a
+ * blocked serial always has a friendly name. `sn` is the join key to a device
+ * recording's `serial_number`.
+ */
+export interface StoredDevice {
+	sn: string;
+	name: string;
+	model: string;
+}
+
 export interface PlaudImporterSettings {
 	secretId: string;
 	// Base host for the Plaud API. Defaults to the US host. The plugin
@@ -141,6 +154,27 @@ export interface PlaudImporterSettings {
 	// note tag: it must cover recordings that were never imported, so no note
 	// exists to carry a marker. Keyed by the stable plaud-id.
 	ignoredRecordingIds: string[];
+	// Recording-source filter (issue #110). When on, recordings whose capture
+	// source is blocked below are kept out of both manual import and, most
+	// importantly, unattended auto-sync (a personal NotePin the user does not want
+	// in the vault). OFF by default so existing installs keep importing everything
+	// until the user opts in. Blocklist semantics: a source is imported unless it
+	// is explicitly blocked, so a brand-new device is imported by default rather
+	// than silently dropped.
+	sourceFilterEnabled: boolean;
+	// Hardware serials (device `sn`) whose recordings the user chose to skip.
+	// Only consulted when sourceFilterEnabled is on. Matched against a device
+	// recording's `serial_number`.
+	blockedDeviceSerials: string[];
+	// When on (and sourceFilterEnabled), skip non-device recordings: those made
+	// through the Plaud desktop/phone app or imported, which carry no hardware
+	// serial. Off by default.
+	blockAppRecordings: boolean;
+	// Remembered device list from the last "Refresh devices" in settings, so the
+	// source filter UI can show a device's name even when offline and a blocked
+	// serial always resolves to a friendly label. Not load-bearing for filtering
+	// (the filter matches serials); purely for display.
+	knownDevices: StoredDevice[];
 	// Title write-back: when on, renaming an imported recording (via the Rename
 	// recording command or a file-explorer rename) also updates that recording's
 	// title in Plaud to match the new note name. OFF by default because it is the
@@ -228,6 +262,10 @@ export const DEFAULT_SETTINGS: PlaudImporterSettings = {
 	hideUpdatesRecordings: false,
 	hideIgnoredRecordings: true,
 	ignoredRecordingIds: [],
+	sourceFilterEnabled: false,
+	blockedDeviceSerials: [],
+	blockAppRecordings: false,
+	knownDevices: [],
 	autoUpdatePlaudTitle: false,
 	autoSyncEnabled: false,
 	autoSyncIntervalMinutes: 60,

--- a/styles.css
+++ b/styles.css
@@ -750,3 +750,49 @@
 	outline: 2px solid var(--text-accent);
 	outline-offset: 2px;
 }
+
+/*
+ * Recording-source filter (issue #110): the device/source checkbox list under
+ * the "Sources" setting. Full-width block below the name/description, matching
+ * the stacked-row treatment of the other doc-heavy rows.
+ */
+.plaud-importer-sources-status {
+	flex-basis: 100%;
+	margin-top: 0.35em;
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+.plaud-importer-sources-list {
+	flex-basis: 100%;
+	margin-top: 0.4em;
+	display: flex;
+	flex-direction: column;
+	gap: 0.35em;
+}
+
+.plaud-importer-sources-empty {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+/* One source row: a checkbox beside a stacked name + class sublabel. */
+.plaud-importer-source-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5em;
+	cursor: pointer;
+}
+
+.plaud-importer-source-row input[type="checkbox"] {
+	margin-top: 0.2em;
+}
+
+.plaud-importer-source-name {
+	color: var(--text-normal);
+}
+
+.plaud-importer-source-sub {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}


### PR DESCRIPTION
## What

Adds an optional filter that keeps recordings from a chosen Plaud device out of import. The reporter (issue #110) records personal notes on a NotePin they do not want in their vault, but background auto-sync pulls everything in before they can ignore it. This lets them uncheck that device once, in settings.

## How it works

A recording's capture source is derived at parse time from the list payload's `scene` + `serial_number`, verified live against the account (scene 1/7 carry the device's hardware serial, which joins to `GET /device/list`; every other scene is the non-device app/desktop/import path with a synthetic serial). So filtering needs **no extra per-recording API call**. A new cached `getDeviceCatalog()` resolves a serial to the paired device's name for the settings UI only.

Blocklist semantics: a source is imported unless explicitly blocked, so a device paired later is imported by default rather than silently dropped.

## Surfaces changed

- **Settings** — a new "Recording sources" section: a master toggle (off by default), a "Load devices" action, and a checkbox per device plus one for app/imported recordings. Rendered once and shared by the imperative and declarative settings paths.
- **Auto import** — a source-blocked recording is skipped in `selectAutoSyncCandidates` exactly like an ignored one, and is never treated as the up-to-date frontier, so an allowed recording sorted below it is still reached.
- **Manual import** — the same filter is applied to the import dialog's list view, so a blocked source is hidden there too.

## Non-breaking

Off by default; existing installs keep importing everything until they opt in. New settings keys default in via the existing `Object.assign(DEFAULT_SETTINGS, stored)` merge, no migration.

## Testing

- 21 new unit tests: source derivation, `getDeviceCatalog` parse/cache, the `isRecordingSourceAllowed`/`buildSourceFilter` predicate across every bucket, `selectAutoSyncCandidates` frontier correctness with a blocked row, and `filterListView` source hiding. Full suite: 1259 passing.
- Lint, build, prettier, submission pre-check all green.
- Hand-verified live over CDP against the real account: `loadPlaudDevices()` returns and persists all three paired devices, and real recordings derive `source` correctly (device recordings join to the right device name, app recordings classify as app). This is hand-verification, not automated coverage.

Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recording-source settings to include or exclude recordings from paired devices, the Plaud app, or imported sources.
  * Source filtering applies to manual imports and background auto-sync.
  * Added paired-device discovery and saved source preferences.
  * Filtering is disabled by default; newly paired devices remain included unless blocked.

* **Documentation**
  * Documented recording-source filtering and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->