### PR TITLE
Raise the js-yaml floor to the patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7177,9 +7177,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
 		"typescript": "^5.8.3"
 	},
 	"overrides": {
-		"js-yaml": "^4.2.0",
 		"@babel/core": "^7.29.6",
 		"@humanfs/node": "^0.16.8",
 		"browserslist": "^4.28.7",
-		"fast-uri": "^3.1.7"
+		"fast-uri": "^3.1.7",
+		"js-yaml": "^4.3.2"
 	}
 }


### PR DESCRIPTION
`GHSA-2883-xcg3-v3hh`, CVSS 7.5: *maxTotalMergeKeys does not limit CPU use for empty merge sources*. Published after the last scan, so it started failing OSV on diffs that touch no dependency at all.

The override permitted the vulnerable version. **Floors go to the patched version, never the installed one.** The advisory fixes 4.x in 4.3.2 and 3.x in 3.15.2.

Where the tree carries both lines the override stays **scoped by major**, because a blanket 4.x floor would force the 4.x API onto a dependency that needs 3.x.

Verified with `osv-scanner --lockfile=package-lock.json` locally: no issues found, and **no suppression added**. `npm run lint` and `npm test` green.

Part of a fleet-wide back-fill; annoteca's copy is already on main.

https://claude.ai/code/session_01DeCVLtj7g43hc3kvdAkWZ8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `js-yaml` version to a newer release.
  * Reordered package configuration entries without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->