### PR TITLE
Surface a recording's device in notes and the import list (issue #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Plaud Importer will be documented in this file.
 ### Added
 
 - **Import only from the Plaud devices you choose.** A new "Recording sources" section in settings lets you load the devices paired to your Plaud account and uncheck any whose recordings you do not want in your vault, plus a separate choice for recordings made in the Plaud app or imported. It applies to both manual import and background auto-sync, so a device you keep for personal recordings (for example a NotePin) stops being pulled in automatically. Off by default, and a device you pair later is included until you change it here.
+- **See where each recording came from, and save it.** The import list now shows a small source chip on every row (the device name, or "App" for a recording made in the Plaud app or imported), so you can tell at a glance which device a recording is from while choosing what to import. A new `{{device}}` token is available in the Extra frontmatter setting, so you can add a property like `device: {{device}}` to write the recording's device onto each note for filtering and Dataview.
 
 ## [0.39.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Optional filter, **off by default**, that limits import to the sources you choos
 
 The filter applies to both manual import and auto-sync. It uses blocklist behavior: a source is imported unless you uncheck it, so a device you pair later is included by default until you change it here.
 
+**Seeing and saving the source.** Whether or not the filter is on, the import list shows a small source chip on each row (the device name, or "App" for a recording made in the Plaud app or imported) so you can tell which device a recording came from while choosing what to import. To keep that on the note itself, add a `{{device}}` token to an Extra frontmatter row in settings, for example `device: {{device}}`, and each imported note records the device it came from for filtering and Dataview.
+
 ### Tags and keywords
 
 - **Tag mode** — which sources land in each note's `tags:` frontmatter: no tags, your custom tags only, Plaud tags (the default), or all (which also adds Plaud's AI keywords as `plaud/...` tags).

--- a/__tests__/note-writer.test.ts
+++ b/__tests__/note-writer.test.ts
@@ -1,3 +1,4 @@
+import { recordingSourceLabel } from '../plaud-client';
 import {
 	NoteWriter,
 	NoteWriterError,
@@ -1659,6 +1660,55 @@ describe('customFrontmatterContext', () => {
 		expect(ctx.template).toBe('');
 		expect(ctx.model).toBe('');
 	});
+
+	it('resolves the device token from the source and name map', () => {
+		const names = new Map([['NP', 'CK PLAUD NotePin']]);
+		const ctx = customFrontmatterContext(
+			makeRecording({ source: { kind: 'device', serial: 'NP' } }),
+			null,
+			'',
+			'',
+			names,
+		);
+		expect(ctx.device).toBe('CK PLAUD NotePin');
+	});
+
+	it('labels a non-device recording as App and no source as empty', () => {
+		expect(
+			customFrontmatterContext(
+				makeRecording({ source: { kind: 'app' } }),
+				null,
+				'',
+			).device,
+		).toBe('App');
+		expect(customFrontmatterContext(makeRecording(), null, '').device).toBe(
+			'',
+		);
+	});
+});
+
+describe('recordingSourceLabel', () => {
+	const names = new Map([['NP', 'CK PLAUD NotePin']]);
+
+	it('returns the device name when the serial is known', () => {
+		expect(
+			recordingSourceLabel({ kind: 'device', serial: 'NP' }, names),
+		).toBe('CK PLAUD NotePin');
+	});
+
+	it('falls back to a generic label for an unknown device serial', () => {
+		expect(
+			recordingSourceLabel({ kind: 'device', serial: 'X' }, names),
+		).toBe('Plaud device');
+	});
+
+	it('labels a non-device recording App', () => {
+		expect(recordingSourceLabel({ kind: 'app' }, names)).toBe('App');
+	});
+
+	it('returns an empty label for a recording with no source', () => {
+		expect(recordingSourceLabel(undefined, names)).toBe('');
+	});
 });
 
 describe('expandCustomFrontmatterValue', () => {
@@ -1692,6 +1742,29 @@ describe('expandCustomFrontmatterValue', () => {
 		expect(expandCustomFrontmatterValue('{{plaud-folder}}', ctx)).toBe(
 			'Meetings',
 		);
+	});
+
+	it('expands the device token from a device-name map', () => {
+		const deviceCtx = customFrontmatterContext(
+			makeRecording({ source: { kind: 'device', serial: 'NP' } }),
+			null,
+			'',
+			'',
+			new Map([['NP', 'CK PLAUD NotePin']]),
+		);
+		expect(expandCustomFrontmatterValue('{{device}}', deviceCtx)).toBe(
+			'CK PLAUD NotePin',
+		);
+		expect(
+			expandCustomFrontmatterValue(
+				'{{device}}',
+				customFrontmatterContext(
+					makeRecording({ source: { kind: 'app' } }),
+					null,
+					'',
+				),
+			),
+		).toBe('App');
 	});
 
 	it('expands the duration content token', () => {
@@ -1804,6 +1877,23 @@ describe('formatFrontmatter custom rows', () => {
 		);
 		expect(fm).toMatch(/^status: unprocessed$/m);
 		expect(fm.indexOf('source: plaud')).toBeLessThan(fm.indexOf('status:'));
+	});
+
+	it('renders {{device}} in a custom row from the device-name map', () => {
+		const fm = formatFrontmatter(
+			makeRecording({ source: { kind: 'device', serial: 'NP' } }),
+			[],
+			null,
+			undefined,
+			undefined,
+			undefined,
+			rows({ key: 'device', value: '{{device}}', preserve: false }),
+			undefined,
+			false,
+			'',
+			new Map([['NP', 'CK PLAUD NotePin']]),
+		);
+		expect(fm).toMatch(/^device: CK PLAUD NotePin$/m);
 	});
 
 	it('writes an empty value as YAML null', () => {

--- a/import-core.ts
+++ b/import-core.ts
@@ -120,6 +120,21 @@ export interface ImportModalOptions extends NoteWriterOptions {
 	 * hidden from manual import too, matching auto-sync. Omitted -> no filtering.
 	 */
 	readonly sourceFilter?: SourceFilter;
+	/**
+	 * Live serial -> device name map (issue #110 follow-up), read at call time so
+	 * it reflects the latest remembered device list. Powers the `{{device}}`
+	 * frontmatter token and the import list's source badge. Omitted -> no names
+	 * (device recordings fall back to a generic label).
+	 */
+	readonly getDeviceNames?: () => ReadonlyMap<string, string>;
+	/**
+	 * Best-effort refresh of the remembered device list (issue #110 follow-up).
+	 * The modal calls this once on open so source badges show real device names
+	 * even before the user has loaded devices in settings. Resolves when the
+	 * remembered list (read via `getDeviceNames`) has been updated; rejects are
+	 * swallowed by the modal.
+	 */
+	readonly refreshDeviceNames?: () => Promise<void>;
 	readonly defaultIncludeSummary?: boolean;
 	readonly defaultIncludeAttachments?: boolean;
 	readonly defaultIncludeMindmap?: boolean;

--- a/import-modal.ts
+++ b/import-modal.ts
@@ -5,6 +5,7 @@ import type {
 	Recording,
 	TranscriptAndSummary,
 } from './plaud-client';
+import { recordingSourceLabel } from './plaud-client';
 import {
 	NoteWriter,
 	NoteWriterError,
@@ -530,6 +531,11 @@ export class ImportModal extends Modal {
 	private hideUpdates: boolean;
 	private hideIgnored: boolean;
 	private readonly ignoredIds: Set<PlaudRecordingId>;
+	// Serial -> device name map for the per-row source chip (issue #110 follow-up).
+	// Seeded from the host's remembered devices, then freshened once on open via
+	// refreshDeviceNames so the chip shows real names even before the user has
+	// loaded devices in settings.
+	private deviceNames: ReadonlyMap<string, string>;
 
 	constructor(
 		app: App,
@@ -548,6 +554,7 @@ export class ImportModal extends Modal {
 		this.hideUpdates = noteWriterOptions.hideUpdatesRecordings === true;
 		this.hideIgnored = noteWriterOptions.hideIgnoredRecordings !== false;
 		this.ignoredIds = new Set(noteWriterOptions.ignoredRecordingIds ?? []);
+		this.deviceNames = noteWriterOptions.getDeviceNames?.() ?? new Map();
 		this.attachments = new AttachmentImporter({
 			app,
 			getAuthToken: noteWriterOptions.getAuthToken,
@@ -570,6 +577,43 @@ export class ImportModal extends Modal {
 			);
 			this.renderError(classifyError(err));
 		});
+		this.refreshDeviceNamesInBackground();
+	}
+
+	// Freshen the serial -> device name map once on open so the per-row source
+	// chip shows real device names even before the user has loaded devices in
+	// settings (issue #110 follow-up). Best-effort: a failed fetch keeps the
+	// seeded map. Re-renders only when the names changed and the modal is still
+	// open (the captured generation guards against a mid-fetch close).
+	private refreshDeviceNamesInBackground(): void {
+		const refresh = this.noteWriterOptions.refreshDeviceNames;
+		if (refresh === undefined) {
+			return;
+		}
+		const generation = this.fetchGeneration;
+		void refresh().then(
+			() => {
+				if (generation !== this.fetchGeneration) {
+					return;
+				}
+				const next =
+					this.noteWriterOptions.getDeviceNames?.() ??
+					new Map<string, string>();
+				const changed =
+					next.size !== this.deviceNames.size ||
+					[...next].some(
+						([sn, name]) => this.deviceNames.get(sn) !== name,
+					);
+				this.deviceNames = next;
+				if (changed && this.currentRecordings.length > 0) {
+					this.renderList();
+				}
+			},
+			() => {
+				// Best-effort: no client, offline, or a Plaud error. Keep the
+				// seeded names; the chip falls back to a generic label.
+			},
+		);
 	}
 
 	onClose(): void {
@@ -1363,6 +1407,18 @@ export class ImportModal extends Modal {
 		});
 		meta.createSpan({ text: '  ·  ', cls: 'plaud-importer-sep' });
 		meta.createSpan({ text: formatDuration(rec.durationSeconds) });
+		// Capture source (issue #110 follow-up): the device name, or "App" for a
+		// non-device recording, so a user can tell at a glance which device a row
+		// came from while choosing what to import. Hidden when the source cannot be
+		// labelled (no classified source).
+		const sourceLabel = recordingSourceLabel(rec.source, this.deviceNames);
+		if (sourceLabel.length > 0) {
+			meta.createSpan({ text: '  ·  ', cls: 'plaud-importer-sep' });
+			meta.createSpan({
+				text: sourceLabel,
+				cls: 'plaud-importer-source-chip',
+			});
+		}
 
 		// Per-row ignore control. A direct child of the row (not the label) so it
 		// sits at the row's trailing edge. Toggling re-renders the list, so the

--- a/import-runner.ts
+++ b/import-runner.ts
@@ -212,6 +212,13 @@ export async function runImport(
 		}
 	}
 
+	// Serial -> device name map for the {{device}} frontmatter token (issue #110
+	// follow-up). Resolved once from the host's live getter; a batch shares one
+	// snapshot. Empty when no devices are remembered, which leaves {{device}} as a
+	// generic label rather than failing.
+	const deviceNames: ReadonlyMap<string, string> =
+		options.getDeviceNames?.() ?? new Map();
+
 	const results: ImportResult[] = [];
 	for (let i = 0; i < total; i++) {
 		// Bail on mid-import modal close. The caller renders the partial
@@ -300,6 +307,7 @@ export async function runImport(
 				keywords: tagResult.keywords,
 				folders: folderNames,
 				consumerNotes,
+				deviceNames,
 			};
 			const selectedChapters = selection.includeTranscript
 				? chapters

--- a/main.ts
+++ b/main.ts
@@ -798,9 +798,30 @@ export default class PlaudImporterPlugin extends Plugin {
 			name: d.name,
 			model: d.model,
 		}));
+		// Persist only when the list actually changed: the import modal calls this
+		// on every open to freshen source labels, and an unconditional save would
+		// rewrite data.json each time for no change.
+		const unchanged =
+			stored.length === this.settings.knownDevices.length &&
+			stored.every((d, i) => {
+				const prev = this.settings.knownDevices[i];
+				return (
+					prev !== undefined &&
+					prev.sn === d.sn &&
+					prev.name === d.name &&
+					prev.model === d.model
+				);
+			});
 		this.settings.knownDevices = stored;
-		await this.saveSettings();
+		if (!unchanged) {
+			await this.saveSettings();
+		}
 		return stored;
+	}
+
+	/** Serial -> device name map from the remembered device list (issue #110). */
+	private deviceNameMap(): ReadonlyMap<string, string> {
+		return new Map(this.settings.knownDevices.map((d) => [d.sn, d.name]));
 	}
 
 	// ---- Auto-sync (issue #5) -------------------------------------------
@@ -862,6 +883,14 @@ export default class PlaudImporterPlugin extends Plugin {
 			// applies, so a blocked source is hidden from the manual import list
 			// too. Built here so the modal needs no settings access of its own.
 			sourceFilter: buildSourceFilter(this.settings),
+			// Device-name resolution for the {{device}} token and the import list
+			// badge (issue #110 follow-up). A live getter so it reflects the latest
+			// remembered device list; the refresh is best-effort and only persists
+			// when the list changed.
+			getDeviceNames: () => this.deviceNameMap(),
+			refreshDeviceNames: async () => {
+				await this.loadPlaudDevices();
+			},
 			debugLogger: this.debugLogger,
 			getAuthToken: () =>
 				this.settings.secretId.length > 0

--- a/note-writer.ts
+++ b/note-writer.ts
@@ -34,6 +34,7 @@ import type {
 	Transcript,
 	TranscriptSegment,
 } from './plaud-client';
+import { recordingSourceLabel } from './plaud-client';
 
 // -----------------------------------------------------------------------------
 // Errors
@@ -1461,6 +1462,13 @@ export interface CustomFrontmatterContext {
 	readonly language: string;
 	readonly template: string;
 	readonly model: string;
+	/**
+	 * The recording's capture source as a display label (issue #110 follow-up):
+	 * the paired device's name, "App" for a non-device recording, or a generic
+	 * fallback for an unknown device serial. Resolved from the supplied device-
+	 * name map. Powers the `{{device}}` token.
+	 */
+	readonly device: string;
 }
 
 /** Build the token context for one recording (folderName '' when unfiled). */
@@ -1469,6 +1477,7 @@ export function customFrontmatterContext(
 	summary: Summary | null | undefined,
 	folderName: string,
 	fallbackTimezone = '',
+	deviceNames: ReadonlyMap<string, string> = new Map(),
 ): CustomFrontmatterContext {
 	return {
 		date: recording.createdAt,
@@ -1487,6 +1496,7 @@ export function customFrontmatterContext(
 		language: summary?.language ?? '',
 		template: summary?.template ?? '',
 		model: summary?.model ?? '',
+		device: recordingSourceLabel(recording.source, deviceNames),
 	};
 }
 
@@ -1511,6 +1521,7 @@ export function expandCustomFrontmatterValue(
 		language: ctx.language,
 		template: ctx.template,
 		model: ctx.model,
+		device: ctx.device,
 	};
 	// Single pass: each `{{...}}` is resolved exactly once, so a substituted value
 	// that itself contains braces (a Plaud category holding "{{...}}") is never
@@ -1552,6 +1563,7 @@ export const TEMPLATE_PREVIEW_CUSTOM_CONTEXT: CustomFrontmatterContext = {
 	language: 'en',
 	template: 'Meeting notes',
 	model: 'gpt-5',
+	device: 'Plaud Note',
 };
 
 /**
@@ -1597,6 +1609,7 @@ export function formatFrontmatter(
 	existingValues?: ReadonlyMap<string, string>,
 	preserveUnknown = false,
 	fallbackTimezone = '',
+	deviceNames: ReadonlyMap<string, string> = new Map(),
 ): string {
 	const duration = Number.isFinite(recording.durationSeconds)
 		? Math.max(0, Math.floor(recording.durationSeconds))
@@ -1745,6 +1758,7 @@ export function formatFrontmatter(
 			summary,
 			folderName,
 			fallbackTimezone,
+			deviceNames,
 		);
 		for (const row of customRows) {
 			const key = row.key.trim();
@@ -2476,6 +2490,13 @@ export interface FormatMarkdownOptions {
 	 * use their own `captureOffsetMinutes`. See `effectiveCaptureOffsetMinutes`.
 	 */
 	readonly fallbackTimezone?: string;
+	/**
+	 * Serial -> device name map (issue #110 follow-up) used to resolve the
+	 * `{{device}}` custom-frontmatter token to a friendly device name. Omitted or
+	 * empty leaves device recordings as a generic label and app recordings as
+	 * "App". Sourced from the remembered device list.
+	 */
+	readonly deviceNames?: ReadonlyMap<string, string>;
 }
 
 export function formatMarkdown(
@@ -2516,6 +2537,7 @@ export function formatMarkdown(
 			options.existingFrontmatter,
 			options.preserveUnknownFrontmatter,
 			options.fallbackTimezone ?? '',
+			options.deviceNames,
 		),
 		'',
 		`# ${expandedTitle}`,

--- a/plaud-client.ts
+++ b/plaud-client.ts
@@ -175,6 +175,27 @@ export function deviceModelLabel(model: string): string {
 	return DEVICE_MODEL_LABELS[model] ?? 'Plaud device';
 }
 
+/**
+ * Display label for a recording's capture source (issue #110 follow-up): the
+ * paired device's name when known, "App" for a non-device (Plaud app / desktop /
+ * imported) recording, and a generic fallback for a device serial not in the
+ * supplied name map. Used by the `{{device}}` frontmatter token and the import
+ * list badge. Returns '' for a recording with no classified source.
+ */
+export function recordingSourceLabel(
+	source: RecordingSource | undefined,
+	deviceNames: ReadonlyMap<string, string>,
+): string {
+	if (source === undefined) {
+		return '';
+	}
+	if (source.kind === 'app') {
+		return 'App';
+	}
+	const name = deviceNames.get(source.serial);
+	return name !== undefined && name.length > 0 ? name : 'Plaud device';
+}
+
 export interface PlaudClient {
 	listRecordings(filter?: RecordingFilter): Promise<readonly Recording[]>;
 	/**

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -301,6 +301,10 @@ const CUSTOM_FRONTMATTER_TOKENS: ReadonlyArray<readonly [string, string]> = [
 	],
 	['{{headline}}', "the summary's one-line headline"],
 	[
+		'{{device}}',
+		'the recording device name, or App for an app or imported recording',
+	],
+	[
 		'{{YYYY}} {{MM}} {{DD}} {{Q}} {{WW}}',
 		'the date set, same as the other fields',
 	],
@@ -313,6 +317,7 @@ const CUSTOM_FRONTMATTER_EXAMPLES: ReadonlyArray<readonly [string, string]> = [
 		'writes quarter: Q3-2026 for a July recording',
 	],
 	['type: {{category}}', "the recording's own category under your key name"],
+	['device: {{device}}', 'the device the recording came from, or App'],
 	['project:', 'writes project: with no value, to fill in by hand'],
 ];
 

--- a/styles.css
+++ b/styles.css
@@ -796,3 +796,15 @@
 	color: var(--text-muted);
 	font-size: var(--font-ui-smaller);
 }
+
+/*
+ * Per-row capture-source chip in the import list meta line (issue #110
+ * follow-up): a small muted pill naming the device (or "App"). Subtle so it
+ * reads as metadata alongside the date and duration, not as a status badge.
+ */
+.plaud-importer-source-chip {
+	padding: 0 0.4em;
+	border-radius: 0.5em;
+	background: var(--background-modifier-hover);
+	color: var(--text-muted);
+}


### PR DESCRIPTION
## What

Follow-up to the recording-source filter (#111): make a recording's capture source **visible and savable**, not just filterable. Two additions built on the merged foundation (`Recording.source` + `getDeviceCatalog`).

## 1. Source chip in the import list

Every row in the import dialog now shows a small source chip in its meta line: the paired device's name, or "App" for a recording made in the Plaud app or imported. So you can tell at a glance which device a recording came from while choosing what to import. The modal freshens device names best-effort on open (guarded against a mid-fetch close), so chips show real names even before you have loaded devices in the Recording sources settings.

## 2. `{{device}}` frontmatter token

A new `{{device}}` token in the existing Extra frontmatter setting resolves to the device name (or "App"). Add a row like `device: {{device}}` and each imported note records the device it came from, for filtering and Dataview. Opt-in, like every other Extra frontmatter token; no new managed field.

## How names resolve

A single shared `recordingSourceLabel(source, deviceNames)` helper serves both the note path and the list badge, so they stay consistent. Names come from the remembered device list (`knownDevices`) via a live `getDeviceNames` getter, so both reflect the latest known devices. `loadPlaudDevices` now persists only when the list actually changed, since the modal calls it on every open.

## Testing

- 8 new unit tests: `recordingSourceLabel` across every bucket, `{{device}}` in `customFrontmatterContext` / `expandCustomFrontmatterValue`, and an end-to-end `formatFrontmatter` device row. Full suite: 1267 passing.
- Lint, build, prettier, submission pre-check green.
- Hand-verified live over CDP: opened the real import modal and confirmed every row renders a source chip with the correct label ("Plaud Note Pro - Find My" for device recordings, "App" for non-device), resolved from the live device list. Hand-verification, not automated coverage.

Refs #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import list rows now show the recording source, including the device name or “App.”
  - Added the `{{device}}` token for custom note frontmatter, enabling filtering and Dataview queries by recording source.
  - Added an example showing how to include the device in note metadata.

- **Documentation**
  - Updated recording-source documentation and the unreleased changelog with these enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->